### PR TITLE
feat: implement webhook system for event notifications

### DIFF
--- a/prisma/migrations/20260315132059_add_webhook_models/migration.sql
+++ b/prisma/migrations/20260315132059_add_webhook_models/migration.sql
@@ -1,0 +1,28 @@
+-- CreateTable
+CREATE TABLE "WebhookSubscription" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "eventId" TEXT NOT NULL,
+    "url" TEXT NOT NULL,
+    "secret" TEXT,
+    "events" TEXT NOT NULL DEFAULT '[]',
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "WebhookSubscription_eventId_fkey" FOREIGN KEY ("eventId") REFERENCES "Event" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "WebhookDelivery" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "webhookId" TEXT NOT NULL,
+    "eventType" TEXT NOT NULL,
+    "payload" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'pending',
+    "attempts" INTEGER NOT NULL DEFAULT 0,
+    "lastAttempt" DATETIME,
+    "deliveredAt" DATETIME,
+    "error" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "WebhookDelivery_webhookId_fkey" FOREIGN KEY ("webhookId") REFERENCES "WebhookSubscription" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "WebhookSubscription_eventId_url_key" ON "WebhookSubscription"("eventId", "url");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,6 +22,7 @@ model Event {
   teamResults    TeamResult[]
   history        GameHistory[]
   pushSubs       PushSubscription[]
+  webhookSubs    WebhookSubscription[]
   createdAt      DateTime      @default(now())
   updatedAt      DateTime      @updatedAt
 }
@@ -79,4 +80,31 @@ model PushSubscription {
   createdAt DateTime @default(now())
 
   @@unique([eventId, endpoint])
+}
+
+model WebhookSubscription {
+  id         String            @id @default(cuid())
+  eventId    String
+  event      Event             @relation(fields: [eventId], references: [id], onDelete: Cascade)
+  url        String
+  secret     String?
+  events     String            @default("[]") // JSON array of event types
+  createdAt  DateTime          @default(now())
+  deliveries WebhookDelivery[]
+
+  @@unique([eventId, url])
+}
+
+model WebhookDelivery {
+  id          String              @id @default(cuid())
+  webhookId   String
+  webhook     WebhookSubscription @relation(fields: [webhookId], references: [id], onDelete: Cascade)
+  eventType   String
+  payload     String              // JSON
+  status      String              @default("pending") // "pending" | "success" | "failed"
+  attempts    Int                 @default(0)
+  lastAttempt DateTime?
+  deliveredAt DateTime?
+  error       String?
+  createdAt   DateTime            @default(now())
 }

--- a/src/components/EventPage.tsx
+++ b/src/components/EventPage.tsx
@@ -4,7 +4,7 @@ import {
   Container, Paper, Typography, TextField, Button, Box, Stack, Chip,
   Alert, IconButton, Tooltip, InputAdornment, Dialog, DialogTitle,
   DialogContent, DialogContentText, DialogActions, Snackbar, alpha, useTheme, Grid2,
-  CircularProgress, Divider, Autocomplete,
+  CircularProgress, Divider, Autocomplete, Accordion, AccordionSummary, AccordionDetails,
 } from "@mui/material";
 import PersonAddIcon from "@mui/icons-material/PersonAdd";
 import HistoryIcon from "@mui/icons-material/History";
@@ -21,6 +21,8 @@ import EmojiPeopleIcon from "@mui/icons-material/EmojiPeople";
 import AirlineSeatReclineNormalIcon from "@mui/icons-material/AirlineSeatReclineNormal";
 import NotificationsIcon from "@mui/icons-material/Notifications";
 import NotificationsOffIcon from "@mui/icons-material/NotificationsOff";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import IntegrationInstructionsIcon from "@mui/icons-material/IntegrationInstructions";
 import { ThemeModeProvider } from "./ThemeModeProvider";
 import { ResponsiveLayout } from "./ResponsiveLayout";
 import { TeamPicker } from "./TeamPicker";
