### PR TITLE
feat: add Google OAuth sign-in

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -6,3 +6,7 @@
 # Email verification (Resend)
 # RESEND_API_KEY=re_xxxxx          # Get from https://resend.com/api-keys
 # EMAIL_FROM=Convocados <noreply@yourdomain.com>
+
+# Google OAuth (better-auth social provider)
+# GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com
+# GOOGLE_CLIENT_SECRET=your-client-secret

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 *.db-shm
 
 # env
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/src/components/SignInPage.tsx
+++ b/src/components/SignInPage.tsx
@@ -1,7 +1,8 @@
 import React, { useState } from "react";
 import {
-  Container, Paper, Typography, TextField, Button, Stack, Alert, Link,
+  Container, Paper, Typography, TextField, Button, Stack, Alert, Link, Divider,
 } from "@mui/material";
+import GoogleIcon from "@mui/icons-material/Google";
 import { ThemeModeProvider } from "./ThemeModeProvider";
 import { ResponsiveLayout } from "./ResponsiveLayout";
 import { useT } from "~/lib/useT";
@@ -40,6 +41,10 @@ export default function SignInPage() {
     }
   };
 
+  const handleGoogleSignIn = async () => {
+    await signIn.social({ provider: "google", callbackURL: "/" });
+  };
+
   return (
     <ThemeModeProvider>
       <ResponsiveLayout>
@@ -58,6 +63,19 @@ export default function SignInPage() {
                   </Link>
                 </Alert>
               )}
+
+              <Button
+                variant="outlined"
+                size="large"
+                fullWidth
+                startIcon={<GoogleIcon />}
+                onClick={handleGoogleSignIn}
+                type="button"
+              >
+                {t("signInWithGoogle")}
+              </Button>
+
+              <Divider>{t("or")}</Divider>
 
               <TextField
                 label={t("email")}

--- a/src/components/SignUpPage.tsx
+++ b/src/components/SignUpPage.tsx
@@ -1,11 +1,12 @@
 import React, { useState } from "react";
 import {
-  Container, Paper, Typography, TextField, Button, Stack, Alert, Link,
+  Container, Paper, Typography, TextField, Button, Stack, Alert, Link, Divider,
 } from "@mui/material";
+import GoogleIcon from "@mui/icons-material/Google";
 import { ThemeModeProvider } from "./ThemeModeProvider";
 import { ResponsiveLayout } from "./ResponsiveLayout";
 import { useT } from "~/lib/useT";
-import { signUp } from "~/lib/auth.client";
+import { signIn, signUp } from "~/lib/auth.client";
 
 export default function SignUpPage() {
   const t = useT();
@@ -46,6 +47,10 @@ export default function SignUpPage() {
     }
   };
 
+  const handleGoogleSignUp = async () => {
+    await signIn.social({ provider: "google", callbackURL: "/" });
+  };
+
   return (
     <ThemeModeProvider>
       <ResponsiveLayout>
@@ -57,6 +62,19 @@ export default function SignUpPage() {
               </Typography>
 
               {error && <Alert severity="error">{error}</Alert>}
+
+              <Button
+                variant="outlined"
+                size="large"
+                fullWidth
+                startIcon={<GoogleIcon />}
+                onClick={handleGoogleSignUp}
+                type="button"
+              >
+                {t("signUpWithGoogle")}
+              </Button>
+
+              <Divider>{t("or")}</Divider>
 
               <TextField
                 label={t("name")}

--- a/src/lib/auth.server.ts
+++ b/src/lib/auth.server.ts
@@ -9,6 +9,12 @@ export const auth = betterAuth({
     enabled: true,
     requireEmailVerification: true,
   },
+  socialProviders: {
+    google: {
+      clientId: process.env.GOOGLE_CLIENT_ID!,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+    },
+  },
   emailVerification: {
     sendOnSignUp: true,
     autoSignInAfterVerification: true,

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -265,6 +265,11 @@ export const translations = {
     // Docs
     docs: "Docs",
 
+    // Social auth
+    signInWithGoogle: "Sign in with Google",
+    signUpWithGoogle: "Sign up with Google",
+    or: "or",
+
     // Email verification
     checkYourEmail: "Check your email",
     checkYourEmailDesc: "We sent a verification link to {email}. Click it to activate your account.",
@@ -542,6 +547,11 @@ export const translations = {
 
     // Docs
     docs: "Docs",
+
+    // Social auth
+    signInWithGoogle: "Entrar com Google",
+    signUpWithGoogle: "Registar com Google",
+    or: "ou",
 
     // Email verification
     checkYourEmail: "Verifica o teu email",


### PR DESCRIPTION
## Summary

Adds Google OAuth as a sign-in/sign-up option using better-auth's social provider.

### Changes

- **`src/lib/auth.server.ts`** — Added `socialProviders.google` with `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` env vars
- **`src/components/SignInPage.tsx`** — "Sign in with Google" button above the email form with a divider
- **`src/components/SignUpPage.tsx`** — "Sign up with Google" button above the email form with a divider
- **`src/lib/i18n.ts`** — Added `signInWithGoogle`, `signUpWithGoogle`, and `or` keys in EN and PT
- **`.env.development`** — Placeholder vars for Google OAuth
- **`.gitignore`** — Added `.env` to prevent credential leaks

### Testing locally

1. Set up Google OAuth credentials in `.env`:
   ```
   GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com
   GOOGLE_CLIENT_SECRET=your-client-secret
   ```
2. Ensure the Google Cloud Console has `http://localhost:4321/api/auth/callback/google` as an authorized redirect URI
3. Run `npm run dev` and visit `/auth/signin`

The callback URL `/api/auth/callback/google` is handled automatically by better-auth. The Prisma `Account` model already has the required fields (`providerId`, `accountId`, `accessToken`, etc.).