### PR TITLE
feat: real-time updates via Server-Sent Events (#66)

### DIFF
--- a/src/lib/sse.server.ts
+++ b/src/lib/sse.server.ts
@@ -1,0 +1,39 @@
+/** Format a Server-Sent Event message. */
+export function formatSSE(event: string, data: unknown): string {
+  return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+type Controller = ReadableStreamDefaultController<string>;
+
+/** In-memory SSE connection manager. One per server process. */
+export function createSSEManager() {
+  const connections = new Map<string, Set<Controller>>();
+
+  return {
+    add(eventId: string, controller: Controller) {
+      if (!connections.has(eventId)) connections.set(eventId, new Set());
+      connections.get(eventId)!.add(controller);
+    },
+
+    remove(eventId: string, controller: Controller) {
+      connections.get(eventId)?.delete(controller);
+      if (connections.get(eventId)?.size === 0) connections.delete(eventId);
+    },
+
+    broadcast(eventId: string, event: string, data: unknown) {
+      const controllers = connections.get(eventId);
+      if (!controllers) return;
+      const msg = formatSSE(event, data);
+      for (const c of controllers) {
+        try { c.enqueue(msg); } catch { /* client disconnected */ }
+      }
+    },
+
+    getConnectionCount(eventId: string): number {
+      return connections.get(eventId)?.size ?? 0;
+    },
+  };
+}
+
+/** Singleton SSE manager for the app. */
+export const sseManager = createSSEManager();

--- a/src/pages/api/events/[id]/stream.ts
+++ b/src/pages/api/events/[id]/stream.ts
@@ -1,0 +1,34 @@
+import type { APIRoute } from "astro";
+import { sseManager, formatSSE } from "~/lib/sse.server";
+
+export const GET: APIRoute = async ({ params }) => {
+  const eventId = params.id!;
+
+  const stream = new ReadableStream<string>({
+    start(controller) {
+      sseManager.add(eventId, controller);
+      controller.enqueue(formatSSE("connected", { eventId }));
+
+      // Heartbeat every 30s to keep connection alive
+      const heartbeat = setInterval(() => {
+        try { controller.enqueue(formatSSE("heartbeat", {})); }
+        catch { clearInterval(heartbeat); }
+      }, 30_000);
+
+      // Cleanup on close — the cancel callback fires when the client disconnects
+      (controller as any)._heartbeat = heartbeat;
+    },
+    cancel(controller: any) {
+      clearInterval(controller?._heartbeat);
+      sseManager.remove(eventId, controller);
+    },
+  });
+
+  return new Response(stream as any, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    },
+  });
+};

--- a/src/test/sse.test.ts
+++ b/src/test/sse.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { createSSEManager, formatSSE } from "~/lib/sse.server";
+
+describe("formatSSE", () => {
+  it("formats event with data", () => {
+    const result = formatSSE("player_joined", { name: "Alice" });
+    expect(result).toBe('event: player_joined\ndata: {"name":"Alice"}\n\n');
+  });
+
+  it("formats heartbeat", () => {
+    const result = formatSSE("heartbeat", {});
+    expect(result).toBe('event: heartbeat\ndata: {}\n\n');
+  });
+});
+
+describe("createSSEManager", () => {
+  it("creates a manager with add/remove/broadcast", () => {
+    const manager = createSSEManager();
+    expect(manager.add).toBeTypeOf("function");
+    expect(manager.remove).toBeTypeOf("function");
+    expect(manager.broadcast).toBeTypeOf("function");
+    expect(manager.getConnectionCount).toBeTypeOf("function");
+  });
+
+  it("tracks connections per event", () => {
+    const manager = createSSEManager();
+    const controller1 = { enqueue: () => {}, close: () => {} } as any;
+    const controller2 = { enqueue: () => {}, close: () => {} } as any;
+
+    manager.add("evt-1", controller1);
+    manager.add("evt-1", controller2);
+    manager.add("evt-2", controller1);
+
+    expect(manager.getConnectionCount("evt-1")).toBe(2);
+    expect(manager.getConnectionCount("evt-2")).toBe(1);
+  });
+
+  it("broadcasts to all connections for an event", () => {
+    const manager = createSSEManager();
+    const enqueued: string[] = [];
+    const controller = { enqueue: (s: string) => enqueued.push(s), close: () => {} } as any;
+
+    manager.add("evt-1", controller);
+    manager.broadcast("evt-1", "player_joined", { name: "Bob" });
+
+    expect(enqueued).toHaveLength(1);
+    expect(enqueued[0]).toContain("player_joined");
+    expect(enqueued[0]).toContain("Bob");
+  });
+
+  it("removes connections", () => {
+    const manager = createSSEManager();
+    const controller = { enqueue: () => {}, close: () => {} } as any;
+
+    manager.add("evt-1", controller);
+    expect(manager.getConnectionCount("evt-1")).toBe(1);
+
+    manager.remove("evt-1", controller);
+    expect(manager.getConnectionCount("evt-1")).toBe(0);
+  });
+
+  it("does not fail broadcasting to empty event", () => {
+    const manager = createSSEManager();
+    expect(() => manager.broadcast("nonexistent", "test", {})).not.toThrow();
+  });
+});


### PR DESCRIPTION
Closes #66

- SSE manager with add/remove/broadcast per event
- GET /api/events/:id/stream endpoint
- Heartbeat every 30s, auto-cleanup on disconnect
- 397 tests pass (7 new)