@@ -247,6 +249,71 @@ function ShareBar({ title }: { title: string }) {
         {copied ? t("linkCopied") : t("shareGame")}
       </Button>
     </Paper>
+  );
+}
+
+// ── Webhook info (developer integration) ──────────────────────────────────────
+
+function WebhookInfo({ eventId }: { eventId: string }) {
+  const t = useT();
+  const [copied, setCopied] = useState(false);
+  const url = typeof window !== "undefined"
+    ? `${window.location.origin}/api/events/${eventId}/webhooks`
+    : "";
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(url);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2500);
+  };
+
+  return (
+    <Accordion
+      disableGutters
+      elevation={0}
+      sx={{
+        "&:before": { display: "none" },
+        backgroundColor: "transparent",
+      }}
+    >
+      <AccordionSummary
+        expandIcon={<ExpandMoreIcon />}
+        sx={{ px: 0, minHeight: 0, "& .MuiAccordionSummary-content": { my: 0.5 } }}
+      >
+        <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+          <IntegrationInstructionsIcon fontSize="small" color="action" />
+          <Typography variant="body2" color="text.secondary">
+            {t("integrations")}
+          </Typography>
+        </Box>
+      </AccordionSummary>
+      <AccordionDetails sx={{ px: 0, pt: 0 }}>
+        <Stack spacing={1}>
+          <Typography variant="caption" color="text.secondary">
+            {t("webhookHelp")}
+          </Typography>
+          <Paper variant="outlined" sx={{
+            borderRadius: 2, p: 1, display: "flex", alignItems: "center", gap: 1,
+          }}>
+            <Typography variant="body2" sx={{
+              flexGrow: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap",
+              fontFamily: "monospace", fontSize: "0.75rem", minWidth: 0,
+            }}>
+              {url}
+            </Typography>
+            <Tooltip title={copied ? t("webhookCopied") : t("webhookEndpoint")}>
+              <IconButton
+                size="small"
+                color={copied ? "success" : "default"}
+                onClick={handleCopy}
+              >
+                {copied ? <CheckIcon fontSize="small" /> : <ContentCopyIcon fontSize="small" />}
+              </IconButton>
+            </Tooltip>
+          </Paper>
+        </Stack>
+      </AccordionDetails>
+    </Accordion>
   );
 }
 
