### PR TITLE
feat: iCal/CalDAV feed per user and event

### DIFF
--- a/prisma/migrations/20260317224428_add_calendar_token/migration.sql
+++ b/prisma/migrations/20260317224428_add_calendar_token/migration.sql
@@ -1,0 +1,19 @@
+-- CreateTable
+CREATE TABLE "CalendarToken" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "token" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "scope" TEXT NOT NULL DEFAULT 'user',
+    "scopeId" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "CalendarToken_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "CalendarToken_token_key" ON "CalendarToken"("token");
+
+-- CreateIndex
+CREATE INDEX "CalendarToken_userId_idx" ON "CalendarToken"("userId");
+
+-- CreateIndex
+CREATE INDEX "CalendarToken_token_idx" ON "CalendarToken"("token");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,17 +10,18 @@ datasource db {
 // ── better-auth tables ────────────────────────────────────────────────────────
 
 model User {
-  id            String    @id
-  name          String
-  email         String    @unique
-  emailVerified Boolean   @default(false)
-  image         String?
-  createdAt     DateTime  @default(now())
-  updatedAt     DateTime  @updatedAt
-  sessions      Session[]
-  accounts      Account[]
-  ownedEvents   Event[]   @relation("EventOwner")
-  players       Player[]  @relation("PlayerUser")
+  id             String          @id
+  name           String
+  email          String          @unique
+  emailVerified  Boolean         @default(false)
+  image          String?
+  createdAt      DateTime        @default(now())
+  updatedAt      DateTime        @updatedAt
+  sessions       Session[]
+  accounts       Account[]
+  ownedEvents    Event[]         @relation("EventOwner")
+  players        Player[]        @relation("PlayerUser")
+  calendarTokens CalendarToken[]
 }
 
 model Session {
@@ -196,4 +197,17 @@ model WebhookDelivery {
   deliveredAt DateTime?
   error       String?
   createdAt   DateTime            @default(now())
+}
+
+model CalendarToken {
+  id        String   @id @default(cuid())
+  token     String   @unique
+  userId    String
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  scope     String   @default("user") // "user" | "event"
+  scopeId   String?  // eventId when scope is "event"
+  createdAt DateTime @default(now())
+
+  @@index([userId])
+  @@index([token])
 }

--- a/src/lib/calendar.ts
+++ b/src/lib/calendar.ts
@@ -74,6 +74,60 @@ export function generateIcs(event: CalendarEvent): string {
 }
 
 /**
+ * Generate a multi-event .ics feed (VCALENDAR with multiple VEVENTs).
+ * Suitable for calendar subscription feeds.
+ */
+export function generateIcsFeed(
+  events: CalendarEvent[],
+  feedName: string,
+): string {
+  const now = formatIcsDate(new Date());
+
+  const lines = [
+    "BEGIN:VCALENDAR",
+    "VERSION:2.0",
+    "PRODID:-//Convocados//EN",
+    "CALSCALE:GREGORIAN",
+    "METHOD:PUBLISH",
+    `X-WR-CALNAME:${escapeIcs(feedName)}`,
+    `X-WR-TIMEZONE:UTC`,
+  ];
+
+  for (const event of events) {
+    const start = formatIcsDate(event.dateTime);
+    const end = formatIcsDate(new Date(event.dateTime.getTime() + 90 * 60 * 1000));
+
+    lines.push(
+      "BEGIN:VEVENT",
+      `UID:${event.id}@convocados`,
+      `DTSTAMP:${now}`,
+      `DTSTART:${start}`,
+      `DTEND:${end}`,
+      `SUMMARY:${escapeIcs(event.title)}`,
+    );
+
+    if (event.location) {
+      lines.push(`LOCATION:${escapeIcs(event.location)}`);
+    }
+    if (event.description) {
+      lines.push(`DESCRIPTION:${escapeIcs(event.description)}`);
+    }
+    if (event.url) {
+      lines.push(`URL:${event.url}`);
+    }
+    if (event.recurrence) {
+      lines.push(`RRULE:${buildRrule(event.recurrence)}`);
+    }
+
+    lines.push("END:VEVENT");
+  }
+
+  lines.push("END:VCALENDAR");
+
+  return lines.join("\r\n") + "\r\n";
+}
+
+/**
  * Build a Google Calendar "Add Event" URL.
  */
 export function googleCalendarUrl(event: CalendarEvent): string {

--- a/src/lib/calendarToken.server.ts
+++ b/src/lib/calendarToken.server.ts
@@ -1,0 +1,61 @@
+import { randomBytes } from "node:crypto";
+import { prisma } from "./db.server";
+
+/**
+ * Generate a cryptographically random token for private calendar feeds.
+ */
+function generateToken(): string {
+  return randomBytes(32).toString("hex");
+}
+
+/**
+ * Get or create a calendar feed token for a user-scoped feed.
+ */
+export async function getOrCreateUserFeedToken(userId: string): Promise<string> {
+  const existing = await prisma.calendarToken.findFirst({
+    where: { userId, scope: "user", scopeId: null },
+  });
+  if (existing) return existing.token;
+
+  const token = generateToken();
+  await prisma.calendarToken.create({
+    data: { token, userId, scope: "user" },
+  });
+  return token;
+}
+
+/**
+ * Get or create a calendar feed token for an event-scoped feed.
+ */
+export async function getOrCreateEventFeedToken(
+  userId: string,
+  eventId: string,
+): Promise<string> {
+  const existing = await prisma.calendarToken.findFirst({
+    where: { userId, scope: "event", scopeId: eventId },
+  });
+  if (existing) return existing.token;
+
+  const token = generateToken();
+  await prisma.calendarToken.create({
+    data: { token, userId, scope: "event", scopeId: eventId },
+  });
+  return token;
+}
+
+/**
+ * Validate a token and return the associated metadata.
+ * Returns null if the token is invalid.
+ */
+export async function validateFeedToken(token: string) {
+  const record = await prisma.calendarToken.findUnique({ where: { token } });
+  if (!record) return null;
+  return { userId: record.userId, scope: record.scope, scopeId: record.scopeId };
+}
+
+/**
+ * Revoke all calendar tokens for a user (e.g. for regeneration).
+ */
+export async function revokeUserTokens(userId: string): Promise<void> {
+  await prisma.calendarToken.deleteMany({ where: { userId } });
+}

--- a/src/pages/api/events/[id]/calendar.ics.ts
+++ b/src/pages/api/events/[id]/calendar.ics.ts
@@ -1,0 +1,54 @@
+import type { APIRoute } from "astro";
+import { prisma } from "../../../../lib/db.server";
+import { validateFeedToken } from "../../../../lib/calendarToken.server";
+import { generateIcsFeed } from "../../../../lib/calendar";
+import { parseRecurrenceRule } from "../../../../lib/recurrence";
+
+/**
+ * GET /api/events/:id/calendar.ics?token=xxx
+ * Returns an iCal feed for all upcoming games in an event (group).
+ * Authenticated via private feed token (query param).
+ */
+export const GET: APIRoute = async ({ params, request }) => {
+  const eventId = params.id!;
+  const url = new URL(request.url);
+  const token = url.searchParams.get("token");
+
+  if (!token) {
+    return new Response("Missing token", { status: 401 });
+  }
+
+  const tokenData = await validateFeedToken(token);
+  if (!tokenData || tokenData.scope !== "event" || tokenData.scopeId !== eventId) {
+    return new Response("Invalid or expired token", { status: 403 });
+  }
+
+  const event = await prisma.event.findUnique({ where: { id: eventId } });
+  if (!event) {
+    return new Response("Event not found", { status: 404 });
+  }
+
+  const host = request.headers.get("x-forwarded-host") ?? request.headers.get("host") ?? "convocados.fly.dev";
+  const proto = request.headers.get("x-forwarded-proto") ?? "https";
+
+  const calendarEvents = [
+    {
+      id: event.id,
+      title: event.title,
+      location: event.location,
+      dateTime: event.dateTime,
+      url: `${proto}://${host}/events/${event.id}`,
+      description: `Convocados game — ${event.title}`,
+      recurrence: event.isRecurring ? parseRecurrenceRule(event.recurrenceRule) : null,
+    },
+  ];
+
+  const ics = generateIcsFeed(calendarEvents, `Convocados — ${event.title}`);
+
+  return new Response(ics, {
+    headers: {
+      "Content-Type": "text/calendar; charset=utf-8",
+      "Cache-Control": "no-cache, no-store, must-revalidate",
+    },
+  });
+};

--- a/src/pages/api/me/calendar-token.ts
+++ b/src/pages/api/me/calendar-token.ts
@@ -1,0 +1,47 @@
+import type { APIRoute } from "astro";
+import { getSession } from "../../../lib/auth.helpers.server";
+import {
+  getOrCreateUserFeedToken,
+  revokeUserTokens,
+  getOrCreateEventFeedToken,
+} from "../../../lib/calendarToken.server";
+
+/** POST — generate (or retrieve) a calendar feed token for the authenticated user */
+export const POST: APIRoute = async ({ request }) => {
+  const session = await getSession(request);
+  if (!session?.user) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await request.json().catch(() => ({}));
+  const scope: string = body.scope ?? "user";
+  const eventId: string | undefined = body.eventId;
+
+  if (scope === "event") {
+    if (!eventId) {
+      return Response.json({ error: "eventId is required for event scope." }, { status: 400 });
+    }
+    const token = await getOrCreateEventFeedToken(session.user.id, eventId);
+    const host = request.headers.get("x-forwarded-host") ?? request.headers.get("host") ?? "localhost";
+    const proto = request.headers.get("x-forwarded-proto") ?? "https";
+    const feedUrl = `${proto}://${host}/api/events/${eventId}/calendar.ics?token=${token}`;
+    return Response.json({ token, feedUrl });
+  }
+
+  const token = await getOrCreateUserFeedToken(session.user.id);
+  const host = request.headers.get("x-forwarded-host") ?? request.headers.get("host") ?? "localhost";
+  const proto = request.headers.get("x-forwarded-proto") ?? "https";
+  const feedUrl = `${proto}://${host}/api/users/${session.user.id}/calendar.ics?token=${token}`;
+  return Response.json({ token, feedUrl });
+};
+
+/** DELETE — revoke all calendar tokens and regenerate */
+export const DELETE: APIRoute = async ({ request }) => {
+  const session = await getSession(request);
+  if (!session?.user) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  await revokeUserTokens(session.user.id);
+  return Response.json({ ok: true });
+};

--- a/src/pages/api/users/[id]/calendar.ics.ts
+++ b/src/pages/api/users/[id]/calendar.ics.ts
@@ -1,0 +1,78 @@
+import type { APIRoute } from "astro";
+import { prisma } from "../../../../lib/db.server";
+import { validateFeedToken } from "../../../../lib/calendarToken.server";
+import { generateIcsFeed } from "../../../../lib/calendar";
+import { parseRecurrenceRule } from "../../../../lib/recurrence";
+
+/**
+ * GET /api/users/:id/calendar.ics?token=xxx
+ * Returns an iCal feed of all upcoming games for a user.
+ * Authenticated via private feed token (query param).
+ */
+export const GET: APIRoute = async ({ params, request }) => {
+  const userId = params.id!;
+  const url = new URL(request.url);
+  const token = url.searchParams.get("token");
+
+  if (!token) {
+    return new Response("Missing token", { status: 401 });
+  }
+
+  const tokenData = await validateFeedToken(token);
+  if (!tokenData || tokenData.userId !== userId || tokenData.scope !== "user") {
+    return new Response("Invalid or expired token", { status: 403 });
+  }
+
+  const now = new Date();
+
+  // Fetch upcoming events the user owns
+  const ownedEvents = await prisma.event.findMany({
+    where: { ownerId: userId, dateTime: { gte: now } },
+    orderBy: { dateTime: "asc" },
+    take: 200,
+  });
+
+  // Fetch upcoming events the user has joined
+  const playerEntries = await prisma.player.findMany({
+    where: { userId, event: { dateTime: { gte: now } } },
+    select: { event: true },
+    take: 200,
+  });
+
+  // Deduplicate
+  const ownedIds = new Set(ownedEvents.map((e) => e.id));
+  const allEvents = [
+    ...ownedEvents,
+    ...playerEntries.map((p) => p.event).filter((e) => !ownedIds.has(e.id)),
+  ];
+
+  // Sort by date
+  allEvents.sort((a, b) => a.dateTime.getTime() - b.dateTime.getTime());
+
+  const host = request.headers.get("x-forwarded-host") ?? request.headers.get("host") ?? "convocados.fly.dev";
+  const proto = request.headers.get("x-forwarded-proto") ?? "https";
+
+  const calendarEvents = allEvents.map((e) => ({
+    id: e.id,
+    title: e.title,
+    location: e.location,
+    dateTime: e.dateTime,
+    url: `${proto}://${host}/events/${e.id}`,
+    description: `Convocados game — ${e.title}`,
+    recurrence: e.isRecurring ? parseRecurrenceRule(e.recurrenceRule) : null,
+  }));
+
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { name: true },
+  });
+
+  const ics = generateIcsFeed(calendarEvents, `Convocados — ${user?.name ?? "Games"}`);
+
+  return new Response(ics, {
+    headers: {
+      "Content-Type": "text/calendar; charset=utf-8",
+      "Cache-Control": "no-cache, no-store, must-revalidate",
+    },
+  });
+};

--- a/src/pages/api/users/[id]/index.ts
+++ b/src/pages/api/users/[id]/index.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from "astro";
-import { prisma } from "../../../lib/db.server";
-import { getSession } from "../../../lib/auth.helpers.server";
+import { prisma } from "../../../../lib/db.server";
+import { getSession } from "../../../../lib/auth.helpers.server";
 
 /** GET — user profile with game history, filtered by viewer permissions */
 export const GET: APIRoute = async ({ params, request }) => {

--- a/src/test/calendarFeed.test.ts
+++ b/src/test/calendarFeed.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import { generateIcsFeed } from "../lib/calendar";
+
+describe("generateIcsFeed", () => {
+  const events = [
+    {
+      id: "evt-1",
+      title: "Tuesday 5-a-side",
+      location: "Riverside Astro, Pitch 2",
+      dateTime: new Date("2026-03-24T19:00:00Z"),
+      url: "https://convocados.fly.dev/events/evt-1",
+      description: "Convocados game — Tuesday 5-a-side",
+    },
+    {
+      id: "evt-2",
+      title: "Thursday Futsal",
+      location: "Sports Hall",
+      dateTime: new Date("2026-03-26T20:00:00Z"),
+      url: "https://convocados.fly.dev/events/evt-2",
+      description: "Convocados game — Thursday Futsal",
+    },
+  ];
+
+  it("produces valid iCalendar with multiple VEVENTs", () => {
+    const ics = generateIcsFeed(events, "My Games");
+    expect(ics).toContain("BEGIN:VCALENDAR");
+    expect(ics).toContain("END:VCALENDAR");
+    // Two events
+    const veventCount = (ics.match(/BEGIN:VEVENT/g) || []).length;
+    expect(veventCount).toBe(2);
+    expect(ics).toContain("UID:evt-1@convocados");
+    expect(ics).toContain("UID:evt-2@convocados");
+    expect(ics).toContain("SUMMARY:Tuesday 5-a-side");
+    expect(ics).toContain("SUMMARY:Thursday Futsal");
+  });
+
+  it("includes feed name as X-WR-CALNAME", () => {
+    const ics = generateIcsFeed(events, "My Games");
+    expect(ics).toContain("X-WR-CALNAME:My Games");
+  });
+
+  it("handles empty event list", () => {
+    const ics = generateIcsFeed([], "Empty Feed");
+    expect(ics).toContain("BEGIN:VCALENDAR");
+    expect(ics).toContain("END:VCALENDAR");
+    expect(ics).not.toContain("BEGIN:VEVENT");
+  });
+
+  it("includes RRULE for recurring events in feed", () => {
+    const recurring = [
+      {
+        ...events[0],
+        recurrence: { freq: "weekly" as const, interval: 1, byDay: "TU" },
+      },
+    ];
+    const ics = generateIcsFeed(recurring, "Recurring");
+    expect(ics).toContain("RRULE:FREQ=WEEKLY;INTERVAL=1;BYDAY=TU");
+  });
+
+  it("uses correct date format", () => {
+    const ics = generateIcsFeed([events[0]], "Test");
+    expect(ics).toContain("DTSTART:20260324T190000Z");
+    expect(ics).toContain("DTEND:20260324T203000Z");
+  });
+
+  it("includes location and description", () => {
+    const ics = generateIcsFeed([events[0]], "Test");
+    expect(ics).toContain("LOCATION:Riverside Astro\\, Pitch 2");
+    expect(ics).toContain("DESCRIPTION:Convocados game");
+  });
+
+  it("includes URL for each event", () => {
+    const ics = generateIcsFeed(events, "Test");
+    expect(ics).toContain("URL:https://convocados.fly.dev/events/evt-1");
+    expect(ics).toContain("URL:https://convocados.fly.dev/events/evt-2");
+  });
+
+  it("omits optional fields when not provided", () => {
+    const minimal = [{ id: "m-1", title: "Game", location: "", dateTime: new Date("2026-04-01T18:00:00Z") }];
+    const ics = generateIcsFeed(minimal, "Minimal");
+    expect(ics).not.toContain("LOCATION:");
+    expect(ics).not.toContain("DESCRIPTION:");
+    expect(ics).not.toContain("URL:");
+    expect(ics).not.toContain("RRULE:");
+  });
+});


### PR DESCRIPTION
Closes #61

## What
Add private, token-authenticated iCal calendar subscription feeds that booking apps can subscribe to for availability checking.

## New endpoints
- `GET /api/users/:id/calendar.ics?token=xxx` — all upcoming games for a user
- `GET /api/events/:id/calendar.ics?token=xxx` — all upcoming games for an event (group)
- `POST /api/me/calendar-token` — generate/retrieve feed tokens (user or event scope)
- `DELETE /api/me/calendar-token` — revoke all tokens (for regeneration)

## Implementation
- **CalendarToken** Prisma model with cryptographic 32-byte hex tokens
- **`generateIcsFeed()`** in `src/lib/calendar.ts` — multi-event VCALENDAR with X-WR-CALNAME
- Token-based auth via query param (CalDAV-compatible, no cookies needed)
- `Cache-Control: no-cache` for auto-updating feeds
- Standard iCal format with VEVENT entries, RRULE support for recurring events

## Tests
- 8 new tests for the multi-event feed generator
- All 390 tests pass