### PR TITLE
feat: Webhook v2 — delivery logs, test endpoint, auto-disable (#58)

### DIFF
--- a/prisma/migrations/20260317231847_add_webhook_disabled/migration.sql
+++ b/prisma/migrations/20260317231847_add_webhook_disabled/migration.sql
@@ -1,0 +1,19 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_WebhookSubscription" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "eventId" TEXT NOT NULL,
+    "url" TEXT NOT NULL,
+    "secret" TEXT,
+    "events" TEXT NOT NULL DEFAULT '[]',
+    "disabled" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "WebhookSubscription_eventId_fkey" FOREIGN KEY ("eventId") REFERENCES "Event" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+INSERT INTO "new_WebhookSubscription" ("createdAt", "eventId", "events", "id", "secret", "url") SELECT "createdAt", "eventId", "events", "id", "secret", "url" FROM "WebhookSubscription";
+DROP TABLE "WebhookSubscription";
+ALTER TABLE "new_WebhookSubscription" RENAME TO "WebhookSubscription";
+CREATE UNIQUE INDEX "WebhookSubscription_eventId_url_key" ON "WebhookSubscription"("eventId", "url");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -179,6 +179,7 @@ model WebhookSubscription {
   url        String
   secret     String?
   events     String            @default("[]") // JSON array of event types
+  disabled   Boolean           @default(false)
   createdAt  DateTime          @default(now())
   deliveries WebhookDelivery[]
 

--- a/src/lib/webhook.server.ts
+++ b/src/lib/webhook.server.ts
@@ -32,6 +32,7 @@ export async function fireWebhooks(
   });
 
   const matching = subs.filter((sub) => {
+    if (sub.disabled) return false;
     const subscribedEvents: string[] = JSON.parse(sub.events);
     return subscribedEvents.length === 0 || subscribedEvents.includes(eventType);
   });
@@ -132,4 +133,32 @@ async function deliverWebhook(
     data: { status: "failed" },
   });
   console.error(`[webhook] gave up on ${url.slice(0, 60)} after ${MAX_ATTEMPTS} attempts`);
+
+  // Check health after failure
+  await checkWebhookHealth(webhookId);
+}
+
+const CONSECUTIVE_FAILURES_THRESHOLD = 10;
+
+/**
+ * Auto-disable a webhook after N consecutive failed deliveries.
+ */
+export async function checkWebhookHealth(webhookId: string): Promise<void> {
+  const recentDeliveries = await prisma.webhookDelivery.findMany({
+    where: { webhookId },
+    orderBy: { createdAt: "desc" },
+    take: CONSECUTIVE_FAILURES_THRESHOLD,
+    select: { status: true },
+  });
+
+  if (recentDeliveries.length < CONSECUTIVE_FAILURES_THRESHOLD) return;
+
+  const allFailed = recentDeliveries.every((d) => d.status === "failed");
+  if (allFailed) {
+    await prisma.webhookSubscription.update({
+      where: { id: webhookId },
+      data: { disabled: true },
+    });
+    console.warn(`[webhook] auto-disabled webhook ${webhookId} after ${CONSECUTIVE_FAILURES_THRESHOLD} consecutive failures`);
+  }
 }

--- a/src/pages/api/events/[id]/webhooks/[webhookId]/deliveries.ts
+++ b/src/pages/api/events/[id]/webhooks/[webhookId]/deliveries.ts
@@ -1,0 +1,32 @@
+import type { APIRoute } from "astro";
+import { prisma } from "../../../../../../lib/db.server";
+
+/** GET — list delivery logs for a webhook */
+export const GET: APIRoute = async ({ params }) => {
+  const eventId = params.id!;
+  const webhookId = params.webhookId!;
+
+  const webhook = await prisma.webhookSubscription.findFirst({
+    where: { id: webhookId, eventId },
+  });
+  if (!webhook) return Response.json({ error: "Not found." }, { status: 404 });
+
+  const deliveries = await prisma.webhookDelivery.findMany({
+    where: { webhookId },
+    orderBy: { createdAt: "desc" },
+    take: 50,
+  });
+
+  return Response.json({
+    deliveries: deliveries.map((d) => ({
+      id: d.id,
+      eventType: d.eventType,
+      status: d.status,
+      attempts: d.attempts,
+      error: d.error,
+      deliveredAt: d.deliveredAt?.toISOString() ?? null,
+      lastAttempt: d.lastAttempt?.toISOString() ?? null,
+      createdAt: d.createdAt.toISOString(),
+    })),
+  });
+};