@@ -714,6 +781,9 @@ export default function EventPage({ eventId }: { eventId: string }) {
                     <NotifyButton eventId={eventId} />
                   </Box>
                 </Stack>
+
+                {/* Integrations — hidden by default, for developers */}
+                <WebhookInfo eventId={eventId} />
               </Stack>
             </Paper>
 

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -144,6 +144,12 @@ export const translations = {
     // Update banner
     updateAvailable: "A new version is available",
     updateNow: "Update",
+
+    // Webhooks / Integrations
+    integrations: "Integrations",
+    webhookEndpoint: "Webhook endpoint",
+    webhookCopied: "Copied!",
+    webhookHelp: "POST to this URL to register a webhook. See docs for payload format.",
   },
   pt: {
     // App
@@ -290,6 +296,12 @@ export const translations = {
     // Update banner
     updateAvailable: "Nova versão disponível",
     updateNow: "Atualizar",
+
+    // Webhooks / Integrations
+    integrations: "Integrações",
+    webhookEndpoint: "Endpoint do webhook",
+    webhookCopied: "Copiado!",
+    webhookHelp: "Faz POST para este URL para registar um webhook. Consulta a documentação para o formato do payload.",
   },
 } as const;
 

--- a/src/lib/webhook.server.ts
+++ b/src/lib/webhook.server.ts
@@ -1,0 +1,135 @@
+import { createHmac, randomUUID } from "crypto";
+import { prisma } from "./db.server";
+
+export type WebhookEventType =
+  | "player_joined"
+  | "player_left"
+  | "game_full"
+  | "game_reset";
+
+const MAX_ATTEMPTS = 5;
+const TIMEOUT_MS = 5000;
+const BACKOFF_BASE_MS = 1000;
+
+export function signPayload(payload: string, secret: string): string {
+  return "sha256=" + createHmac("sha256", secret).update(payload).digest("hex");
+}
+
+interface WebhookPayloadData {
+  playerName?: string;
+  isActive?: boolean;
+  spotsLeft?: number;
+  [key: string]: unknown;
+}
+
+export async function fireWebhooks(
+  eventId: string,
+  eventType: WebhookEventType,
+  data: WebhookPayloadData,
+) {
+  const subs = await prisma.webhookSubscription.findMany({
+    where: { eventId },
+  });
+
+  const matching = subs.filter((sub) => {
+    const subscribedEvents: string[] = JSON.parse(sub.events);
+    return subscribedEvents.length === 0 || subscribedEvents.includes(eventType);
+  });
+
+  if (matching.length === 0) return;
+
+  const deliveryId = randomUUID();
+  const payload = JSON.stringify({
+    event: eventType,
+    eventId,
+    deliveryId,
+    timestamp: new Date().toISOString(),
+    data,
+  });
+
+  await Promise.allSettled(
+    matching.map((sub) => deliverWebhook(sub.id, sub.url, sub.secret, eventType, payload)),
+  );
+}
+
+async function deliverWebhook(
+  webhookId: string,
+  url: string,
+  secret: string | null,
+  eventType: string,
+  payload: string,
+) {
+  const delivery = await prisma.webhookDelivery.create({
+    data: { webhookId, eventType, payload, status: "pending" },
+  });
+
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    try {
+      const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+        "User-Agent": "Convocados-Webhook/1.0",
+      };
+      if (secret) {
+        headers["X-Webhook-Signature"] = signPayload(payload, secret);
+      }
+
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+      const res = await fetch(url, {
+        method: "POST",
+        headers,
+        body: payload,
+        signal: controller.signal,
+      });
+      clearTimeout(timeout);
+
+      await prisma.webhookDelivery.update({
+        where: { id: delivery.id },
+        data: {
+          attempts: attempt,
+          lastAttempt: new Date(),
+        },
+      });
+
+      if (res.ok) {
+        await prisma.webhookDelivery.update({
+          where: { id: delivery.id },
+          data: { status: "success", deliveredAt: new Date() },
+        });
+        console.log(`[webhook] delivered to ${url.slice(0, 60)} (attempt ${attempt})`);
+        return;
+      }
+
+      const errText = `HTTP ${res.status}`;
+      await prisma.webhookDelivery.update({
+        where: { id: delivery.id },
+        data: { error: errText },
+      });
+      console.warn(`[webhook] ${url.slice(0, 60)} returned ${res.status} (attempt ${attempt})`);
+    } catch (err: any) {
+      const errMsg = err?.name === "AbortError" ? "Timeout" : (err?.message ?? "Unknown error");
+      await prisma.webhookDelivery.update({
+        where: { id: delivery.id },
+        data: {
+          attempts: attempt,
+          lastAttempt: new Date(),
+          error: errMsg,
+        },
+      });
+      console.warn(`[webhook] failed ${url.slice(0, 60)}: ${errMsg} (attempt ${attempt})`);
+    }
+
+    // Exponential backoff before retry
+    if (attempt < MAX_ATTEMPTS) {
+      await new Promise((r) => setTimeout(r, BACKOFF_BASE_MS * Math.pow(2, attempt - 1)));
+    }
+  }
+
+  // All attempts exhausted
+  await prisma.webhookDelivery.update({
+    where: { id: delivery.id },
+    data: { status: "failed" },
+  });
+  console.error(`[webhook] gave up on ${url.slice(0, 60)} after ${MAX_ATTEMPTS} attempts`);
+}

--- a/src/pages/api/events/[id]/index.ts
+++ b/src/pages/api/events/[id]/index.ts
@@ -1,6 +1,7 @@
 import type { APIRoute } from "astro";
 import { prisma } from "../../../../lib/db.server";
 import { parseRecurrenceRule, nextOccurrence } from "../../../../lib/recurrence";
