### PR TITLE
feat: documentation site at /docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ yarn-error.log*
 
 # vite
 .vite/
+
+# astro
+.astro/

--- a/README.md
+++ b/README.md
@@ -1,13 +1,64 @@
 # Convocados
 
-![Unit test - Jest](https://github.com/Cabeda/Convocados/workflows/Unit%20test%20-%20Jest/badge.svg)
+Web app for organizing pickup football games — manage events, randomize teams, track scores, and notify players.
 
 ![Screenshot](./public/screenshot.png)
 
-Web application to randomize teams. Currently the only existing mode is to select a random team and attribute to a player.
+## Features
 
-## Test locally
+- Create and share game events via link
+- Player sign-up with automatic bench when full
+- Random team generation
+- Recurring events (weekly/monthly)
+- Game history with editable scores
+- Push notifications (Web Push)
+- Webhook integrations
+- Full REST API
 
-1. Install yarn
-2. Run _yarn_ on console
-3. Run yarn start on console
+## Tech stack
+
+| Layer      | Technology                    |
+|------------|-------------------------------|
+| Framework  | Astro 5 (SSR, Node adapter)  |
+| UI         | React 19 + MUI 6             |
+| Database   | SQLite via Prisma 6           |
+| Testing    | Vitest + Supertest            |
+| Deployment | Docker on Fly.io              |
+
+## Quick start
+
+```bash
+git clone https://github.com/Cabeda/Convocados.git
+cd Convocados
+npm ci
+npx prisma generate
+npx prisma db push
+npm run dev
+```
+
+The dev server starts at `http://localhost:4321`.
+
+## Scripts
+
+| Command              | Description                  |
+|----------------------|------------------------------|
+| `npm run dev`        | Start dev server             |
+| `npm run build`      | Production build             |
+| `npm run test`       | Run tests (Vitest)           |
+| `npm run typecheck`  | TypeScript type checking     |
+| `npm run db:migrate` | Create & apply DB migrations |
+| `npm run db:studio`  | Open Prisma Studio           |
+
+## Documentation
+
+Full documentation is available at [`/docs`](https://convocados.fly.dev/docs) when the app is running, covering:
+
+- Getting started & tutorial
+- Feature guides
+- Complete API reference
+- Self-hosting & deployment
+- Contributing guidelines
+
+## License
+
+MIT

--- a/src/components/ResponsiveLayout.tsx
+++ b/src/components/ResponsiveLayout.tsx
@@ -8,6 +8,7 @@ import Brightness7Icon from "@mui/icons-material/Brightness7";
 import GitHubIcon from "@mui/icons-material/GitHub";
 import SportsIcon from "@mui/icons-material/Sports";
 import SystemUpdateAltIcon from "@mui/icons-material/SystemUpdateAlt";
+import MenuBookIcon from "@mui/icons-material/MenuBook";
 import { useThemeMode } from "./ThemeModeProvider";
 import { useT } from "~/lib/useT";
 
@@ -105,6 +106,13 @@ export const ResponsiveLayout: React.FC<{ children: React.ReactNode }> = ({ chil
             >
               {t("appName")}
             </Typography>
+            <Tooltip title={t("docs")}>
+              <IconButton color="inherit" aria-label={t("docs")}
+                href="/docs"
+                component="a">
+                <MenuBookIcon />
+              </IconButton>
+            </Tooltip>
             <Tooltip title={t("toggleDarkMode")}>
               <IconButton onClick={toggleMode} color="inherit" aria-label={t("toggleDarkMode")}>
                 {isDark ? <Brightness7Icon /> : <Brightness4Icon />}

--- a/src/layouts/DocsLayout.astro
+++ b/src/layouts/DocsLayout.astro
@@ -1,0 +1,447 @@
+---
+interface Props {
+  title: string;
+  description?: string;
+}
+const { title, description } = Astro.props;
+const currentPath = Astro.url.pathname.replace(/\/$/, '') || '/docs';
+
+const sections = [
+  {
+    title: 'Getting Started',
+    items: [
+      { href: '/docs', label: 'Overview' },
+      { href: '/docs/quickstart', label: 'Quickstart' },
+      { href: '/docs/tutorial', label: 'Tutorial' },
+    ],
+  },
+  {
+    title: 'Features',
+    items: [
+      { href: '/docs/features/events', label: 'Events' },
+      { href: '/docs/features/players', label: 'Players & Bench' },
+      { href: '/docs/features/teams', label: 'Teams' },
+      { href: '/docs/features/recurrence', label: 'Recurring Games' },
+      { href: '/docs/features/notifications', label: 'Notifications' },
+      { href: '/docs/features/history', label: 'History & Scores' },
+    ],
+  },
+  {
+    title: 'API Reference',
+    items: [
+      { href: '/docs/api', label: 'Overview' },
+      { href: '/docs/api/events', label: 'Events' },
+      { href: '/docs/api/players', label: 'Players' },
+      { href: '/docs/api/teams', label: 'Teams' },
+      { href: '/docs/api/webhooks', label: 'Webhooks' },
+      { href: '/docs/api/push', label: 'Push Notifications' },
+      { href: '/docs/api/history', label: 'History' },
+    ],
+  },
+  {
+    title: 'Guides',
+    items: [
+      { href: '/docs/guides/webhook-openclaw', label: 'Webhook + OpenClaw' },
+      { href: '/docs/guides/self-hosting', label: 'Self-Hosting' },
+      { href: '/docs/guides/contributing', label: 'Contributing' },
+    ],
+  },
+];
+
+// Flatten for prev/next
+const allPages = sections.flatMap((s) => s.items);
+const currentIndex = allPages.findIndex((p) => p.href === currentPath);
+const prev = currentIndex > 0 ? allPages[currentIndex - 1] : null;
+const next = currentIndex < allPages.length - 1 ? allPages[currentIndex + 1] : null;
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{title} — Convocados Docs</title>
+    {description && <meta name="description" content={description} />}
+    <link rel="icon" href="/favicon.ico" />
+    <style>
+      *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+      :root {
+        --bg: #ffffff;
+        --bg-sidebar: #f8f9fa;
+        --text: #1a1a2e;
+        --text-muted: #6b7280;
+        --border: #e5e7eb;
+        --primary: #1976d2;
+        --primary-light: #e3f2fd;
+        --code-bg: #f1f5f9;
+        --code-block-bg: #1e293b;
+        --code-block-text: #e2e8f0;
+        --link: #1976d2;
+        --nav-hover: #e3f2fd;
+        --nav-active: #1976d2;
+        --nav-active-bg: #e3f2fd;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #121212;
+          --bg-sidebar: #1e1e1e;
+          --text: #e0e0e0;
+          --text-muted: #9e9e9e;
+          --border: #333333;
+          --primary: #90caf9;
+          --primary-light: #1a2332;
+          --code-bg: #2d2d2d;
+          --code-block-bg: #0d1117;
+          --code-block-text: #c9d1d9;
+          --link: #90caf9;
+          --nav-hover: #2a2a2a;
+          --nav-active: #90caf9;
+          --nav-active-bg: #1a2332;
+        }
+      }
+
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+        color: var(--text);
+        background: var(--bg);
+        line-height: 1.7;
+      }
+
+      /* Top bar */
+      .docs-topbar {
+        position: sticky;
+        top: 0;
+        z-index: 100;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        padding: 12px 24px;
+        background: var(--bg-sidebar);
+        border-bottom: 1px solid var(--border);
+        backdrop-filter: blur(8px);
+      }
+      .docs-topbar a.brand {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        text-decoration: none;
+        color: var(--text);
+        font-weight: 700;
+        font-size: 1.1rem;
+      }
+      .docs-topbar a.brand:hover { color: var(--primary); }
+      .docs-topbar .spacer { flex-grow: 1; }
+      .docs-topbar a.nav-link {
+        text-decoration: none;
+        color: var(--text-muted);
+        font-size: 0.875rem;
+        font-weight: 500;
+        padding: 4px 8px;
+        border-radius: 6px;
+      }
+      .docs-topbar a.nav-link:hover { color: var(--primary); background: var(--nav-hover); }
+
+      .menu-toggle {
+        display: none;
+        background: none;
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        padding: 6px 10px;
+        color: var(--text);
+        cursor: pointer;
+        font-size: 1.2rem;
+      }
+
+      /* Layout */
+      .docs-layout {
+        display: flex;
+        min-height: calc(100vh - 57px);
+      }
+
+      /* Sidebar */
+      .docs-sidebar {
+        width: 260px;
+        flex-shrink: 0;
+        padding: 24px 16px;
+        background: var(--bg-sidebar);
+        border-right: 1px solid var(--border);
+        overflow-y: auto;
+        position: sticky;
+        top: 57px;
+        height: calc(100vh - 57px);
+      }
+      .docs-sidebar .section-title {
+        font-size: 0.7rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--text-muted);
+        margin: 20px 0 8px 8px;
+      }
+      .docs-sidebar .section-title:first-child { margin-top: 0; }
+      .docs-sidebar a {
+        display: block;
+        padding: 6px 12px;
+        border-radius: 6px;
+        text-decoration: none;
+        color: var(--text);
+        font-size: 0.875rem;
+        transition: background 0.15s, color 0.15s;
+      }
+      .docs-sidebar a:hover { background: var(--nav-hover); }
+      .docs-sidebar a.active {
+        background: var(--nav-active-bg);
+        color: var(--nav-active);
+        font-weight: 600;
+      }
+
+      /* Content */
+      .docs-content {
+        flex-grow: 1;
+        max-width: 800px;
+        padding: 40px 48px 80px;
+      }
+
+      .docs-content h1 {
+        font-size: 2rem;
+        font-weight: 800;
+        margin-bottom: 8px;
+        line-height: 1.2;
+      }
+      .docs-content h2 {
+        font-size: 1.4rem;
+        font-weight: 700;
+        margin-top: 40px;
+        margin-bottom: 12px;
+        padding-bottom: 6px;
+        border-bottom: 1px solid var(--border);
+      }
+      .docs-content h3 {
+        font-size: 1.1rem;
+        font-weight: 600;
+        margin-top: 28px;
+        margin-bottom: 8px;
+      }
+      .docs-content p { margin-bottom: 16px; }
+      .docs-content .subtitle {
+        font-size: 1.1rem;
+        color: var(--text-muted);
+        margin-bottom: 32px;
+      }
+      .docs-content a { color: var(--link); }
+      .docs-content a:hover { text-decoration: underline; }
+
+      .docs-content ul, .docs-content ol {
+        margin-bottom: 16px;
+        padding-left: 24px;
+      }
+      .docs-content li { margin-bottom: 6px; }
+
+      .docs-content code {
+        background: var(--code-bg);
+        padding: 2px 6px;
+        border-radius: 4px;
+        font-size: 0.875em;
+        font-family: 'SF Mono', 'Fira Code', monospace;
+      }
+      .docs-content pre {
+        background: var(--code-block-bg);
+        color: var(--code-block-text);
+        padding: 16px 20px;
+        border-radius: 8px;
+        overflow-x: auto;
+        margin-bottom: 20px;
+        font-size: 0.85rem;
+        line-height: 1.6;
+      }
+      .docs-content pre code {
+        background: none;
+        padding: 0;
+        color: inherit;
+        font-size: inherit;
+      }
+
+      .docs-content table {
+        width: 100%;
+        border-collapse: collapse;
+        margin-bottom: 20px;
+        font-size: 0.9rem;
+      }
+      .docs-content th, .docs-content td {
+        text-align: left;
+        padding: 10px 14px;
+        border: 1px solid var(--border);
+      }
+      .docs-content th {
+        background: var(--bg-sidebar);
+        font-weight: 600;
+        font-size: 0.8rem;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+      }
+
+      .docs-content .callout {
+        padding: 16px 20px;
+        border-radius: 8px;
+        margin-bottom: 20px;
+        font-size: 0.9rem;
+      }
+      .docs-content .callout-info {
+        background: var(--primary-light);
+        border-left: 4px solid var(--primary);
+      }
+      .docs-content .callout-warn {
+        background: #fff8e1;
+        border-left: 4px solid #f9a825;
+      }
+      @media (prefers-color-scheme: dark) {
+        .docs-content .callout-warn { background: #332b00; }
+      }
+
+      .docs-content .endpoint {
+        display: inline-block;
+        font-family: 'SF Mono', 'Fira Code', monospace;
+        font-size: 0.85rem;
+        font-weight: 600;
+        padding: 2px 8px;
+        border-radius: 4px;
+      }
+      .docs-content .method-get { background: #e8f5e9; color: #2e7d32; }
+      .docs-content .method-post { background: #e3f2fd; color: #1565c0; }
+      .docs-content .method-put { background: #fff3e0; color: #e65100; }
+      .docs-content .method-delete { background: #fce4ec; color: #c62828; }
+      .docs-content .method-patch { background: #f3e5f5; color: #7b1fa2; }
+      @media (prefers-color-scheme: dark) {
+        .docs-content .method-get { background: #1b3a1b; color: #81c784; }
+        .docs-content .method-post { background: #0d2137; color: #64b5f6; }
+        .docs-content .method-put { background: #3e2200; color: #ffb74d; }
+        .docs-content .method-delete { background: #3b1010; color: #ef9a9a; }
+        .docs-content .method-patch { background: #2a1533; color: #ce93d8; }
+      }
+
+      /* Prev/Next nav */
+      .docs-nav-footer {
+        display: flex;
+        justify-content: space-between;
+        gap: 16px;
+        margin-top: 48px;
+        padding-top: 24px;
+        border-top: 1px solid var(--border);
+      }
+      .docs-nav-footer a {
+        display: flex;
+        flex-direction: column;
+        padding: 12px 16px;
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        text-decoration: none;
+        color: var(--text);
+        font-size: 0.9rem;
+        transition: border-color 0.15s;
+        min-width: 0;
+      }
+      .docs-nav-footer a:hover { border-color: var(--primary); }
+      .docs-nav-footer a .label {
+        font-size: 0.75rem;
+        color: var(--text-muted);
+        margin-bottom: 2px;
+      }
+      .docs-nav-footer a .title { font-weight: 600; color: var(--primary); }
+      .docs-nav-footer .next { margin-left: auto; text-align: right; }
+
+      /* Mobile */
+      @media (max-width: 768px) {
+        .menu-toggle { display: block; }
+        .docs-sidebar {
+          position: fixed;
+          top: 57px;
+          left: 0;
+          z-index: 50;
+          width: 280px;
+          height: calc(100vh - 57px);
+          transform: translateX(-100%);
+          transition: transform 0.2s ease;
+        }
+        .docs-sidebar.open { transform: translateX(0); }
+        .docs-overlay {
+          display: none;
+          position: fixed;
+          inset: 0;
+          top: 57px;
+          background: rgba(0,0,0,0.4);
+          z-index: 49;
+        }
+        .docs-overlay.open { display: block; }
+        .docs-content { padding: 24px 20px 60px; }
+        .docs-content h1 { font-size: 1.6rem; }
+        .docs-nav-footer { flex-direction: column; }
+        .docs-nav-footer .next { margin-left: 0; text-align: left; }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="docs-topbar">
+      <button class="menu-toggle" id="menuToggle" aria-label="Toggle menu">&#9776;</button>
+      <a class="brand" href="/">&#9917; Convocados</a>
+      <span class="spacer"></span>
+      <a class="nav-link" href="/docs">Docs</a>
+      <a class="nav-link" href="https://github.com/Cabeda/Convocados" target="_blank" rel="noopener">GitHub</a>
+    </div>
+
+    <div class="docs-layout">
+      <div class="docs-overlay" id="sidebarOverlay"></div>
+      <nav class="docs-sidebar" id="sidebar">
+        {sections.map((section) => (
+          <div>
+            <div class="section-title">{section.title}</div>
+            {section.items.map((item) => (
+              <a href={item.href} class={currentPath === item.href ? 'active' : ''}>
+                {item.label}
+              </a>
+            ))}
+          </div>
+        ))}
+      </nav>
+
+      <div class="docs-content">
+        <slot />
+
+        {(prev || next) && (
+          <div class="docs-nav-footer">
+            {prev ? (
+              <a href={prev.href}>
+                <span class="label">&larr; Previous</span>
+                <span class="title">{prev.label}</span>
+              </a>
+            ) : <span />}
+            {next ? (
+              <a href={next.href} class="next">
+                <span class="label">Next &rarr;</span>
+                <span class="title">{next.label}</span>
+              </a>
+            ) : <span />}
+          </div>
+        )}
+      </div>
+    </div>
+
+    <script is:inline>
+      const toggle = document.getElementById('menuToggle');
+      const sidebar = document.getElementById('sidebar');
+      const overlay = document.getElementById('sidebarOverlay');
+      function closeSidebar() {
+        sidebar.classList.remove('open');
+        overlay.classList.remove('open');
+      }
+      toggle.addEventListener('click', () => {
+        sidebar.classList.toggle('open');
+        overlay.classList.toggle('open');
+      });
+      overlay.addEventListener('click', closeSidebar);
+      // Close on nav
+      sidebar.querySelectorAll('a').forEach(a => a.addEventListener('click', closeSidebar));
+    </script>
+  </body>
+</html>

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -150,6 +150,9 @@ export const translations = {
     webhookEndpoint: "Webhook endpoint",
     webhookCopied: "Copied!",
     webhookHelp: "POST to this URL to register a webhook. See docs for payload format.",
+
+    // Docs
+    docs: "Docs",
   },
   pt: {
     // App
@@ -302,6 +305,9 @@ export const translations = {
     webhookEndpoint: "Endpoint do webhook",
     webhookCopied: "Copiado!",
     webhookHelp: "Faz POST para este URL para registar um webhook. Consulta a documentação para o formato do payload.",
+
+    // Docs
+    docs: "Docs",
   },
 } as const;
 

--- a/src/pages/docs/api/events.astro
+++ b/src/pages/docs/api/events.astro
@@ -1,0 +1,79 @@
+---
+import DocsLayout from '../../../layouts/DocsLayout.astro';
+---
+
+<DocsLayout title="Events API" description="Create and retrieve events.">
+  <h1>Events API</h1>
+
+  <h2><span class="endpoint method-post">POST</span> /api/events</h2>
+  <p>Create a new event.</p>
+
+  <h3>Request body</h3>
+  <table>
+    <thead><tr><th>Field</th><th>Type</th><th>Required</th><th>Description</th></tr></thead>
+    <tbody>
+      <tr><td><code>title</code></td><td>string</td><td>Yes</td><td>Game title (max 100 chars)</td></tr>
+      <tr><td><code>dateTime</code></td><td>string</td><td>Yes</td><td>ISO 8601 date, must be in the future</td></tr>
+      <tr><td><code>location</code></td><td>string</td><td>No</td><td>Location text or URL (max 200 chars)</td></tr>
+      <tr><td><code>maxPlayers</code></td><td>number</td><td>No</td><td>2–30, defaults to 10</td></tr>
+      <tr><td><code>teamOneName</code></td><td>string</td><td>No</td><td>Defaults to "Ninjas"</td></tr>
+      <tr><td><code>teamTwoName</code></td><td>string</td><td>No</td><td>Defaults to "Gunas"</td></tr>
+      <tr><td><code>isRecurring</code></td><td>boolean</td><td>No</td><td>Enable recurrence</td></tr>
+      <tr><td><code>recurrenceFreq</code></td><td>string</td><td>No</td><td>"weekly" or "monthly"</td></tr>
+      <tr><td><code>recurrenceInterval</code></td><td>number</td><td>No</td><td>Repeat interval (default 1)</td></tr>
+      <tr><td><code>recurrenceByDay</code></td><td>string</td><td>No</td><td>Day code: MO, TU, WE, TH, FR, SA, SU</td></tr>
+    </tbody>
+  </table>
+
+  <h3>Example</h3>
+  <pre><code>{`curl -X POST https://convocados.fly.dev/api/events \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "title": "Friday Footy",
+    "dateTime": "2026-03-20T19:00:00Z",
+    "location": "Riverside Astro",
+    "maxPlayers": 10
+  }'`}</code></pre>
+
+  <h3>Response</h3>
+  <pre><code>{`{ "id": "clx1abc2d..." }`}</code></pre>
+
+  <h2><span class="endpoint method-get">GET</span> /api/events/[id]</h2>
+  <p>Get full event details including players and team results. Also triggers lazy recurrence reset if applicable.</p>
+
+  <h3>Response</h3>
+  <pre><code>{`{
+  "id": "clx1abc2d...",
+  "title": "Friday Footy",
+  "location": "Riverside Astro",
+  "dateTime": "2026-03-20T19:00:00.000Z",
+  "maxPlayers": 10,
+  "teamOneName": "Ninjas",
+  "teamTwoName": "Gunas",
+  "isRecurring": false,
+  "nextResetAt": null,
+  "wasReset": false,
+  "players": [...],
+  "teamResults": [...]
+}`}</code></pre>
+
+  <h2><span class="endpoint method-get">GET</span> /api/events/[id]/status</h2>
+  <p>Compact event status with player counts and team assignments. Useful for polling.</p>
+
+  <h3>Response</h3>
+  <pre><code>{`{
+  "id": "clx1abc2d...",
+  "title": "Friday Footy",
+  "maxPlayers": 10,
+  "players": {
+    "active": [{ "id": "...", "name": "Alice" }],
+    "bench": [],
+    "total": 1,
+    "spotsLeft": 9
+  },
+  "teams": [
+    { "name": "Ninjas", "players": ["Alice", "Bob"] },
+    { "name": "Gunas", "players": ["Carol", "Dave"] }
+  ]
+}`}</code></pre>
+</DocsLayout>

--- a/src/pages/docs/api/history.astro
+++ b/src/pages/docs/api/history.astro
@@ -1,0 +1,74 @@
+---
+import DocsLayout from '../../../layouts/DocsLayout.astro';
+---
+
+<DocsLayout title="History API" description="Record and update game results.">
+  <h1>History API</h1>
+  <p class="subtitle">Endpoints for listing past game results and editing scores while they are still editable.</p>
+
+  <h2><span class="endpoint method-get">GET</span> /api/events/[id]/history</h2>
+  <p>List all history entries for an event, ordered by date descending.</p>
+
+  <h3>Response</h3>
+  <pre><code>{`[
+  {
+    "id": "clx9abc...",
+    "eventId": "clx1abc...",
+    "dateTime": "2026-03-13T19:00:00.000Z",
+    "status": "played",
+    "scoreOne": 3,
+    "scoreTwo": 2,
+    "teamsSnapshot": "{\\"teamOne\\":[...],\\"teamTwo\\":[...]}",
+    "editableUntil": "2026-03-14T19:00:00.000Z",
+    "createdAt": "2026-03-13T21:00:00.000Z",
+    "editable": true
+  }
+]`}</code></pre>
+
+  <h3>Fields</h3>
+  <table>
+    <thead><tr><th>Field</th><th>Type</th><th>Description</th></tr></thead>
+    <tbody>
+      <tr><td><code>id</code></td><td>string</td><td>History entry ID</td></tr>
+      <tr><td><code>eventId</code></td><td>string</td><td>Parent event ID</td></tr>
+      <tr><td><code>dateTime</code></td><td>string</td><td>When the game was played (ISO 8601)</td></tr>
+      <tr><td><code>status</code></td><td>string</td><td><code>"played"</code> or <code>"cancelled"</code></td></tr>
+      <tr><td><code>scoreOne</code></td><td>number | null</td><td>Team one score</td></tr>
+      <tr><td><code>scoreTwo</code></td><td>number | null</td><td>Team two score</td></tr>
+      <tr><td><code>teamsSnapshot</code></td><td>string</td><td>JSON snapshot of team assignments at game time</td></tr>
+      <tr><td><code>editableUntil</code></td><td>string</td><td>Deadline for editing this entry (ISO 8601)</td></tr>
+      <tr><td><code>editable</code></td><td>boolean</td><td>Whether the entry can still be modified</td></tr>
+    </tbody>
+  </table>
+
+  <h2><span class="endpoint method-patch">PATCH</span> /api/events/[id]/history/[historyId]</h2>
+  <p>Update a history entry. Only works while <code>editable</code> is <code>true</code> (before <code>editableUntil</code>). Returns <code>403</code> if the edit window has closed.</p>
+
+  <h3>Request body</h3>
+  <table>
+    <thead><tr><th>Field</th><th>Type</th><th>Required</th><th>Description</th></tr></thead>
+    <tbody>
+      <tr><td><code>status</code></td><td>string</td><td>No</td><td><code>"played"</code> or <code>"cancelled"</code></td></tr>
+      <tr><td><code>scoreOne</code></td><td>number | null</td><td>No</td><td>Team one score (null to clear)</td></tr>
+      <tr><td><code>scoreTwo</code></td><td>number | null</td><td>No</td><td>Team two score (null to clear)</td></tr>
+      <tr><td><code>teamsSnapshot</code></td><td>object</td><td>No</td><td>Updated team assignments</td></tr>
+    </tbody>
+  </table>
+
+  <h3>Example</h3>
+  <pre><code>{`curl -X PATCH https://convocados.fly.dev/api/events/EVENT_ID/history/HISTORY_ID \\
+  -H "Content-Type: application/json" \\
+  -d '{ "scoreOne": 4, "scoreTwo": 3 }'`}</code></pre>
+
+  <h3>Response</h3>
+  <p>Returns the updated history entry in the same format as the GET response.</p>
+
+  <h3>Error responses</h3>
+  <table>
+    <thead><tr><th>Status</th><th>Reason</th></tr></thead>
+    <tbody>
+      <tr><td><code>404</code></td><td>History entry not found</td></tr>
+      <tr><td><code>403</code></td><td>Edit window has expired</td></tr>
+    </tbody>
+  </table>
+</DocsLayout>

--- a/src/pages/docs/api/index.astro
+++ b/src/pages/docs/api/index.astro
@@ -1,0 +1,63 @@
+---
+import DocsLayout from '../../../layouts/DocsLayout.astro';
+---
+
+<DocsLayout title="API Overview" description="Convocados REST API reference.">
+  <h1>API Reference</h1>
+  <p class="subtitle">All endpoints accept and return JSON. The base URL is your deployment origin.</p>
+
+  <h2>Base URL</h2>
+  <pre><code>https://convocados.fly.dev</code></pre>
+  <p>For local development: <code>http://localhost:4321</code></p>
+
+  <h2>Content Type</h2>
+  <p>All requests with a body must include:</p>
+  <pre><code>Content-Type: application/json</code></pre>
+
+  <h2>Error format</h2>
+  <p>Errors return a JSON object with an <code>error</code> field:</p>
+  <pre><code>{`{ "error": "Not found." }`}</code></pre>
+
+  <h2>Common status codes</h2>
+  <table>
+    <thead><tr><th>Code</th><th>Meaning</th></tr></thead>
+    <tbody>
+      <tr><td><code>200</code></td><td>Success</td></tr>
+      <tr><td><code>400</code></td><td>Bad request (missing/invalid fields)</td></tr>
+      <tr><td><code>403</code></td><td>Forbidden (e.g. editing locked history)</td></tr>
+      <tr><td><code>404</code></td><td>Resource not found</td></tr>
+      <tr><td><code>409</code></td><td>Conflict (duplicate player name, duplicate webhook URL)</td></tr>
+      <tr><td><code>429</code></td><td>Rate limited</td></tr>
+    </tbody>
+  </table>
+
+  <h2>Rate limiting</h2>
+  <p>
+    Event creation is limited to <strong>10 per hour per IP</strong>.
+    The IP is read from <code>fly-client-ip</code> or <code>x-forwarded-for</code> headers.
+  </p>
+
+  <h2>Endpoints</h2>
+  <table>
+    <thead><tr><th>Method</th><th>Endpoint</th><th>Description</th></tr></thead>
+    <tbody>
+      <tr><td><span class="endpoint method-post">POST</span></td><td><code>/api/events</code></td><td>Create an event</td></tr>
+      <tr><td><span class="endpoint method-get">GET</span></td><td><code>/api/events/[id]</code></td><td>Get event details</td></tr>
+      <tr><td><span class="endpoint method-get">GET</span></td><td><code>/api/events/[id]/status</code></td><td>Get event status (compact)</td></tr>
+      <tr><td><span class="endpoint method-post">POST</span></td><td><code>/api/events/[id]/players</code></td><td>Add a player</td></tr>
+      <tr><td><span class="endpoint method-delete">DELETE</span></td><td><code>/api/events/[id]/players</code></td><td>Remove a player</td></tr>
+      <tr><td><span class="endpoint method-post">POST</span></td><td><code>/api/events/[id]/randomize</code></td><td>Randomize teams</td></tr>
+      <tr><td><span class="endpoint method-put">PUT</span></td><td><code>/api/events/[id]/teams</code></td><td>Save team assignments</td></tr>
+      <tr><td><span class="endpoint method-put">PUT</span></td><td><code>/api/events/[id]/team-names</code></td><td>Update team names</td></tr>
+      <tr><td><span class="endpoint method-get">GET</span></td><td><code>/api/events/[id]/known-players</code></td><td>Get player suggestions</td></tr>
+      <tr><td><span class="endpoint method-post">POST</span></td><td><code>/api/events/[id]/webhooks</code></td><td>Subscribe a webhook</td></tr>
+      <tr><td><span class="endpoint method-get">GET</span></td><td><code>/api/events/[id]/webhooks</code></td><td>List webhooks</td></tr>
+      <tr><td><span class="endpoint method-delete">DELETE</span></td><td><code>/api/events/[id]/webhooks/[webhookId]</code></td><td>Unsubscribe a webhook</td></tr>
+      <tr><td><span class="endpoint method-post">POST</span></td><td><code>/api/events/[id]/push</code></td><td>Subscribe to push notifications</td></tr>
+      <tr><td><span class="endpoint method-delete">DELETE</span></td><td><code>/api/events/[id]/push</code></td><td>Unsubscribe from push</td></tr>
+      <tr><td><span class="endpoint method-get">GET</span></td><td><code>/api/push/vapid-public-key</code></td><td>Get VAPID public key</td></tr>
+      <tr><td><span class="endpoint method-get">GET</span></td><td><code>/api/events/[id]/history</code></td><td>List game history</td></tr>
+      <tr><td><span class="endpoint method-patch">PATCH</span></td><td><code>/api/events/[id]/history/[historyId]</code></td><td>Update history entry</td></tr>
+    </tbody>
+  </table>
+</DocsLayout>

--- a/src/pages/docs/api/players.astro
+++ b/src/pages/docs/api/players.astro
@@ -1,0 +1,79 @@
+---
+import DocsLayout from '../../../layouts/DocsLayout.astro';
+---
+
+<DocsLayout title="Players API" description="Add and remove players from events.">
+  <h1>Players API</h1>
+
+  <h2><span class="endpoint method-post">POST</span> /api/events/[id]/players</h2>
+  <p>Add a player to the event.</p>
+
+  <h3>Request body</h3>
+  <table>
+    <thead><tr><th>Field</th><th>Type</th><th>Required</th><th>Description</th></tr></thead>
+    <tbody>
+      <tr><td><code>name</code></td><td>string</td><td>Yes</td><td>Player name (max 50 chars, trimmed)</td></tr>
+    </tbody>
+  </table>
+
+  <h3>Headers (optional)</h3>
+  <table>
+    <thead><tr><th>Header</th><th>Description</th></tr></thead>
+    <tbody>
+      <tr><td><code>X-Client-Id</code></td><td>Client identifier — used to suppress self-notifications</td></tr>
+    </tbody>
+  </table>
+
+  <h3>Example</h3>
+  <pre><code>{`curl -X POST https://convocados.fly.dev/api/events/EVENT_ID/players \\
+  -H "Content-Type: application/json" \\
+  -d '{ "name": "Alice" }'`}</code></pre>
+
+  <h3>Response</h3>
+  <pre><code>{`{ "ok": true }`}</code></pre>
+
+  <h3>Errors</h3>
+  <table>
+    <thead><tr><th>Code</th><th>Reason</th></tr></thead>
+    <tbody>
+      <tr><td><code>400</code></td><td>Name is empty</td></tr>
+      <tr><td><code>404</code></td><td>Event not found</td></tr>
+      <tr><td><code>409</code></td><td>Player name already exists in this event</td></tr>
+    </tbody>
+  </table>
+
+  <h2><span class="endpoint method-delete">DELETE</span> /api/events/[id]/players</h2>
+  <p>Remove a player from the event.</p>
+
+  <h3>Request body</h3>
+  <table>
+    <thead><tr><th>Field</th><th>Type</th><th>Required</th><th>Description</th></tr></thead>
+    <tbody>
+      <tr><td><code>playerId</code></td><td>string</td><td>Yes</td><td>The player's ID</td></tr>
+    </tbody>
+  </table>
+
+  <h3>Example</h3>
+  <pre><code>{`curl -X DELETE https://convocados.fly.dev/api/events/EVENT_ID/players \\
+  -H "Content-Type: application/json" \\
+  -d '{ "playerId": "clx..." }'`}</code></pre>
+
+  <h3>Side effects</h3>
+  <ul>
+    <li>If the removed player was active and there's a bench player, the first bench player is promoted</li>
+    <li>Push notifications are sent to subscribers</li>
+    <li>Webhooks are fired (<code>player_left</code>)</li>
+  </ul>
+
+  <h2><span class="endpoint method-get">GET</span> /api/events/[id]/known-players</h2>
+  <p>Get player name suggestions from game history. Returns names sorted by frequency, excluding current players.</p>
+
+  <h3>Response</h3>
+  <pre><code>{`{
+  "players": [
+    { "name": "Alice", "gamesPlayed": 5 },
+    { "name": "Bob", "gamesPlayed": 3 }
+  ]
+}`}</code></pre>
+  <p>Returns up to 30 suggestions. Only includes names from "played" (not cancelled) history entries.</p>
+</DocsLayout>

--- a/src/pages/docs/api/push.astro
+++ b/src/pages/docs/api/push.astro
@@ -1,0 +1,50 @@
+---
+import DocsLayout from '../../../layouts/DocsLayout.astro';
+---
+
+<DocsLayout title="Push Notifications API" description="Subscribe to browser push notifications.">
+  <h1>Push Notifications API</h1>
+
+  <h2><span class="endpoint method-get">GET</span> /api/push/vapid-public-key</h2>
+  <p>Get the server's VAPID public key for push subscription.</p>
+
+  <h3>Response</h3>
+  <pre><code>{`{ "publicKey": "BPx..." }`}</code></pre>
+
+  <h2><span class="endpoint method-post">POST</span> /api/events/[id]/push</h2>
+  <p>Subscribe to push notifications for an event.</p>
+
+  <h3>Request body</h3>
+  <table>
+    <thead><tr><th>Field</th><th>Type</th><th>Required</th><th>Description</th></tr></thead>
+    <tbody>
+      <tr><td><code>endpoint</code></td><td>string</td><td>Yes</td><td>Push subscription endpoint URL</td></tr>
+      <tr><td><code>keys.p256dh</code></td><td>string</td><td>Yes</td><td>P-256 Diffie-Hellman public key</td></tr>
+      <tr><td><code>keys.auth</code></td><td>string</td><td>Yes</td><td>Authentication secret</td></tr>
+      <tr><td><code>locale</code></td><td>string</td><td>No</td><td>Language for notifications (e.g. "pt-PT"). Defaults to "en"</td></tr>
+      <tr><td><code>clientId</code></td><td>string</td><td>No</td><td>Client ID for self-notification suppression</td></tr>
+    </tbody>
+  </table>
+
+  <h3>Response</h3>
+  <pre><code>{`{ "ok": true }`}</code></pre>
+
+  <div class="callout callout-info">
+    <strong>Upsert behavior:</strong> If a subscription with the same endpoint already exists for this event,
+    it is updated with the new keys and locale.
+  </div>
+
+  <h2><span class="endpoint method-delete">DELETE</span> /api/events/[id]/push</h2>
+  <p>Unsubscribe from push notifications.</p>
+
+  <h3>Request body</h3>
+  <table>
+    <thead><tr><th>Field</th><th>Type</th><th>Required</th><th>Description</th></tr></thead>
+    <tbody>
+      <tr><td><code>endpoint</code></td><td>string</td><td>Yes</td><td>The push subscription endpoint to remove</td></tr>
+    </tbody>
+  </table>
+
+  <h3>Response</h3>
+  <pre><code>{`{ "ok": true }`}</code></pre>
+</DocsLayout>

--- a/src/pages/docs/api/teams.astro
+++ b/src/pages/docs/api/teams.astro
@@ -1,0 +1,62 @@
+---
+import DocsLayout from '../../../layouts/DocsLayout.astro';
+---
+
+<DocsLayout title="Teams API" description="Randomize teams, save assignments, rename teams.">
+  <h1>Teams API</h1>
+
+  <h2><span class="endpoint method-post">POST</span> /api/events/[id]/randomize</h2>
+  <p>Randomly assign active players to two teams.</p>
+
+  <h3>Example</h3>
+  <pre><code>{`curl -X POST https://convocados.fly.dev/api/events/EVENT_ID/randomize`}</code></pre>
+
+  <h3>Response</h3>
+  <pre><code>{`{ "ok": true }`}</code></pre>
+
+  <h3>Errors</h3>
+  <table>
+    <thead><tr><th>Code</th><th>Reason</th></tr></thead>
+    <tbody>
+      <tr><td><code>400</code></td><td>Fewer than 2 active players</td></tr>
+      <tr><td><code>404</code></td><td>Event not found</td></tr>
+    </tbody>
+  </table>
+
+  <h2><span class="endpoint method-put">PUT</span> /api/events/[id]/teams</h2>
+  <p>Save team assignments (e.g. after drag-and-drop reordering).</p>
+
+  <h3>Request body</h3>
+  <pre><code>{`{
+  "matches": [
+    {
+      "team": "Ninjas",
+      "players": [
+        { "name": "Alice", "order": 0 },
+        { "name": "Bob", "order": 1 }
+      ]
+    },
+    {
+      "team": "Gunas",
+      "players": [
+        { "name": "Carol", "order": 0 }
+      ]
+    }
+  ]
+}`}</code></pre>
+
+  <h3>Response</h3>
+  <pre><code>{`{ "ok": true }`}</code></pre>
+
+  <h2><span class="endpoint method-put">PUT</span> /api/events/[id]/team-names</h2>
+  <p>Update team names. Empty strings fall back to defaults ("Ninjas" / "Gunas").</p>
+
+  <h3>Request body</h3>
+  <pre><code>{`{
+  "teamOneName": "Eagles",
+  "teamTwoName": "Lions"
+}`}</code></pre>
+
+  <h3>Response</h3>
+  <pre><code>{`{ "ok": true }`}</code></pre>
+</DocsLayout>

--- a/src/pages/docs/api/webhooks.astro
+++ b/src/pages/docs/api/webhooks.astro
@@ -1,0 +1,138 @@
+---
+import DocsLayout from '../../../layouts/DocsLayout.astro';
+---
+
+<DocsLayout title="Webhooks API" description="Subscribe to event notifications via HTTP callbacks.">
+  <h1>Webhooks API</h1>
+  <p class="subtitle">Receive HTTP POST callbacks when events happen — player joins, leaves, game full, or game reset.</p>
+
+  <h2>Event types</h2>
+  <table>
+    <thead><tr><th>Type</th><th>Triggered when</th></tr></thead>
+    <tbody>
+      <tr><td><code>player_joined</code></td><td>A player is added to the event</td></tr>
+      <tr><td><code>player_left</code></td><td>A player is removed from the event</td></tr>
+      <tr><td><code>game_full</code></td><td>The last active spot is filled (spotsLeft = 0)</td></tr>
+      <tr><td><code>game_reset</code></td><td>A recurring event resets its player list</td></tr>
+    </tbody>
+  </table>
+
+  <h2><span class="endpoint method-post">POST</span> /api/events/[id]/webhooks</h2>
+  <p>Subscribe a webhook URL to receive event notifications.</p>
+
+  <h3>Request body</h3>
+  <table>
+    <thead><tr><th>Field</th><th>Type</th><th>Required</th><th>Description</th></tr></thead>
+    <tbody>
+      <tr><td><code>url</code></td><td>string</td><td>Yes</td><td>The URL to receive POST callbacks</td></tr>
+      <tr><td><code>events</code></td><td>string[]</td><td>No</td><td>Event types to subscribe to. Empty array = all events</td></tr>
+      <tr><td><code>secret</code></td><td>string</td><td>No</td><td>Shared secret for HMAC-SHA256 signature verification</td></tr>
+    </tbody>
+  </table>
+
+  <h3>Example</h3>
+  <pre><code>{`curl -X POST https://convocados.fly.dev/api/events/EVENT_ID/webhooks \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "url": "https://example.com/webhook",
+    "events": ["player_joined", "game_full"],
+    "secret": "my-shared-secret"
+  }'`}</code></pre>
+
+  <h3>Response</h3>
+  <pre><code>{`{
+  "id": "cmm...",
+  "url": "https://example.com/webhook",
+  "events": ["player_joined", "game_full"],
+  "createdAt": "2026-03-15T13:00:00.000Z"
+}`}</code></pre>
+
+  <h3>Limits</h3>
+  <ul>
+    <li>Maximum <strong>10 webhooks per event</strong></li>
+    <li>Duplicate URLs on the same event return <code>409</code></li>
+  </ul>
+
+  <h2><span class="endpoint method-get">GET</span> /api/events/[id]/webhooks</h2>
+  <p>List all webhook subscriptions for an event.</p>
+
+  <h3>Response</h3>
+  <pre><code>{`{
+  "webhooks": [
+    {
+      "id": "cmm...",
+      "url": "https://example.com/webhook",
+      "events": ["player_joined", "game_full"],
+      "createdAt": "2026-03-15T13:00:00.000Z"
+    }
+  ]
+}`}</code></pre>
+
+  <h2><span class="endpoint method-delete">DELETE</span> /api/events/[id]/webhooks/[webhookId]</h2>
+  <p>Unsubscribe a webhook.</p>
+
+  <h3>Example</h3>
+  <pre><code>{`curl -X DELETE https://convocados.fly.dev/api/events/EVENT_ID/webhooks/WEBHOOK_ID`}</code></pre>
+
+  <h3>Response</h3>
+  <pre><code>{`{ "ok": true }`}</code></pre>
+
+  <h2>Webhook payload</h2>
+  <p>When an event occurs, Convocados sends a POST request to your URL with this JSON body:</p>
+  <pre><code>{`{
+  "event": "player_joined",
+  "eventId": "clx...",
+  "deliveryId": "550e8400-e29b-41d4-a716-446655440000",
+  "timestamp": "2026-03-15T13:30:00.000Z",
+  "data": {
+    "playerName": "Carlos",
+    "isActive": true,
+    "spotsLeft": 3
+  }
+}`}</code></pre>
+
+  <h3>Payload fields by event type</h3>
+  <table>
+    <thead><tr><th>Event type</th><th>data fields</th></tr></thead>
+    <tbody>
+      <tr><td><code>player_joined</code></td><td><code>playerName</code>, <code>isActive</code>, <code>spotsLeft</code></td></tr>
+      <tr><td><code>player_left</code></td><td><code>playerName</code>, <code>spotsLeft</code></td></tr>
+      <tr><td><code>game_full</code></td><td><code>playerName</code>, <code>isActive</code>, <code>spotsLeft</code> (always 0)</td></tr>
+      <tr><td><code>game_reset</code></td><td><code>newDateTime</code> (ISO 8601)</td></tr>
+    </tbody>
+  </table>
+
+  <h2>Signature verification</h2>
+  <p>
+    If you provided a <code>secret</code> when subscribing, each delivery includes an
+    <code>X-Webhook-Signature</code> header with an HMAC-SHA256 signature:
+  </p>
+  <pre><code>X-Webhook-Signature: sha256=a1b2c3d4e5f6...</code></pre>
+  <p>To verify in Node.js:</p>
+  <pre><code>{`import { createHmac } from "crypto";
+
+function verify(payload, signature, secret) {
+  const expected = "sha256=" + createHmac("sha256", secret)
+    .update(payload)
+    .digest("hex");
+  return expected === signature;
+}`}</code></pre>
+
+  <h2>Delivery &amp; retry</h2>
+  <ul>
+    <li><strong>Timeout:</strong> 5 seconds per request</li>
+    <li><strong>Retries:</strong> up to 5 attempts with exponential backoff (1s, 2s, 4s, 8s, 16s)</li>
+    <li><strong>Success:</strong> any 2xx response</li>
+    <li><strong>Failure:</strong> after 5 failed attempts, the delivery is marked as failed</li>
+  </ul>
+
+  <h2>Headers sent</h2>
+  <table>
+    <thead><tr><th>Header</th><th>Value</th></tr></thead>
+    <tbody>
+      <tr><td><code>Content-Type</code></td><td><code>application/json</code></td></tr>
+      <tr><td><code>User-Agent</code></td><td><code>Convocados-Webhook/1.0</code></td></tr>
+      <tr><td><code>X-Webhook-Signature</code></td><td>HMAC-SHA256 (only if secret configured)</td></tr>
+    </tbody>
+  </table>
+</DocsLayout>

--- a/src/pages/docs/features/events.astro
+++ b/src/pages/docs/features/events.astro
@@ -1,0 +1,48 @@
+---
+import DocsLayout from '../../../layouts/DocsLayout.astro';
+---
+
+<DocsLayout title="Events" description="Creating and managing events in Convocados.">
+  <h1>Events</h1>
+  <p class="subtitle">Events are the core of Convocados — each one represents a game session.</p>
+
+  <h2>Creating an event</h2>
+  <p>From the home page, fill in the create form:</p>
+  <table>
+    <thead><tr><th>Field</th><th>Required</th><th>Description</th></tr></thead>
+    <tbody>
+      <tr><td><code>title</code></td><td>Yes</td><td>Game name, up to 100 characters</td></tr>
+      <tr><td><code>dateTime</code></td><td>Yes</td><td>Must be in the future</td></tr>
+      <tr><td><code>location</code></td><td>No</td><td>Text or URL — URLs become clickable links, plain text links to Google Maps</td></tr>
+      <tr><td><code>maxPlayers</code></td><td>No</td><td>2–30, defaults to 10. Players beyond this go to the bench</td></tr>
+      <tr><td><code>teamOneName</code></td><td>No</td><td>Defaults to "Ninjas"</td></tr>
+      <tr><td><code>teamTwoName</code></td><td>No</td><td>Defaults to "Gunas"</td></tr>
+    </tbody>
+  </table>
+
+  <h2>Event URL</h2>
+  <p>
+    Each event gets a unique URL like <code>/events/clx1abc2d...</code>. This is the only way to access the event —
+    there's no login or account system. Share this link with your group.
+  </p>
+
+  <h2>Event lifecycle</h2>
+  <ol>
+    <li><strong>Created</strong> — event is live, players can join</li>
+    <li><strong>Players join</strong> — via the shared link</li>
+    <li><strong>Teams randomized</strong> — when enough players are in</li>
+    <li><strong>Game played</strong> — at the scheduled date/time</li>
+    <li><strong>Reset</strong> (recurring only) — player list clears, event advances to next date</li>
+  </ol>
+
+  <h2>Recurring events</h2>
+  <p>
+    Enable <strong>Recurring game</strong> in advanced options to auto-reset the player list.
+    See <a href="/docs/features/recurrence">Recurring Games</a> for details.
+  </p>
+
+  <h2>Rate limiting</h2>
+  <p>
+    Event creation is rate-limited to <strong>10 events per hour per IP</strong> to prevent abuse.
+  </p>
+</DocsLayout>

--- a/src/pages/docs/features/history.astro
+++ b/src/pages/docs/features/history.astro
@@ -1,0 +1,40 @@
+---
+import DocsLayout from '../../../layouts/DocsLayout.astro';
+---
+
+<DocsLayout title="History & Scores" description="Track past games and record scores.">
+  <h1>History &amp; Scores</h1>
+  <p class="subtitle">Review past games and keep score for recurring events.</p>
+
+  <h2>How history works</h2>
+  <p>
+    History is only available for <strong>recurring events</strong>. Each time the player list resets,
+    a history entry is automatically created with:
+  </p>
+  <ul>
+    <li>The game date</li>
+    <li>Team names</li>
+    <li>A snapshot of team assignments (players and their order)</li>
+    <li>Status: "played" (default) or "cancelled"</li>
+  </ul>
+
+  <h2>Viewing history</h2>
+  <p>
+    Click the <strong>History</strong> button on the event page (only visible for recurring events).
+    Past games are listed in reverse chronological order.
+  </p>
+
+  <h2>Editing results</h2>
+  <p>History entries are editable for <strong>7 days</strong> after the game date. You can:</p>
+  <ul>
+    <li><strong>Record scores</strong> — enter the score for each team</li>
+    <li><strong>Change status</strong> — mark as "played" or "cancelled"</li>
+  </ul>
+  <p>After 7 days, the entry is locked and shows "Result locked".</p>
+
+  <h2>Cancelled games</h2>
+  <p>
+    Games marked as cancelled are excluded from the <strong>known players</strong> suggestions.
+    Only "played" games contribute to the player frequency ranking.
+  </p>
+</DocsLayout>

--- a/src/pages/docs/features/notifications.astro
+++ b/src/pages/docs/features/notifications.astro
@@ -1,0 +1,65 @@
+---
+import DocsLayout from '../../../layouts/DocsLayout.astro';
+---
+
+<DocsLayout title="Notifications" description="Push notifications for player join/leave events.">
+  <h1>Notifications</h1>
+  <p class="subtitle">Get notified when players join or leave your game.</p>
+
+  <h2>How it works</h2>
+  <p>
+    Convocados uses <strong>Web Push Notifications</strong> (via the Push API and Service Workers).
+    No app install is needed — notifications work directly in the browser.
+  </p>
+
+  <h2>Subscribing</h2>
+  <ol>
+    <li>Open an event page</li>
+    <li>Click <strong>Get notified</strong></li>
+    <li>Allow notifications when the browser prompts you</li>
+  </ol>
+  <p>
+    The button changes to <strong>Notifications on</strong> (green). Click it again to unsubscribe.
+  </p>
+
+  <h2>What you'll receive</h2>
+  <table>
+    <thead><tr><th>Event</th><th>Notification</th></tr></thead>
+    <tbody>
+      <tr><td>Player joins (active)</td><td>"Alice joined the game · 3 spot(s) left"</td></tr>
+      <tr><td>Player joins (bench)</td><td>"Alice joined the bench · Game is full"</td></tr>
+      <tr><td>Player leaves</td><td>"Alice left the game · 1 spot(s) left"</td></tr>
+      <tr><td>Player leaves + promotion</td><td>"Alice left · Bob is now playing"</td></tr>
+    </tbody>
+  </table>
+
+  <div class="callout callout-info">
+    <strong>Self-suppression:</strong> You won't receive notifications for your own actions.
+    This is tracked via a client ID stored in localStorage.
+  </div>
+
+  <h2>Browser support</h2>
+  <p>
+    Push notifications work in Chrome, Edge, Firefox, and Safari 16.4+.
+    If the browser doesn't support push, the notification button is hidden.
+    If the user has blocked notifications, the button shows "Notifications blocked".
+  </p>
+
+  <h2>VAPID keys (self-hosting)</h2>
+  <p>
+    Push notifications require VAPID keys. Generate them with:
+  </p>
+  <pre><code>npx web-push generate-vapid-keys</code></pre>
+  <p>Set the output as environment variables:</p>
+  <pre><code>VAPID_PUBLIC_KEY="BPx..."
+VAPID_PRIVATE_KEY="abc..."</code></pre>
+  <p>
+    Without these keys, push notifications are silently disabled — the rest of the app works fine.
+  </p>
+
+  <h2>Localization</h2>
+  <p>
+    Notification text is sent in the subscriber's language (detected from <code>navigator.language</code>).
+    Currently English and Portuguese are supported.
+  </p>
+</DocsLayout>

--- a/src/pages/docs/features/players.astro
+++ b/src/pages/docs/features/players.astro
@@ -1,0 +1,48 @@
+---
+import DocsLayout from '../../../layouts/DocsLayout.astro';
+---
+
+<DocsLayout title="Players & Bench" description="Adding and removing players, bench system, auto-promotion.">
+  <h1>Players &amp; Bench</h1>
+  <p class="subtitle">Manage who's playing and who's waiting.</p>
+
+  <h2>Adding players</h2>
+  <p>There are two ways to add players:</p>
+  <ul>
+    <li><strong>Quick Join</strong> — the top section shows recent players as tappable chips. Tap a name or type a new one.</li>
+    <li><strong>Player list input</strong> — type a name and press Enter, or paste a newline-separated list to add multiple at once.</li>
+  </ul>
+  <p>Player names must be unique within an event (case-sensitive) and are limited to 50 characters.</p>
+
+  <h2>Autocomplete</h2>
+  <p>
+    The input shows suggestions from two sources:
+  </p>
+  <ul>
+    <li><strong>Server history</strong> — names from past games (for recurring events)</li>
+    <li><strong>Local storage</strong> — names you've used before on this device</li>
+  </ul>
+  <p>Suggestions are sorted by frequency, with your last-used name at the top.</p>
+
+  <h2>Bench system</h2>
+  <p>
+    When the number of players exceeds <code>maxPlayers</code>, additional players go to the <strong>bench</strong>.
+    Bench players are shown separately with a numbered order.
+  </p>
+  <ul>
+    <li>Active players: included in team randomization</li>
+    <li>Bench players: waiting for a spot to open</li>
+  </ul>
+
+  <h2>Auto-promotion</h2>
+  <p>
+    When an active player leaves, the <strong>first bench player</strong> is automatically promoted to active status.
+    Push notifications inform everyone about the change.
+  </p>
+
+  <h2>Removing players</h2>
+  <p>
+    Click the <strong>X</strong> on any player chip to remove them. If you joined via Quick Join,
+    you'll see a "Leave" button instead.
+  </p>
+</DocsLayout>

--- a/src/pages/docs/features/recurrence.astro
+++ b/src/pages/docs/features/recurrence.astro
@@ -1,0 +1,46 @@
+---
+import DocsLayout from '../../../layouts/DocsLayout.astro';
+---
+
+<DocsLayout title="Recurring Games" description="Auto-resetting player lists on a schedule.">
+  <h1>Recurring Games</h1>
+  <p class="subtitle">Set it once, reuse the same link every week.</p>
+
+  <h2>How it works</h2>
+  <p>
+    When you create an event with <strong>Recurring game</strong> enabled, the player list
+    automatically resets after each game. The event URL stays the same — share it once
+    and players can rejoin each week.
+  </p>
+
+  <h2>Configuration</h2>
+  <table>
+    <thead><tr><th>Setting</th><th>Options</th><th>Description</th></tr></thead>
+    <tbody>
+      <tr><td>Frequency</td><td>Weekly, Monthly</td><td>How often the game repeats</td></tr>
+      <tr><td>Interval</td><td>1–52</td><td>e.g. "every 2 weeks"</td></tr>
+      <tr><td>Day (weekly only)</td><td>Mon–Sun</td><td>Optional — defaults to the same day as the event</td></tr>
+    </tbody>
+  </table>
+
+  <h2>Reset behavior</h2>
+  <p>The reset happens <strong>1 hour after the scheduled game time</strong>. When triggered:</p>
+  <ol>
+    <li>Current teams and players are saved as a <strong>history snapshot</strong></li>
+    <li>All players are removed from the event</li>
+    <li>All team assignments are cleared</li>
+    <li>The event date advances to the next occurrence</li>
+  </ol>
+
+  <div class="callout callout-info">
+    <strong>Lazy reset:</strong> The reset is triggered by the first person who opens the event page
+    after the reset time. It uses an optimistic lock to prevent duplicate resets from concurrent requests.
+  </div>
+
+  <h2>History</h2>
+  <p>
+    Each reset creates a history entry with the team snapshot. Click <strong>History</strong>
+    on the event page to view past games, record scores, and mark games as played or cancelled.
+    See <a href="/docs/features/history">History &amp; Scores</a>.
+  </p>
+</DocsLayout>

--- a/src/pages/docs/features/teams.astro
+++ b/src/pages/docs/features/teams.astro
@@ -1,0 +1,42 @@
+---
+import DocsLayout from '../../../layouts/DocsLayout.astro';
+---
+
+<DocsLayout title="Teams" description="Randomizing teams, drag-and-drop editing, renaming.">
+  <h1>Teams</h1>
+  <p class="subtitle">Randomize fair teams and adjust as needed.</p>
+
+  <h2>Randomizing</h2>
+  <p>
+    Click <strong>Randomize teams</strong> when you have at least 2 active players.
+    The algorithm randomly assigns players to two teams, balancing the count.
+  </p>
+  <p>
+    Only <strong>active players</strong> (not bench) are included in the randomization.
+  </p>
+
+  <h2>Re-randomizing</h2>
+  <p>
+    If teams have already been set, clicking the button again shows a confirmation dialog.
+    Re-randomizing replaces the current team assignment entirely.
+  </p>
+
+  <h2>Drag and drop</h2>
+  <p>
+    After randomizing, you can drag players between teams to make manual adjustments.
+    Changes are saved automatically to the server.
+  </p>
+
+  <h2>Renaming teams</h2>
+  <p>
+    Click the <strong>edit icon</strong> next to a team name to rename it.
+    Press Enter to save or Escape to cancel. Names are limited to 50 characters
+    and default to "Ninjas" and "Gunas" if left empty.
+  </p>
+
+  <h2>Out-of-sync warning</h2>
+  <p>
+    If players are added or removed after teams were randomized, a warning banner appears
+    suggesting you re-randomize to include the new players.
+  </p>
+</DocsLayout>

--- a/src/pages/docs/guides/contributing.astro
+++ b/src/pages/docs/guides/contributing.astro
@@ -1,0 +1,88 @@
+---
+import DocsLayout from '../../../layouts/DocsLayout.astro';
+---
+
+<DocsLayout title="Contributing" description="Set up the development environment and contribute to Convocados.">
+  <h1>Contributing</h1>
+  <p class="subtitle">Development setup, project structure, and contribution guidelines.</p>
+
+  <h2>Getting started</h2>
+  <pre><code>{`git clone https://github.com/Cabeda/Convocados.git
+cd Convocados
+npm ci
+npx prisma generate
+npx prisma db push        # create local SQLite DB
+npm run dev                # start dev server on http://localhost:4321`}</code></pre>
+
+  <h2>Project structure</h2>
+  <pre><code>{`Convocados/
+├── prisma/
+│   └── schema.prisma       # Database schema
+├── public/                 # Static assets
+├── src/
+│   ├── components/         # React components (MUI)
+│   ├── layouts/            # Astro layouts (DocsLayout, etc.)
+│   ├── lib/                # Server utilities (db, webhook, push, i18n)
+│   ├── pages/
+│   │   ├── api/            # API routes (Astro endpoints)
+│   │   ├── docs/           # Documentation pages
+│   │   ├── events/         # Event UI pages
+│   │   └── index.astro     # Home page
+│   └── test/               # Vitest test files
+├── Dockerfile
+├── fly.toml
+└── package.json`}</code></pre>
+
+  <h2>Tech stack</h2>
+  <table>
+    <thead><tr><th>Layer</th><th>Technology</th></tr></thead>
+    <tbody>
+      <tr><td>Framework</td><td>Astro 5 (SSR with Node adapter)</td></tr>
+      <tr><td>UI</td><td>React 19 + MUI 6</td></tr>
+      <tr><td>Database</td><td>SQLite via Prisma 6</td></tr>
+      <tr><td>Testing</td><td>Vitest + Supertest</td></tr>
+      <tr><td>Deployment</td><td>Docker on Fly.io</td></tr>
+    </tbody>
+  </table>
+
+  <h2>Scripts</h2>
+  <table>
+    <thead><tr><th>Command</th><th>Description</th></tr></thead>
+    <tbody>
+      <tr><td><code>npm run dev</code></td><td>Start Astro dev server</td></tr>
+      <tr><td><code>npm run build</code></td><td>Production build</td></tr>
+      <tr><td><code>npm run test</code></td><td>Run tests with Vitest</td></tr>
+      <tr><td><code>npm run typecheck</code></td><td>TypeScript type checking</td></tr>
+      <tr><td><code>npm run db:generate</code></td><td>Regenerate Prisma client</td></tr>
+      <tr><td><code>npm run db:migrate</code></td><td>Create and apply migrations</td></tr>
+      <tr><td><code>npm run db:studio</code></td><td>Open Prisma Studio GUI</td></tr>
+    </tbody>
+  </table>
+
+  <h2>Running tests</h2>
+  <pre><code>{`npm run test`}</code></pre>
+  <p>
+    Tests use Vitest with Supertest for API endpoint testing. The test suite uses an in-memory SQLite database,
+    so no external setup is needed.
+  </p>
+
+  <h2>Code style</h2>
+  <ul>
+    <li>TypeScript strict mode</li>
+    <li>Astro pages use <code>.astro</code> files; interactive components use React <code>.tsx</code></li>
+    <li>API routes export named HTTP method handlers (<code>GET</code>, <code>POST</code>, <code>PATCH</code>, <code>DELETE</code>)</li>
+    <li>Server-only code lives in <code>*.server.ts</code> files</li>
+  </ul>
+
+  <h2>Making changes</h2>
+  <ol>
+    <li>Fork the repository and create a feature branch</li>
+    <li>Make your changes</li>
+    <li>Run <code>npm run typecheck</code> and <code>npm run test</code> to verify</li>
+    <li>Open a pull request against <code>main</code></li>
+  </ol>
+
+  <div class="callout callout-info">
+    <strong>Database changes:</strong> If you modify <code>prisma/schema.prisma</code>, run <code>npm run db:migrate</code> to create a migration file, then commit it with your PR.
+  </div>
+</DocsLayout>

--- a/src/pages/docs/guides/self-hosting.astro
+++ b/src/pages/docs/guides/self-hosting.astro
@@ -1,0 +1,95 @@
+---
+import DocsLayout from '../../../layouts/DocsLayout.astro';
+---
+
+<DocsLayout title="Self-Hosting" description="Deploy Convocados with Docker or Fly.io.">
+  <h1>Self-Hosting</h1>
+  <p class="subtitle">Run your own Convocados instance using Docker, Fly.io, or any Node.js host.</p>
+
+  <h2>Prerequisites</h2>
+  <ul>
+    <li>Node.js 22+ (or Docker)</li>
+    <li>A persistent volume or directory for the SQLite database</li>
+  </ul>
+
+  <h2>Option A — Docker</h2>
+  <p>The project includes a production-ready <code>Dockerfile</code>.</p>
+
+  <h3>Build the image</h3>
+  <pre><code>{`docker build -t convocados .`}</code></pre>
+
+  <h3>Run the container</h3>
+  <pre><code>{`docker run -d \\
+  --name convocados \\
+  -p 3000:3000 \\
+  -v convocados-data:/data \\
+  -e DATABASE_URL="file:/data/convocados.db" \\
+  -e NODE_ENV=production \\
+  convocados`}</code></pre>
+
+  <p>The app will be available at <code>http://localhost:3000</code>. The <code>-v</code> flag mounts a named volume so your database persists across restarts.</p>
+
+  <h2>Option B — Fly.io</h2>
+  <p>Convocados is deployed on Fly.io by default. To deploy your own instance:</p>
+
+  <h3>1. Install the Fly CLI</h3>
+  <pre><code>{`curl -L https://fly.io/install.sh | sh
+fly auth login`}</code></pre>
+
+  <h3>2. Launch the app</h3>
+  <pre><code>{`fly launch`}</code></pre>
+  <p>This reads the existing <code>fly.toml</code> and creates your app. Accept the defaults or customize the region.</p>
+
+  <h3>3. Create a persistent volume</h3>
+  <pre><code>{`fly volumes create football_data --region cdg --size 1`}</code></pre>
+
+  <h3>4. Set secrets</h3>
+  <pre><code>{`fly secrets set DATABASE_URL="file:/data/convocados.db"
+fly secrets set VAPID_PUBLIC_KEY="your-vapid-public-key"
+fly secrets set VAPID_PRIVATE_KEY="your-vapid-private-key"
+fly secrets set VAPID_SUBJECT="mailto:you@example.com"`}</code></pre>
+
+  <h3>5. Deploy</h3>
+  <pre><code>{`fly deploy`}</code></pre>
+
+  <h2>Option C — Bare Node.js</h2>
+  <pre><code>{`git clone https://github.com/Cabeda/Convocados.git
+cd Convocados
+npm ci
+npx prisma generate
+npm run build
+DATABASE_URL="file:./convocados.db" npm run start`}</code></pre>
+
+  <p>The <code>start</code> script runs <code>prisma migrate deploy</code> automatically before starting the server.</p>
+
+  <h2>Environment variables</h2>
+  <table>
+    <thead><tr><th>Variable</th><th>Required</th><th>Description</th></tr></thead>
+    <tbody>
+      <tr><td><code>DATABASE_URL</code></td><td>Yes</td><td>SQLite connection string, e.g. <code>file:/data/convocados.db</code></td></tr>
+      <tr><td><code>PORT</code></td><td>No</td><td>Server port (default <code>3000</code>)</td></tr>
+      <tr><td><code>NODE_ENV</code></td><td>No</td><td>Set to <code>production</code> for production builds</td></tr>
+      <tr><td><code>VAPID_PUBLIC_KEY</code></td><td>No*</td><td>VAPID public key for push notifications</td></tr>
+      <tr><td><code>VAPID_PRIVATE_KEY</code></td><td>No*</td><td>VAPID private key for push notifications</td></tr>
+      <tr><td><code>VAPID_SUBJECT</code></td><td>No*</td><td>VAPID subject (mailto: or URL)</td></tr>
+    </tbody>
+  </table>
+  <p><em>* Required only if you want push notifications.</em></p>
+
+  <div class="callout callout-info">
+    <strong>Generating VAPID keys:</strong> Run <code>npx web-push generate-vapid-keys</code> to create a new key pair.
+  </div>
+
+  <h2>Database</h2>
+  <p>
+    Convocados uses SQLite via Prisma. The database file is created automatically on first run.
+    Migrations are applied by <code>prisma migrate deploy</code> which runs as part of the <code>start</code> script.
+  </p>
+
+  <div class="callout callout-warn">
+    <strong>Important:</strong> Always mount a persistent volume for the database directory. Without it, your data will be lost on container restarts.
+  </div>
+
+  <h2>Health check</h2>
+  <p>The app exposes <code>GET /api/health</code> which returns <code>200 OK</code> when the server is running. Use this for load balancer or orchestrator health checks.</p>
+</DocsLayout>

--- a/src/pages/docs/guides/webhook-openclaw.astro
+++ b/src/pages/docs/guides/webhook-openclaw.astro
@@ -1,0 +1,93 @@
+---
+import DocsLayout from '../../../layouts/DocsLayout.astro';
+---
+
+<DocsLayout title="Webhook + OpenClaw Integration" description="Use webhooks to connect Convocados with OpenClaw or any external service.">
+  <h1>Webhook + OpenClaw Integration</h1>
+  <p class="subtitle">Push real-time event updates to OpenClaw or any HTTP endpoint using Convocados webhooks.</p>
+
+  <h2>Overview</h2>
+  <p>
+    Convocados fires webhooks whenever key actions happen on an event — players joining, teams being randomized, or scores being recorded.
+    You can subscribe any URL to receive these payloads, making it easy to integrate with tools like
+    <a href="https://openclaw.com" target="_blank" rel="noopener">OpenClaw</a> or your own services.
+  </p>
+
+  <h2>Step 1 — Create a webhook subscription</h2>
+  <p>Register a webhook URL for your event:</p>
+  <pre><code>{`curl -X POST https://convocados.fly.dev/api/events/EVENT_ID/webhooks \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "url": "https://your-openclaw-instance.com/hooks/convocados",
+    "events": ["player.added", "player.removed", "teams.randomized"]
+  }'`}</code></pre>
+
+  <p>The response includes the subscription ID and a <code>secret</code> you can use to verify payloads.</p>
+
+  <h2>Step 2 — Receive payloads</h2>
+  <p>When a subscribed action occurs, Convocados sends a POST request to your URL with a JSON body:</p>
+  <pre><code>{`{
+  "event": "player.added",
+  "eventId": "clx1abc...",
+  "timestamp": "2026-03-15T18:30:00.000Z",
+  "data": {
+    "player": { "id": "...", "name": "Alice", "isBench": false }
+  }
+}`}</code></pre>
+
+  <h3>Available event types</h3>
+  <table>
+    <thead><tr><th>Event</th><th>Fired when</th></tr></thead>
+    <tbody>
+      <tr><td><code>player.added</code></td><td>A player joins the event</td></tr>
+      <tr><td><code>player.removed</code></td><td>A player is removed</td></tr>
+      <tr><td><code>teams.randomized</code></td><td>Teams are randomized</td></tr>
+      <tr><td><code>event.updated</code></td><td>Event details change</td></tr>
+      <tr><td><code>history.created</code></td><td>A game result is recorded</td></tr>
+    </tbody>
+  </table>
+
+  <h2>Step 3 — Verify the signature</h2>
+  <p>
+    Each delivery includes an <code>X-Webhook-Signature</code> header containing an HMAC-SHA256 hex digest of the request body,
+    signed with the <code>secret</code> returned when you created the subscription.
+  </p>
+  <pre><code>{`import crypto from 'crypto';
+
+function verifySignature(body: string, signature: string, secret: string) {
+  const expected = crypto
+    .createHmac('sha256', secret)
+    .update(body)
+    .digest('hex');
+  return crypto.timingSafeEqual(
+    Buffer.from(signature),
+    Buffer.from(expected)
+  );
+}`}</code></pre>
+
+  <h2>Step 4 — OpenClaw configuration</h2>
+  <p>In your OpenClaw dashboard:</p>
+  <ol>
+    <li>Go to <strong>Integrations &rarr; Incoming Webhooks</strong></li>
+    <li>Create a new webhook receiver and copy the endpoint URL</li>
+    <li>Use that URL when creating the Convocados webhook subscription (Step 1)</li>
+    <li>Map the incoming fields to your OpenClaw data model</li>
+  </ol>
+
+  <div class="callout callout-info">
+    <strong>Tip:</strong> You can subscribe multiple URLs to the same event. Each will receive its own independent delivery with retry logic.
+  </div>
+
+  <h2>Monitoring deliveries</h2>
+  <p>
+    Check delivery status in the Convocados UI under the <strong>Integrations</strong> accordion on the event page,
+    or query the API directly. Failed deliveries are retried automatically with exponential backoff.
+  </p>
+
+  <h2>Troubleshooting</h2>
+  <ul>
+    <li><strong>Not receiving payloads?</strong> Ensure your endpoint is publicly reachable and returns a 2xx status code.</li>
+    <li><strong>Signature mismatch?</strong> Make sure you're comparing against the raw request body (not a parsed/re-serialized version).</li>
+    <li><strong>Duplicate deliveries?</strong> Implement idempotency using the delivery ID in the payload headers.</li>
+  </ul>
+</DocsLayout>

--- a/src/pages/docs/index.astro
+++ b/src/pages/docs/index.astro
@@ -1,0 +1,45 @@
+---
+import DocsLayout from '../../layouts/DocsLayout.astro';
+---
+
+<DocsLayout title="Overview" description="Convocados — organise football games, manage players, randomize teams.">
+  <h1>Convocados</h1>
+  <p class="subtitle">Organise your football game, manage players, and randomize fair teams — all from a single shareable link.</p>
+
+  <h2>What is Convocados?</h2>
+  <p>
+    Convocados is a web app for organising pickup football (soccer) games. Create an event, share the link with your group,
+    and let players add themselves. When everyone's in, randomize teams with one click.
+  </p>
+
+  <h2>Key Features</h2>
+  <ul>
+    <li><strong>Create events</strong> — set a title, date, location, and max players</li>
+    <li><strong>Share a link</strong> — no accounts needed, anyone with the link can join</li>
+    <li><strong>Player management</strong> — add/remove players, automatic bench when full</li>
+    <li><strong>Team randomizer</strong> — fair random team assignment with drag-and-drop editing</li>
+    <li><strong>Recurring games</strong> — auto-reset player lists on a weekly/monthly schedule</li>
+    <li><strong>Push notifications</strong> — get notified when players join or leave</li>
+    <li><strong>Game history</strong> — track past games with scores for recurring events</li>
+    <li><strong>Webhooks</strong> — integrate with external systems via HTTP callbacks</li>
+    <li><strong>Bilingual</strong> — English and Portuguese UI</li>
+  </ul>
+
+  <h2>Tech Stack</h2>
+  <ul>
+    <li><strong>Frontend</strong> — Astro + React + Material UI</li>
+    <li><strong>Backend</strong> — Astro SSR with Node.js adapter</li>
+    <li><strong>Database</strong> — SQLite via Prisma ORM</li>
+    <li><strong>Hosting</strong> — Fly.io (Docker)</li>
+    <li><strong>Tests</strong> — Vitest with 95% coverage thresholds</li>
+  </ul>
+
+  <h2>Quick Links</h2>
+  <ul>
+    <li><a href="/docs/quickstart">Quickstart</a> — get running in 5 minutes</li>
+    <li><a href="/docs/tutorial">Tutorial</a> — create your first game end-to-end</li>
+    <li><a href="/docs/api">API Reference</a> — integrate programmatically</li>
+    <li><a href="/docs/guides/webhook-openclaw">Webhook Guide</a> — connect to OpenClaw or other systems</li>
+    <li><a href="/docs/guides/self-hosting">Self-Hosting</a> — deploy your own instance</li>
+  </ul>
+</DocsLayout>

--- a/src/pages/docs/quickstart.astro
+++ b/src/pages/docs/quickstart.astro
@@ -1,0 +1,72 @@
+---
+import DocsLayout from '../../layouts/DocsLayout.astro';
+---
+
+<DocsLayout title="Quickstart" description="Get Convocados running locally in 5 minutes.">
+  <h1>Quickstart</h1>
+  <p class="subtitle">Get Convocados running on your machine in 5 minutes.</p>
+
+  <h2>Prerequisites</h2>
+  <ul>
+    <li><a href="https://nodejs.org/">Node.js</a> 20 or later</li>
+    <li>npm (comes with Node.js)</li>
+  </ul>
+
+  <h2>1. Clone the repository</h2>
+  <pre><code>git clone https://github.com/Cabeda/Convocados.git
+cd Convocados</code></pre>
+
+  <h2>2. Install dependencies</h2>
+  <pre><code>npm install</code></pre>
+
+  <h2>3. Set up the database</h2>
+  <p>Convocados uses SQLite, so no external database is needed. Create the database and run migrations:</p>
+  <pre><code>npx prisma migrate dev</code></pre>
+
+  <h2>4. Configure environment variables</h2>
+  <p>Create a <code>.env</code> file in the project root:</p>
+  <pre><code># Required
+DATABASE_URL="file:./prisma/dev.db"
+
+# Optional — needed for push notifications
+VAPID_PUBLIC_KEY="your-vapid-public-key"
+VAPID_PRIVATE_KEY="your-vapid-private-key"</code></pre>
+
+  <div class="callout callout-info">
+    <strong>Tip:</strong> You can generate VAPID keys with <code>npx web-push generate-vapid-keys</code>.
+    Push notifications are optional — the app works fine without them.
+  </div>
+
+  <h2>5. Start the dev server</h2>
+  <pre><code>npm run dev</code></pre>
+  <p>Open <a href="http://localhost:4321">http://localhost:4321</a> in your browser. You should see the "Create a Game" form.</p>
+
+  <h2>6. Create your first game</h2>
+  <ol>
+    <li>Enter a game title (e.g. "Tuesday 5-a-side")</li>
+    <li>Pick a date and time</li>
+    <li>Click <strong>Create game</strong></li>
+    <li>Share the generated link with your players</li>
+  </ol>
+
+  <h2>Available scripts</h2>
+  <table>
+    <thead>
+      <tr><th>Command</th><th>Description</th></tr>
+    </thead>
+    <tbody>
+      <tr><td><code>npm run dev</code></td><td>Start development server</td></tr>
+      <tr><td><code>npm run build</code></td><td>Build for production</td></tr>
+      <tr><td><code>npm run preview</code></td><td>Preview production build</td></tr>
+      <tr><td><code>npm test</code></td><td>Run tests</td></tr>
+      <tr><td><code>npm run db:studio</code></td><td>Open Prisma Studio (DB browser)</td></tr>
+    </tbody>
+  </table>
+
+  <h2>Next steps</h2>
+  <ul>
+    <li><a href="/docs/tutorial">Tutorial</a> — walk through the full game flow</li>
+    <li><a href="/docs/guides/self-hosting">Self-Hosting</a> — deploy to production</li>
+    <li><a href="/docs/api">API Reference</a> — integrate programmatically</li>
+  </ul>
+</DocsLayout>

--- a/src/pages/docs/tutorial.astro
+++ b/src/pages/docs/tutorial.astro
@@ -1,0 +1,75 @@
+---
+import DocsLayout from '../../layouts/DocsLayout.astro';
+---
+
+<DocsLayout title="Tutorial" description="End-to-end walkthrough: create a game, add players, randomize teams.">
+  <h1>Tutorial</h1>
+  <p class="subtitle">Walk through the complete flow — from creating a game to viewing history.</p>
+
+  <h2>Step 1: Create an event</h2>
+  <p>Go to the home page and fill in the form:</p>
+  <ul>
+    <li><strong>Game title</strong> — e.g. "Friday Footy"</li>
+    <li><strong>Date &amp; time</strong> — when the game starts</li>
+  </ul>
+  <p>Optionally expand <strong>Advanced options</strong> to set:</p>
+  <ul>
+    <li><strong>Location</strong> — a text address or Google Maps link (becomes clickable)</li>
+    <li><strong>Max players</strong> — players beyond this go to the bench (default: 10)</li>
+    <li><strong>Team names</strong> — defaults to "Ninjas" vs "Gunas"</li>
+    <li><strong>Recurrence</strong> — auto-reset the player list weekly or monthly</li>
+  </ul>
+  <p>Click <strong>Create game</strong>. You'll be redirected to the event page with a unique URL.</p>
+
+  <h2>Step 2: Share the link</h2>
+  <p>
+    The event page shows a <strong>Share</strong> button. On mobile, it uses the native share sheet.
+    On desktop, it copies the URL to your clipboard. Send this link to your group chat.
+  </p>
+  <p>No accounts are needed — anyone with the link can join.</p>
+
+  <h2>Step 3: Players join</h2>
+  <p>Players can join in two ways:</p>
+  <ul>
+    <li><strong>Quick Join</strong> — tap a name from the recent players list, or type a new name</li>
+    <li><strong>Add Player</strong> — type a name in the player list section and press Enter</li>
+  </ul>
+  <p>
+    Players are added in order. Once the max is reached, additional players go to the <strong>bench</strong>.
+    If an active player leaves, the first bench player is automatically promoted.
+  </p>
+
+  <h2>Step 4: Randomize teams</h2>
+  <p>
+    When you have at least 2 active players, click <strong>Randomize teams</strong>.
+    The app splits players into two balanced teams randomly.
+  </p>
+  <p>After randomizing, you can:</p>
+  <ul>
+    <li><strong>Drag and drop</strong> players between teams to adjust</li>
+    <li><strong>Rename teams</strong> by clicking the edit icon next to each team name</li>
+    <li><strong>Re-randomize</strong> — click the button again (you'll be asked to confirm)</li>
+  </ul>
+
+  <h2>Step 5: Get notified</h2>
+  <p>
+    Click <strong>Get notified</strong> to receive push notifications when players join or leave.
+    This uses browser push notifications — no app install needed.
+  </p>
+
+  <h2>Step 6: Recurring games</h2>
+  <p>
+    If you enabled recurrence, the player list automatically resets 1 hour after the game time.
+    The event URL stays the same — just share it once and reuse it every week.
+  </p>
+  <p>
+    Past games are saved in <strong>History</strong>, where you can record scores and mark games as played or cancelled.
+  </p>
+
+  <h2>Step 7: Integrate (optional)</h2>
+  <p>
+    Expand the <strong>Integrations</strong> section at the bottom of the event header to find the webhook API URL.
+    Use this to connect external systems. See the <a href="/docs/api/webhooks">Webhooks API</a> and
+    <a href="/docs/guides/webhook-openclaw">OpenClaw guide</a> for details.
+  </p>
+</DocsLayout>


### PR DESCRIPTION
Closes #34

## Summary

Full documentation site served from the app at `/docs`, with 19 pages covering getting started, features, API reference, and guides.

## What's included

**Infrastructure:**
- `DocsLayout.astro` — shared layout with collapsible sidebar, mobile hamburger drawer, prev/next page navigation, dark/light mode via `prefers-color-scheme`
- Navbar "Docs" button (MenuBookIcon) in `ResponsiveLayout.tsx`
- i18n strings for `docs` key (en/pt)

**Pages (19 total):**
- Getting Started: Overview, Quickstart, Tutorial
- Features: Events, Players & Bench, Teams, Recurring Games, Notifications, History & Scores
- API Reference: Overview, Events, Players, Teams, Webhooks, Push Notifications, History
- Guides: Webhook + OpenClaw Integration, Self-Hosting (Docker/Fly.io), Contributing

**Other:**
- Updated `README.md` to reflect current stack (Astro/Vitest, not yarn/Jest)
- Added `.astro/` to `.gitignore`

## Verification

- `npx tsc --noEmit` — 0 errors
- `npx vitest run` — 148 tests passing