--- a/src/pages/api/events/[id]/webhooks/[webhookId]/index.ts
+++ b/src/pages/api/events/[id]/webhooks/[webhookId]/index.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from "astro";
-import { prisma } from "../../../../../lib/db.server";
-import { checkOwnership } from "../../../../../lib/auth.helpers.server";
+import { prisma } from "../../../../../../lib/db.server";
+import { checkOwnership } from "../../../../../../lib/auth.helpers.server";
 
 /** DELETE — unsubscribe a webhook */
 export const DELETE: APIRoute = async ({ params, request }) => {

--- a/src/pages/api/events/[id]/webhooks/[webhookId]/test.ts
+++ b/src/pages/api/events/[id]/webhooks/[webhookId]/test.ts
@@ -1,0 +1,77 @@
+import type { APIRoute } from "astro";
+import { prisma } from "../../../../../../lib/db.server";
+import { signPayload } from "../../../../../../lib/webhook.server";
+
+/** POST — send a test payload to a webhook */
+export const POST: APIRoute = async ({ params }) => {
+  const eventId = params.id!;
+  const webhookId = params.webhookId!;
+
+  const webhook = await prisma.webhookSubscription.findFirst({
+    where: { id: webhookId, eventId },
+  });
+  if (!webhook) return Response.json({ error: "Not found." }, { status: 404 });
+
+  const payload = JSON.stringify({
+    event: "test",
+    eventId,
+    deliveryId: `test-${Date.now()}`,
+    timestamp: new Date().toISOString(),
+    data: { message: "This is a test webhook delivery from Convocados." },
+  });
+
+  const delivery = await prisma.webhookDelivery.create({
+    data: { webhookId, eventType: "test", payload, status: "pending" },
+  });
+
+  try {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      "User-Agent": "Convocados-Webhook/1.0",
+    };
+    if (webhook.secret) {
+      headers["X-Webhook-Signature"] = signPayload(payload, webhook.secret);
+    }
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 5000);
+    const res = await fetch(webhook.url, {
+      method: "POST",
+      headers,
+      body: payload,
+      signal: controller.signal,
+    });
+    clearTimeout(timeout);
+
+    if (res.ok) {
+      await prisma.webhookDelivery.update({
+        where: { id: delivery.id },
+        data: { status: "success", attempts: 1, deliveredAt: new Date(), lastAttempt: new Date() },
+      });
+    } else {
+      await prisma.webhookDelivery.update({
+        where: { id: delivery.id },
+        data: { status: "failed", attempts: 1, lastAttempt: new Date(), error: `HTTP ${res.status}` },
+      });
+    }
+  } catch (err: any) {
+    const errMsg = err?.name === "AbortError" ? "Timeout" : (err?.message ?? "Unknown error");
+    await prisma.webhookDelivery.update({
+      where: { id: delivery.id },
+      data: { status: "failed", attempts: 1, lastAttempt: new Date(), error: errMsg },
+    });
+  }
+
+  const updated = await prisma.webhookDelivery.findUnique({ where: { id: delivery.id } });
+
+  return Response.json({
+    delivery: {
+      id: updated!.id,
+      eventType: updated!.eventType,
+      status: updated!.status,
+      error: updated!.error,
+      deliveredAt: updated!.deliveredAt?.toISOString() ?? null,
+      createdAt: updated!.createdAt.toISOString(),
+    },
+  });
+};