+import { fireWebhooks } from "../../../../lib/webhook.server";
 
 export const GET: APIRoute = async ({ params }) => {
   const event = await prisma.event.findUnique({
@@ -60,6 +61,11 @@ export const GET: APIRoute = async ({ params }) => {
         ]);
 
         wasReset = true;
+
+        // Fire game_reset webhook (non-blocking)
+        fireWebhooks(event.id, "game_reset", {
+          newDateTime: newDateTime.toISOString(),
+        }).catch(() => {});
       }
 
       const fresh = await prisma.event.findUnique({

--- a/src/pages/api/events/[id]/players.ts
+++ b/src/pages/api/events/[id]/players.ts
@@ -1,6 +1,7 @@
 import type { APIRoute } from "astro";
 import { prisma } from "../../../../lib/db.server";
 import { sendPushToEvent } from "../../../../lib/push.server";
+import { fireWebhooks } from "../../../../lib/webhook.server";
 
 export const POST: APIRoute = async ({ params, request }) => {
   const eventId = params.id!;
@@ -37,6 +38,13 @@ export const POST: APIRoute = async ({ params, request }) => {
     await sendPushToEvent(eventId, event.title, "notifyPlayerJoinedBench", { name: trimmed }, url, spotsLeft, senderClientId);
   } else {
     await sendPushToEvent(eventId, event.title, "notifyPlayerJoined", { name: trimmed }, url, spotsLeft, senderClientId);
+  }
+
+  // Fire webhooks (non-blocking)
+  const webhookData = { playerName: trimmed, isActive: !isOnBench, spotsLeft };
+  fireWebhooks(eventId, "player_joined", webhookData).catch(() => {});
+  if (spotsLeft === 0) {
+    fireWebhooks(eventId, "game_full", webhookData).catch(() => {});
   }
 
   return Response.json({ ok: true });
@@ -79,6 +87,9 @@ export const DELETE: APIRoute = async ({ params, request }) => {
   } else {
     await sendPushToEvent(eventId, event.title, "notifyPlayerLeft", { name: player.name }, url, spotsLeft, senderClientId);
   }
+
+  // Fire webhooks (non-blocking)
+  fireWebhooks(eventId, "player_left", { playerName: player.name, spotsLeft }).catch(() => {});
 
   return Response.json({ ok: true });
 };

--- a/src/pages/api/events/[id]/webhooks/[webhookId].ts
+++ b/src/pages/api/events/[id]/webhooks/[webhookId].ts
@@ -1,0 +1,17 @@
+import type { APIRoute } from "astro";
+import { prisma } from "../../../../../lib/db.server";
+
+/** DELETE — unsubscribe a webhook */
+export const DELETE: APIRoute = async ({ params }) => {
+  const eventId = params.id!;
+  const webhookId = params.webhookId!;
+
+  const webhook = await prisma.webhookSubscription.findFirst({
+    where: { id: webhookId, eventId },
+  });
+  if (!webhook) return Response.json({ error: "Not found." }, { status: 404 });
+
+  await prisma.webhookSubscription.delete({ where: { id: webhookId } });
+
+  return Response.json({ ok: true });
+};

--- a/src/pages/api/events/[id]/webhooks/index.ts
+++ b/src/pages/api/events/[id]/webhooks/index.ts
@@ -1,0 +1,77 @@
+import type { APIRoute } from "astro";
+import { prisma } from "../../../../../lib/db.server";
+
+const MAX_WEBHOOKS_PER_EVENT = 10;
+
+/** POST — subscribe a webhook */
+export const POST: APIRoute = async ({ params, request }) => {
+  const eventId = params.id!;
+  const event = await prisma.event.findUnique({ where: { id: eventId } });
+  if (!event) return Response.json({ error: "Not found." }, { status: 404 });
+
+  const body = await request.json();
+  const url = String(body.url ?? "").trim();
+  if (!url) return Response.json({ error: "url is required." }, { status: 400 });
+
+  try {
+    new URL(url);
+  } catch {
+    return Response.json({ error: "Invalid URL." }, { status: 400 });
+  }
+
+  // Rate limit: max webhooks per event
+  const count = await prisma.webhookSubscription.count({ where: { eventId } });
+  if (count >= MAX_WEBHOOKS_PER_EVENT) {
+    return Response.json({ error: `Maximum ${MAX_WEBHOOKS_PER_EVENT} webhooks per event.` }, { status: 429 });
+  }
+
+  const validEvents = ["player_joined", "player_left", "game_full", "game_reset"];
+  const events: string[] = Array.isArray(body.events)
+    ? body.events.filter((e: string) => validEvents.includes(e))
+    : [];
+  const secret = typeof body.secret === "string" ? body.secret : null;
+
+  try {
+    const webhook = await prisma.webhookSubscription.create({
+      data: {
+        eventId,
+        url,
+        secret,
+        events: JSON.stringify(events),
+      },
+    });
+
+    return Response.json({
+      id: webhook.id,
+      url: webhook.url,
+      events: JSON.parse(webhook.events),
+      createdAt: webhook.createdAt.toISOString(),
+    });
+  } catch (e: any) {
+    if (e?.code === "P2002") {
+      return Response.json({ error: "Webhook already registered for this URL." }, { status: 409 });
+    }
+    throw e;
+  }
+};
+
+/** GET — list webhooks for an event */
+export const GET: APIRoute = async ({ params }) => {
+  const eventId = params.id!;
+  const event = await prisma.event.findUnique({ where: { id: eventId } });
+  if (!event) return Response.json({ error: "Not found." }, { status: 404 });
+
+  const webhooks = await prisma.webhookSubscription.findMany({
+    where: { eventId },
+    orderBy: { createdAt: "asc" },
+  });
+
+  return Response.json({
+    webhooks: webhooks.map((w) => ({
+      id: w.id,
+      url: w.url,
+      events: JSON.parse(w.events),
+      createdAt: w.createdAt.toISOString(),
+    })),
+  });
+};

--- a/src/test/webhook.test.ts
+++ b/src/test/webhook.test.ts
@@ -1,0 +1,368 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { prisma } from "~/lib/db.server";
+
+import { POST as createWebhook, GET as listWebhooks } from "~/pages/api/events/[id]/webhooks/index";
+import { DELETE as deleteWebhook } from "~/pages/api/events/[id]/webhooks/[webhookId]";
+import { signPayload, fireWebhooks } from "~/lib/webhook.server";
+
+// Helpers
+function ctx(params: Record<string, string>, body?: unknown) {
+  const request = new Request("http://localhost/api/test", {
+    method: body !== undefined ? "POST" : "GET",
+    headers: { "content-type": "application/json" },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+  return { request, params } as any;
+}
+
+function deleteCtx(params: Record<string, string>) {
+  const request = new Request("http://localhost/api/test", {
+    method: "DELETE",
+    headers: { "content-type": "application/json" },
+  });
+  return { request, params } as any;
+}
+
+async function seedEvent() {
+  const event = await prisma.event.create({
+    data: {
+      title: "Test Event",
+      location: "Pitch A",
+      dateTime: new Date(Date.now() + 86400_000),
+      teamOneName: "Ninjas",
+      teamTwoName: "Gunas",
+    },
+  });
+  return event.id;
+}
+
+beforeEach(async () => {
+  await prisma.webhookDelivery.deleteMany();
+  await prisma.webhookSubscription.deleteMany();
+  await prisma.gameHistory.deleteMany();
+  await prisma.teamResult.deleteMany();
+  await prisma.player.deleteMany();
+  await prisma.event.deleteMany();
+});
+
+// ─── POST /api/events/[id]/webhooks ─────────────────────────────────────────
+
+describe("POST /api/events/[id]/webhooks", () => {
+  it("creates a webhook subscription", async () => {
+    const id = await seedEvent();
+    const res = await createWebhook(ctx({ id }, {
+      url: "https://example.com/hook",
+      events: ["player_joined"],
+    }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.id).toBeTruthy();
+    expect(body.url).toBe("https://example.com/hook");
+    expect(body.events).toEqual(["player_joined"]);
+  });
+
+  it("returns 404 for unknown event", async () => {
+    const res = await createWebhook(ctx({ id: "bad-id" }, {
+      url: "https://example.com/hook",
+    }));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 400 when url is missing", async () => {
+    const id = await seedEvent();
+    const res = await createWebhook(ctx({ id }, {}));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for invalid URL", async () => {
+    const id = await seedEvent();
+    const res = await createWebhook(ctx({ id }, { url: "not-a-url" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 409 for duplicate URL on same event", async () => {
+    const id = await seedEvent();
+    await createWebhook(ctx({ id }, { url: "https://example.com/hook" }));
+    const res = await createWebhook(ctx({ id }, { url: "https://example.com/hook" }));
+    expect(res.status).toBe(409);
+  });
+
+  it("filters invalid event types", async () => {
+    const id = await seedEvent();
+    const res = await createWebhook(ctx({ id }, {
+      url: "https://example.com/hook",
+      events: ["player_joined", "invalid_event", "game_full"],
+    }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.events).toEqual(["player_joined", "game_full"]);
+  });
+
+  it("defaults to empty events array (subscribe to all)", async () => {
+    const id = await seedEvent();
+    const res = await createWebhook(ctx({ id }, {
+      url: "https://example.com/hook",
+    }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.events).toEqual([]);
+  });
+
+  it("returns 429 when max webhooks reached", async () => {
+    const id = await seedEvent();
+    for (let i = 0; i < 10; i++) {
+      await createWebhook(ctx({ id }, { url: `https://example.com/hook${i}` }));
+    }
+    const res = await createWebhook(ctx({ id }, { url: "https://example.com/hook10" }));
+    expect(res.status).toBe(429);
+  });
+});
+
+// ─── GET /api/events/[id]/webhooks ──────────────────────────────────────────
+
+describe("GET /api/events/[id]/webhooks", () => {
+  it("lists webhooks for an event", async () => {
+    const id = await seedEvent();
+    await createWebhook(ctx({ id }, { url: "https://example.com/hook1" }));
+    await createWebhook(ctx({ id }, { url: "https://example.com/hook2" }));
+
+    const res = await listWebhooks(ctx({ id }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.webhooks).toHaveLength(2);
+  });
+
+  it("returns 404 for unknown event", async () => {
+    const res = await listWebhooks(ctx({ id: "bad-id" }));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns empty array when no webhooks", async () => {
+    const id = await seedEvent();
+    const res = await listWebhooks(ctx({ id }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.webhooks).toEqual([]);
+  });
+});
+
+// ─── DELETE /api/events/[id]/webhooks/[webhookId] ───────────────────────────
+
+describe("DELETE /api/events/[id]/webhooks/[webhookId]", () => {
+  it("deletes a webhook subscription", async () => {
+    const id = await seedEvent();
+    const createRes = await createWebhook(ctx({ id }, { url: "https://example.com/hook" }));
+    const { id: webhookId } = await createRes.json();
+
+    const res = await deleteWebhook(deleteCtx({ id, webhookId }));
+    expect(res.status).toBe(200);
+
+    const listRes = await listWebhooks(ctx({ id }));
+    const body = await listRes.json();
+    expect(body.webhooks).toHaveLength(0);
+  });
+
+  it("returns 404 for unknown webhook", async () => {
+    const id = await seedEvent();
+    const res = await deleteWebhook(deleteCtx({ id, webhookId: "bad-id" }));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 when webhook belongs to different event", async () => {
+    const id1 = await seedEvent();
+    const id2 = await seedEvent();
+    const createRes = await createWebhook(ctx({ id: id1 }, { url: "https://example.com/hook" }));
+    const { id: webhookId } = await createRes.json();
+
+    const res = await deleteWebhook(deleteCtx({ id: id2, webhookId }));
+    expect(res.status).toBe(404);
+  });
+});
+
+// ─── signPayload ────────────────────────────────────────────────────────────
+
+describe("signPayload", () => {
+  it("produces a deterministic HMAC-SHA256 signature", () => {
+    const sig = signPayload('{"test":true}', "my-secret");
+    expect(sig).toMatch(/^sha256=[a-f0-9]{64}$/);
+    // Same input = same output
+    expect(signPayload('{"test":true}', "my-secret")).toBe(sig);
+  });
+
+  it("produces different signatures for different secrets", () => {
+    const sig1 = signPayload('{"test":true}', "secret-a");
+    const sig2 = signPayload('{"test":true}', "secret-b");
+    expect(sig1).not.toBe(sig2);
+  });
+});
+
+// ─── fireWebhooks ───────────────────────────────────────────────────────────
+
+describe("fireWebhooks", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("delivers to matching webhook and records success", async () => {
+    const id = await seedEvent();
+    await prisma.webhookSubscription.create({
+      data: {
+        eventId: id,
+        url: "https://httpbin.org/post",
+        events: JSON.stringify(["player_joined"]),
+      },
+    });
+
+    // Mock fetch to avoid real HTTP calls
+    const mockFetch = vi.fn().mockResolvedValue(new Response("OK", { status: 200 }));
+    vi.stubGlobal("fetch", mockFetch);
+
+    await fireWebhooks(id, "player_joined", { playerName: "Alice", spotsLeft: 3 });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toBe("https://httpbin.org/post");
+    expect(opts.method).toBe("POST");
+
+    const payload = JSON.parse(opts.body);
+    expect(payload.event).toBe("player_joined");
+    expect(payload.data.playerName).toBe("Alice");
+
+    // Check delivery was recorded
+    const deliveries = await prisma.webhookDelivery.findMany();
+    expect(deliveries).toHaveLength(1);
+    expect(deliveries[0].status).toBe("success");
+  });
+
+  it("skips webhooks not subscribed to the event type", async () => {
+    const id = await seedEvent();
+    await prisma.webhookSubscription.create({
+      data: {
+        eventId: id,
+        url: "https://httpbin.org/post",
+        events: JSON.stringify(["game_full"]),
+      },
+    });
+
+    const mockFetch = vi.fn();
+    vi.stubGlobal("fetch", mockFetch);
+
+    await fireWebhooks(id, "player_joined", { playerName: "Alice" });
+
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("delivers to webhooks with empty events array (subscribe to all)", async () => {
+    const id = await seedEvent();
+    await prisma.webhookSubscription.create({
+      data: {
+        eventId: id,
+        url: "https://httpbin.org/post",
+        events: JSON.stringify([]),
+      },
+    });
+
+    const mockFetch = vi.fn().mockResolvedValue(new Response("OK", { status: 200 }));
+    vi.stubGlobal("fetch", mockFetch);
+
+    await fireWebhooks(id, "player_left", { playerName: "Bob" });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("includes HMAC signature when secret is configured", async () => {
+    const id = await seedEvent();
+    await prisma.webhookSubscription.create({
+      data: {
+        eventId: id,
+        url: "https://httpbin.org/post",
+        secret: "test-secret",
+        events: JSON.stringify([]),
+      },
+    });
+
+    const mockFetch = vi.fn().mockResolvedValue(new Response("OK", { status: 200 }));
+    vi.stubGlobal("fetch", mockFetch);
+
+    await fireWebhooks(id, "player_joined", { playerName: "Alice" });
+
+    const [, opts] = mockFetch.mock.calls[0];
+    expect(opts.headers["X-Webhook-Signature"]).toMatch(/^sha256=[a-f0-9]{64}$/);
+  });
+
+  it("records failed delivery after all retries exhausted", async () => {
+    const id = await seedEvent();
+    await prisma.webhookSubscription.create({
+      data: {
+        eventId: id,
+        url: "https://httpbin.org/status/500",
+        events: JSON.stringify([]),
+      },
+    });
+
+    // Mock fetch to always fail
+    const mockFetch = vi.fn().mockResolvedValue(new Response("Error", { status: 500 }));
+    vi.stubGlobal("fetch", mockFetch);
+
+    await fireWebhooks(id, "player_joined", { playerName: "Alice" });
+
+    expect(mockFetch).toHaveBeenCalledTimes(5); // MAX_ATTEMPTS
+    const deliveries = await prisma.webhookDelivery.findMany();
+    expect(deliveries).toHaveLength(1);
+    expect(deliveries[0].status).toBe("failed");
+    expect(deliveries[0].attempts).toBe(5);
+  }, 60000);
+
+  it("does nothing when no webhooks are registered", async () => {
+    const id = await seedEvent();
+    const mockFetch = vi.fn();
+    vi.stubGlobal("fetch", mockFetch);
+
+    await fireWebhooks(id, "player_joined", { playerName: "Alice" });
+
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("records network errors and retries", async () => {
+    const id = await seedEvent();
+    await prisma.webhookSubscription.create({
+      data: {
+        eventId: id,
+        url: "https://unreachable.invalid/hook",
+        events: JSON.stringify([]),
+      },
+    });
+
+    const mockFetch = vi.fn().mockRejectedValue(new Error("fetch failed"));
+    vi.stubGlobal("fetch", mockFetch);
+
+    await fireWebhooks(id, "player_joined", { playerName: "Alice" });
+
+    expect(mockFetch).toHaveBeenCalledTimes(5);
+    const deliveries = await prisma.webhookDelivery.findMany();
+    expect(deliveries).toHaveLength(1);
+    expect(deliveries[0].status).toBe("failed");
+    expect(deliveries[0].error).toBe("fetch failed");
+  }, 60000);
+
+  it("records AbortError as Timeout", async () => {
+    const id = await seedEvent();
+    await prisma.webhookSubscription.create({
+      data: {
+        eventId: id,
+        url: "https://slow.invalid/hook",
+        events: JSON.stringify([]),
+      },
+    });
+
+    const abortErr = new DOMException("The operation was aborted", "AbortError");
+    const mockFetch = vi.fn().mockRejectedValue(abortErr);
+    vi.stubGlobal("fetch", mockFetch);
+
+    await fireWebhooks(id, "player_joined", { playerName: "Alice" });
+
+    const deliveries = await prisma.webhookDelivery.findMany();
+    expect(deliveries).toHaveLength(1);
+    expect(deliveries[0].error).toBe("Timeout");
+  }, 60000);
+});


### PR DESCRIPTION
Closes #32

## Summary

Implements an outgoing webhook system so external systems (e.g. OpenClaw) can subscribe to event changes and receive HTTP POST callbacks.

## Changes

### Backend
- **Prisma schema**: Added `WebhookSubscription` and `WebhookDelivery` models with cascade delete from Event
- **Webhook service** (`src/lib/webhook.server.ts`): Delivery engine with HMAC-SHA256 signing, 5-attempt retry with exponential backoff, 5s timeout per request
- **CRUD endpoints**:
  - `POST /api/events/[id]/webhooks` — subscribe (with URL validation, max 10 per event, duplicate detection)
  - `GET /api/events/[id]/webhooks` — list subscriptions
  - `DELETE /api/events/[id]/webhooks/[webhookId]` — unsubscribe
- **Webhook triggers** integrated into:
  - Player join → `player_joined` (+ `game_full` when spots reach 0)
  - Player leave → `player_left`
  - Recurrence reset → `game_reset`

### Frontend
- **Integrations accordion** in the event page header (collapsed by default, progressive disclosure)
- Displays the webhook API endpoint URL with a one-click copy button
- i18n strings added for en/pt

### Tests
- 24 new tests covering: CRUD operations, HMAC signing, successful delivery, event type filtering, retry on HTTP errors, retry on network errors, timeout handling (AbortError), and no-op when no webhooks registered

## Webhook Payload Format

```json
{
  "event": "player_joined",
  "eventId": "clx...",
  "deliveryId": "uuid",
  "timestamp": "2026-03-15T13:00:00.000Z",
  "data": {
    "playerName": "Carlos",
    "isActive": true,
    "spotsLeft": 3
  }
}
```

When a secret is configured, requests include an `X-Webhook-Signature: sha256=<hmac>` header.

## Testing with OpenClaw

Register a webhook pointing to your OpenClaw instance:
```bash
curl -X POST https://convocados.fly.dev/api/events/<ID>/webhooks \
  -H 'Content-Type: application/json' \
  -d '{"url": "https://<openclaw-host>/hooks/agent", "secret": "your-secret"}'
```