### PR TITLE
fix: OSM map tiles blocked due to missing Referer header

### DIFF
--- a/src/components/PublicGamesPage.tsx
+++ b/src/components/PublicGamesPage.tsx
@@ -255,7 +255,7 @@ function MapView({ events, t, locale }: {
           height="100%"
           style={{ border: 0 }}
           sandbox="allow-scripts allow-top-navigation"
-          src={buildMapUrl(center, geoEvents, t, locale)}
+          srcDoc={buildMapHtml(center, geoEvents, t, locale)}
         />
       </Paper>
       {geoEvents.length === 0 && (
@@ -267,7 +267,7 @@ function MapView({ events, t, locale }: {
   );
 }
 
-function buildMapUrl(
+function buildMapHtml(
   center: [number, number],
   events: GeoEvent[],
   t: any,
@@ -309,7 +309,7 @@ ${events.length > 1 ? `map.fitBounds([${events.map((e) => `[${e.lat},${e.lng}]`)
 <\/script>
 </body></html>`;
 
-  return `data:text/html;charset=utf-8,${encodeURIComponent(html)}`;
+  return html;
 }
 
 // ── Main component ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

OpenStreetMap tile servers now require a valid `Referer` header. The public games map was loaded via a `data:` URI iframe, which sends no `Referer` — causing tiles to be blocked with the message:

> access blocked: Referer is required by tile usage policy of OpenStreetMap's volunteer-run servers

## Fix

Switch from `src={dataUri}` to `srcDoc={html}` on the iframe. This way the embedded HTML inherits the parent page's origin, and the browser sends a proper `Referer` header to OSM tile servers.

3-line change in `src/components/PublicGamesPage.tsx`:
- `buildMapUrl` → `buildMapHtml` (returns raw HTML instead of data URI)
- `src=` → `srcDoc=` on the iframe