--- a/src/test/webhook-v2.test.ts
+++ b/src/test/webhook-v2.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { prisma } from "~/lib/db.server";
+import { checkWebhookHealth } from "~/lib/webhook.server";
+
+// Helpers
+function ctx(params: Record<string, string>, body?: unknown) {
+  const request = new Request("http://localhost/api/test", {
+    method: body !== undefined ? "POST" : "GET",
+    headers: { "content-type": "application/json" },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+  return { request, params } as any;
+}
+
+async function seedEvent() {
+  return (await prisma.event.create({
+    data: {
+      title: "Webhook V2 Test",
+      location: "Pitch B",
+      dateTime: new Date(Date.now() + 86400_000),
+      teamOneName: "A",
+      teamTwoName: "B",
+    },
+  })).id;
+}
+
+async function seedWebhookWithDeliveries(eventId: string, failCount: number) {
+  const webhook = await prisma.webhookSubscription.create({
+    data: { eventId, url: "https://example.com/hook", events: "[]" },
+  });
+  for (let i = 0; i < failCount; i++) {
+    await prisma.webhookDelivery.create({
+      data: {
+        webhookId: webhook.id,
+        eventType: "player_joined",
+        payload: "{}",
+        status: "failed",
+        attempts: 5,
+        lastAttempt: new Date(),
+        error: "HTTP 500",
+      },
+    });
+  }
+  return webhook;
+}
+
+beforeEach(async () => {
+  await prisma.webhookDelivery.deleteMany();
+  await prisma.webhookSubscription.deleteMany();
+  await prisma.gameHistory.deleteMany();
+  await prisma.teamResult.deleteMany();
+  await prisma.player.deleteMany();
+  await prisma.event.deleteMany();
+});
+
+describe("GET /api/events/[id]/webhooks/[webhookId]/deliveries", () => {
+  it("returns delivery logs for a webhook", async () => {
+    const { GET } = await import("~/pages/api/events/[id]/webhooks/[webhookId]/deliveries");
+    const eventId = await seedEvent();
+    const webhook = await prisma.webhookSubscription.create({
+      data: { eventId, url: "https://example.com/hook", events: "[]" },
+    });
+    await prisma.webhookDelivery.create({
+      data: {
+        webhookId: webhook.id,
+        eventType: "player_joined",
+        payload: '{"test":true}',
+        status: "success",
+        attempts: 1,
+        deliveredAt: new Date(),
+      },
+    });
+
+    const res = await GET(ctx({ id: eventId, webhookId: webhook.id }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.deliveries).toHaveLength(1);
+    expect(body.deliveries[0].eventType).toBe("player_joined");
+    expect(body.deliveries[0].status).toBe("success");
+  });
+
+  it("returns 404 for non-existent webhook", async () => {
+    const { GET } = await import("~/pages/api/events/[id]/webhooks/[webhookId]/deliveries");
+    const eventId = await seedEvent();
+    const res = await GET(ctx({ id: eventId, webhookId: "nonexistent" }));
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("POST /api/events/[id]/webhooks/[webhookId]/test", () => {
+  it("creates a test delivery record", async () => {
+    const { POST } = await import("~/pages/api/events/[id]/webhooks/[webhookId]/test");
+    const eventId = await seedEvent();
+    const webhook = await prisma.webhookSubscription.create({
+      data: { eventId, url: "https://httpbin.org/post", events: "[]" },
+    });
+
+    const res = await POST(ctx({ id: eventId, webhookId: webhook.id }, {}));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.delivery).toBeDefined();
+    expect(body.delivery.eventType).toBe("test");
+  });
+
+  it("returns 404 for non-existent webhook", async () => {
+    const { POST } = await import("~/pages/api/events/[id]/webhooks/[webhookId]/test");
+    const eventId = await seedEvent();
+    const res = await POST(ctx({ id: eventId, webhookId: "nonexistent" }, {}));
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("checkWebhookHealth", () => {
+  it("disables webhook after consecutive failures", async () => {
+    const eventId = await seedEvent();
+    const webhook = await seedWebhookWithDeliveries(eventId, 10);
+
+    await checkWebhookHealth(webhook.id);
+
+    const updated = await prisma.webhookSubscription.findUnique({ where: { id: webhook.id } });
+    expect(updated?.disabled).toBe(true);
+  });
+
+  it("does not disable webhook with fewer failures", async () => {
+    const eventId = await seedEvent();
+    const webhook = await seedWebhookWithDeliveries(eventId, 3);
+
+    await checkWebhookHealth(webhook.id);
+
+    const updated = await prisma.webhookSubscription.findUnique({ where: { id: webhook.id } });
+    expect(updated?.disabled).toBeFalsy();
+  });
+});

--- a/src/test/webhook.test.ts
+++ b/src/test/webhook.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
 import { prisma } from "~/lib/db.server";
 
 import { POST as createWebhook, GET as listWebhooks } from "~/pages/api/events/[id]/webhooks/index";
-import { DELETE as deleteWebhook } from "~/pages/api/events/[id]/webhooks/[webhookId]";
+import { DELETE as deleteWebhook } from "~/pages/api/events/[id]/webhooks/[webhookId]/index";
 import { signPayload, fireWebhooks } from "~/lib/webhook.server";
 
 // Helpers


### PR DESCRIPTION
Closes #58

- Webhook delivery logs API
- Test endpoint: POST /api/events/:id/webhooks/:id/test
- Auto-disable after consecutive failures
- 396 tests pass (6 new)