### PR TITLE
feat: SEO for public games — structured data, meta tags, sitemap (#71)

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,11 @@
+User-agent: *
+Allow: /
+Allow: /public
+Allow: /events/
+Allow: /docs/
+
+Disallow: /api/
+Disallow: /auth/
+Disallow: /dashboard
+
+Sitemap: https://convocados.fly.dev/sitemap.xml

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,0 +1,68 @@
+/**
+ * SEO utilities: Schema.org JSON-LD, Open Graph, and Twitter Card meta tags.
+ */
+
+interface EventJsonLdInput {
+  id: string;
+  title: string;
+  location: string;
+  dateTime: Date;
+  sport: string;
+  maxPlayers: number;
+  playerCount: number;
+  url: string;
+}
+
+/** Generate Schema.org SportsEvent JSON-LD string */
+export function generateEventJsonLd(event: EventJsonLdInput): string {
+  return JSON.stringify({
+    "@context": "https://schema.org",
+    "@type": "SportsEvent",
+    name: event.title,
+    startDate: event.dateTime.toISOString(),
+    endDate: new Date(event.dateTime.getTime() + 90 * 60 * 1000).toISOString(),
+    location: {
+      "@type": "Place",
+      name: event.location || "TBD",
+    },
+    url: event.url,
+    eventStatus: "https://schema.org/EventScheduled",
+    eventAttendanceMode: "https://schema.org/OfflineEventAttendanceMode",
+    maximumAttendeeCapacity: event.maxPlayers,
+    remainingAttendeeCapacity: Math.max(0, event.maxPlayers - event.playerCount),
+    organizer: {
+      "@type": "Organization",
+      name: "Convocados",
+      url: "https://convocados.fly.dev",
+    },
+  });
+}
+
+interface MetaTagInput {
+  title: string;
+  description: string;
+  url: string;
+  dateTime?: Date;
+  location?: string;
+  playerCount?: number;
+  maxPlayers?: number;
+}
+
+interface MetaTag {
+  property: string;
+  content: string;
+}
+
+/** Generate Open Graph + Twitter Card meta tags */
+export function generateEventMetaTags(event: MetaTagInput): MetaTag[] {
+  return [
+    { property: "og:title", content: event.title },
+    { property: "og:description", content: event.description },
+    { property: "og:url", content: event.url },
+    { property: "og:type", content: "website" },
+    { property: "og:site_name", content: "Convocados" },
+    { property: "twitter:card", content: "summary" },
+    { property: "twitter:title", content: event.title },
+    { property: "twitter:description", content: event.description },
+  ];
+}

--- a/src/pages/events/[id].astro
+++ b/src/pages/events/[id].astro
@@ -1,6 +1,60 @@
 ---
 import EventPageComponent from "../../components/EventPage";
+import { prisma } from "../../lib/db.server";
+import { generateEventJsonLd, generateEventMetaTags } from "../../lib/seo";
+
 const { id } = Astro.params;
+
+const host = Astro.request.headers.get("x-forwarded-host") ?? Astro.request.headers.get("host") ?? "convocados.fly.dev";
+const proto = Astro.request.headers.get("x-forwarded-proto") ?? "https";
+const canonicalUrl = `${proto}://${host}/events/${id}`;
+
+// Fetch event data for SSR meta tags (non-blocking — page still works if DB fails)
+let title = "Convocados";
+let description = "Organize pickup sports games — manage events, randomize teams, track scores.";
+let jsonLd = "";
+let metaTags: { property: string; content: string }[] = [];
+
+try {
+  const event = await prisma.event.findUnique({
+    where: { id },
+    select: {
+      id: true, title: true, location: true, dateTime: true,
+      sport: true, maxPlayers: true, isPublic: true,
+      _count: { select: { players: true } },
+    },
+  });
+
+  if (event) {
+    const playerCount = event._count.players;
+    const spotsLeft = Math.max(0, event.maxPlayers - playerCount);
+    title = `${event.title} — Convocados`;
+    description = `${event.location || "Game"} · ${playerCount}/${event.maxPlayers} players · ${spotsLeft} spot(s) left`;
+
+    if (event.isPublic) {
+      jsonLd = generateEventJsonLd({
+        id: event.id,
+        title: event.title,
+        location: event.location,
+        dateTime: event.dateTime,
+        sport: event.sport,
+        maxPlayers: event.maxPlayers,
+        playerCount,
+        url: canonicalUrl,
+      });
+    }
+
+    metaTags = generateEventMetaTags({
+      title: event.title,
+      description,
+      url: canonicalUrl,
+      dateTime: event.dateTime,
+      location: event.location,
+      playerCount,
+      maxPlayers: event.maxPlayers,
+    });
+  }
+} catch { /* SSR meta is best-effort */ }
 ---
 
 <!doctype html>
@@ -8,10 +62,19 @@ const { id } = Astro.params;
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Convocados</title>
+    <title>{title}</title>
+    <meta name="description" content={description} />
+    <link rel="canonical" href={canonicalUrl} />
     <link rel="icon" href="/favicon.ico" />
+    <link rel="apple-touch-icon" href="/icons/apple-touch-icon.png" />
     <link rel="manifest" href="/manifest.json" />
     <meta name="theme-color" content="#1b6b4a" />
+    {metaTags.map((tag) => (
+      <meta property={tag.property} content={tag.content} />
+    ))}
+    {jsonLd && (
+      <script type="application/ld+json" set:html={jsonLd} />
+    )}
   </head>
   <body>
     <EventPageComponent client:only="react" eventId={id!} />

--- a/src/pages/public.astro
+++ b/src/pages/public.astro
@@ -1,5 +1,9 @@
 ---
 import PublicGamesPage from "../components/PublicGamesPage";
+
+const host = Astro.request.headers.get("x-forwarded-host") ?? Astro.request.headers.get("host") ?? "convocados.fly.dev";
+const proto = Astro.request.headers.get("x-forwarded-proto") ?? "https";
+const canonicalUrl = `${proto}://${host}/public`;
 ---
 
 <!doctype html>
@@ -8,10 +12,20 @@ import PublicGamesPage from "../components/PublicGamesPage";
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Convocados — Public Games</title>
-    <meta name="description" content="Browse public sports games looking for players." />
+    <meta name="description" content="Browse public sports games looking for players. Join one or create your own!" />
+    <link rel="canonical" href={canonicalUrl} />
     <link rel="icon" href="/favicon.ico" />
+    <link rel="apple-touch-icon" href="/icons/apple-touch-icon.png" />
     <link rel="manifest" href="/manifest.json" />
     <meta name="theme-color" content="#1b6b4a" />
+    <meta property="og:title" content="Public Games — Convocados" />
+    <meta property="og:description" content="Browse public sports games looking for players. Join one or create your own!" />
+    <meta property="og:url" content={canonicalUrl} />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Convocados" />
+    <meta property="twitter:card" content="summary" />
+    <meta property="twitter:title" content="Public Games — Convocados" />
+    <meta property="twitter:description" content="Browse public sports games looking for players." />
   </head>
   <body>
     <PublicGamesPage client:only="react" />

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -1,0 +1,51 @@
+import type { APIRoute } from "astro";
+import { prisma } from "../lib/db.server";
+
+export const GET: APIRoute = async ({ request }) => {
+  const host = request.headers.get("x-forwarded-host") ?? request.headers.get("host") ?? "convocados.fly.dev";
+  const proto = request.headers.get("x-forwarded-proto") ?? "https";
+  const base = `${proto}://${host}`;
+
+  const publicEvents = await prisma.event.findMany({
+    where: { isPublic: true, dateTime: { gte: new Date() } },
+    select: { id: true, updatedAt: true },
+    orderBy: { dateTime: "asc" },
+    take: 1000,
+  });
+
+  const staticPages = [
+    { loc: "/", priority: "1.0", changefreq: "daily" },
+    { loc: "/public", priority: "0.9", changefreq: "hourly" },
+    { loc: "/docs", priority: "0.5", changefreq: "weekly" },
+  ];
+
+  const urls = [
+    ...staticPages.map((p) =>
+      `  <url>
+    <loc>${base}${p.loc}</loc>
+    <changefreq>${p.changefreq}</changefreq>
+    <priority>${p.priority}</priority>
+  </url>`
+    ),
+    ...publicEvents.map((e) =>
+      `  <url>
+    <loc>${base}/events/${e.id}</loc>
+    <lastmod>${e.updatedAt.toISOString()}</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.7</priority>
+  </url>`
+    ),
+  ];
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urls.join("\n")}
+</urlset>`;
+
+  return new Response(xml, {
+    headers: {
+      "Content-Type": "application/xml; charset=utf-8",
+      "Cache-Control": "public, max-age=3600",
+    },
+  });
+};

--- a/src/test/seo.test.ts
+++ b/src/test/seo.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { generateEventJsonLd, generateEventMetaTags } from "../lib/seo";
+
+describe("generateEventJsonLd", () => {
+  const event = {
+    id: "evt-1",
+    title: "Tuesday 5-a-side",
+    location: "Riverside Astro, Pitch 2",
+    dateTime: new Date("2026-03-24T19:00:00Z"),
+    sport: "football-5v5",
+    maxPlayers: 10,
+    playerCount: 6,
+    url: "https://convocados.fly.dev/events/evt-1",
+  };
+
+  it("produces valid Schema.org SportsEvent JSON-LD", () => {
+    const jsonLd = generateEventJsonLd(event);
+    const parsed = JSON.parse(jsonLd);
+    expect(parsed["@context"]).toBe("https://schema.org");
+    expect(parsed["@type"]).toBe("SportsEvent");
+    expect(parsed.name).toBe("Tuesday 5-a-side");
+    expect(parsed.location.name).toBe("Riverside Astro, Pitch 2");
+    expect(parsed.startDate).toBe("2026-03-24T19:00:00.000Z");
+    expect(parsed.url).toBe("https://convocados.fly.dev/events/evt-1");
+    expect(parsed.maximumAttendeeCapacity).toBe(10);
+    expect(parsed.remainingAttendeeCapacity).toBe(4);
+  });
+
+  it("includes organizer as Convocados", () => {
+    const parsed = JSON.parse(generateEventJsonLd(event));
+    expect(parsed.organizer.name).toBe("Convocados");
+  });
+
+  it("sets eventStatus to EventScheduled", () => {
+    const parsed = JSON.parse(generateEventJsonLd(event));
+    expect(parsed.eventStatus).toBe("https://schema.org/EventScheduled");
+  });
+});
+
+describe("generateEventMetaTags", () => {
+  const event = {
+    title: "Tuesday 5-a-side",
+    description: "Join this game on Convocados",
+    url: "https://convocados.fly.dev/events/evt-1",
+    dateTime: new Date("2026-03-24T19:00:00Z"),
+    location: "Riverside Astro",
+    playerCount: 6,
+    maxPlayers: 10,
+  };
+
+  it("generates og: meta tags", () => {
+    const tags = generateEventMetaTags(event);
+    expect(tags).toContainEqual({ property: "og:title", content: "Tuesday 5-a-side" });
+    expect(tags).toContainEqual({ property: "og:type", content: "website" });
+    expect(tags).toContainEqual({ property: "og:url", content: "https://convocados.fly.dev/events/evt-1" });
+    expect(tags.find((t) => t.property === "og:description")?.content).toContain("Join this game");
+  });
+
+  it("generates twitter: meta tags", () => {
+    const tags = generateEventMetaTags(event);
+    expect(tags).toContainEqual({ property: "twitter:card", content: "summary" });
+    expect(tags).toContainEqual({ property: "twitter:title", content: "Tuesday 5-a-side" });
+  });
+});


### PR DESCRIPTION
Closes #71

- Schema.org Event JSON-LD structured data
- Open Graph and Twitter Card meta tags
- sitemap.xml for public events
- robots.txt
- 395 tests pass (5 new)