### PR TITLE
feat: scheduled game reminders with cron endpoint (#50)

### DIFF
--- a/prisma/migrations/20260318112041_add_reminder_log/migration.sql
+++ b/prisma/migrations/20260318112041_add_reminder_log/migration.sql
@@ -1,0 +1,11 @@
+-- CreateTable
+CREATE TABLE "ReminderLog" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "eventId" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "sentAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "ReminderLog_eventId_fkey" FOREIGN KEY ("eventId") REFERENCES "Event" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ReminderLog_eventId_type_key" ON "ReminderLog"("eventId", "type");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -88,6 +88,7 @@ model Event {
   playerRatings  PlayerRating[]
   pushSubs       PushSubscription[]
   webhookSubs    WebhookSubscription[]
+  reminderLogs   ReminderLog[]
   createdAt      DateTime      @default(now())
   updatedAt      DateTime      @updatedAt
 
@@ -197,6 +198,16 @@ model WebhookDelivery {
   deliveredAt DateTime?
   error       String?
   createdAt   DateTime            @default(now())
+}
+
+model ReminderLog {
+  id        String   @id @default(cuid())
+  eventId   String
+  event     Event    @relation(fields: [eventId], references: [id], onDelete: Cascade)
+  type      String   // "24h" | "2h" | "1h"
+  sentAt    DateTime @default(now())
+
+  @@unique([eventId, type])
 }
 
 model CalendarToken {

--- a/src/lib/reminders.server.ts
+++ b/src/lib/reminders.server.ts
@@ -1,0 +1,50 @@
+import { prisma } from "./db.server";
+
+const WINDOWS: Record<string, { minMs: number; maxMs: number }> = {
+  "24h": { minMs: 22 * 3600_000, maxMs: 26 * 3600_000 },
+  "2h":  { minMs: 1 * 3600_000,  maxMs: 3 * 3600_000 },
+  "1h":  { minMs: 30 * 60_000,   maxMs: 90 * 60_000 },
+};
+
+export interface UpcomingReminder {
+  eventId: string;
+  eventTitle: string;
+  dateTime: Date;
+  location: string;
+  players: { name: string; userId: string | null; email: string | null }[];
+}
+
+/** Find events that need a reminder of the given type and haven't been sent yet. */
+export async function getUpcomingReminders(type: "24h" | "2h" | "1h"): Promise<UpcomingReminder[]> {
+  const window = WINDOWS[type];
+  const now = Date.now();
+  const from = new Date(now + window.minMs);
+  const to = new Date(now + window.maxMs);
+
+  const events = await prisma.event.findMany({
+    where: {
+      dateTime: { gte: from, lte: to },
+      reminderLogs: { none: { type } },
+    },
+    include: {
+      players: { include: { user: { select: { email: true } } } },
+    },
+  });
+
+  return events.map((e) => ({
+    eventId: e.id,
+    eventTitle: e.title,
+    dateTime: e.dateTime,
+    location: e.location,
+    players: e.players.map((p) => ({
+      name: p.name,
+      userId: p.userId,
+      email: p.user?.email ?? null,
+    })),
+  }));
+}
+
+/** Mark a reminder as sent so it won't fire again. */
+export async function markReminderSent(eventId: string, type: string) {
+  await prisma.reminderLog.create({ data: { eventId, type } });
+}

--- a/src/pages/api/cron/reminders.ts
+++ b/src/pages/api/cron/reminders.ts
@@ -1,0 +1,29 @@
+import type { APIRoute } from "astro";
+import { getUpcomingReminders, markReminderSent } from "~/lib/reminders.server";
+import { sendPushToEvent } from "~/lib/push.server";
+
+const CRON_SECRET = import.meta.env.CRON_SECRET ?? process.env.CRON_SECRET;
+
+export const POST: APIRoute = async ({ request }) => {
+  if (CRON_SECRET && request.headers.get("authorization") !== `Bearer ${CRON_SECRET}`) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  const sent: string[] = [];
+  for (const type of ["24h", "2h", "1h"] as const) {
+    const reminders = await getUpcomingReminders(type);
+    for (const r of reminders) {
+      try {
+        await sendPushToEvent(r.eventId, "Reminder", "notifyReminder" as any, { title: r.eventTitle }, `/events/${r.eventId}`, 0);
+        await markReminderSent(r.eventId, type);
+        sent.push(`${r.eventId}:${type}`);
+      } catch (err) {
+        console.error(`[cron] Failed to send ${type} reminder for ${r.eventId}:`, err);
+      }
+    }
+  }
+
+  return new Response(JSON.stringify({ ok: true, sent }), {
+    headers: { "Content-Type": "application/json" },
+  });
+};

--- a/src/test/reminders.test.ts
+++ b/src/test/reminders.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { prisma } from "~/lib/db.server";
+import { getUpcomingReminders, markReminderSent } from "~/lib/reminders.server";
+
+// Seed helpers
+async function seedUser(id = "user-rem-1") {
+  await prisma.user.upsert({
+    where: { id },
+    update: {},
+    create: { id, name: "Reminder User", email: `${id}@test.com`, emailVerified: true, createdAt: new Date(), updatedAt: new Date() },
+  });
+  return id;
+}
+
+async function seedEvent(ownerId: string, dateTime: Date, id = "evt-rem-1") {
+  await prisma.event.upsert({
+    where: { id },
+    update: { dateTime },
+    create: {
+      id, title: "Reminder Game", location: "Test Field", dateTime,
+      maxPlayers: 10, ownerId, createdAt: new Date(), updatedAt: new Date(),
+    },
+  });
+  return id;
+}
+
+beforeEach(async () => {
+  await prisma.reminderLog.deleteMany();
+  await prisma.player.deleteMany();
+  await prisma.event.deleteMany();
+  await prisma.session.deleteMany();
+  await prisma.account.deleteMany();
+  await prisma.user.deleteMany();
+});
+
+describe("getUpcomingReminders", () => {
+  it("returns events needing 24h reminder", async () => {
+    const userId = await seedUser();
+    const inAbout24h = new Date(Date.now() + 23.5 * 60 * 60 * 1000);
+    const eventId = await seedEvent(userId, inAbout24h);
+    await prisma.player.create({ data: { name: "Player1", eventId, userId } });
+
+    const reminders = await getUpcomingReminders("24h");
+    expect(reminders.length).toBeGreaterThanOrEqual(1);
+    expect(reminders.some((r) => r.eventId === eventId)).toBe(true);
+  });
+
+  it("skips events already reminded", async () => {
+    const userId = await seedUser();
+    const inAbout24h = new Date(Date.now() + 23.5 * 60 * 60 * 1000);
+    const eventId = await seedEvent(userId, inAbout24h);
+    await prisma.player.create({ data: { name: "Player1", eventId, userId } });
+    await markReminderSent(eventId, "24h");
+
+    const reminders = await getUpcomingReminders("24h");
+    expect(reminders.every((r) => r.eventId !== eventId)).toBe(true);
+  });
+
+  it("returns events needing 2h reminder", async () => {
+    const userId = await seedUser();
+    const inAbout2h = new Date(Date.now() + 1.5 * 60 * 60 * 1000);
+    const eventId = await seedEvent(userId, inAbout2h, "evt-rem-2h");
+    await prisma.player.create({ data: { name: "Player1", eventId, userId } });
+
+    const reminders = await getUpcomingReminders("2h");
+    expect(reminders.some((r) => r.eventId === eventId)).toBe(true);
+  });
+
+  it("ignores past events", async () => {
+    const userId = await seedUser();
+    const past = new Date(Date.now() - 60 * 60 * 1000);
+    await seedEvent(userId, past, "evt-past");
+
+    const reminders = await getUpcomingReminders("24h");
+    expect(reminders.every((r) => r.eventId !== "evt-past")).toBe(true);
+  });
+});
+
+describe("markReminderSent", () => {
+  it("creates a reminder log entry", async () => {
+    const userId = await seedUser();
+    const eventId = await seedEvent(userId, new Date(Date.now() + 24 * 60 * 60 * 1000));
+
+    await markReminderSent(eventId, "24h");
+
+    const log = await prisma.reminderLog.findFirst({ where: { eventId, type: "24h" } });
+    expect(log).not.toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #50

- ReminderLog model to track sent reminders
- getUpcomingReminders/markReminderSent logic with configurable windows (24h, 2h, 1h)
- POST /api/cron/reminders endpoint (protected by CRON_SECRET)
- 395 tests pass (5 new)