### PR TITLE
feat: admin dashboard — role, stats, user management (#68)

### DIFF
--- a/prisma/migrations/20260318112916_add_user_role/migration.sql
+++ b/prisma/migrations/20260318112916_add_user_role/migration.sql
@@ -1,0 +1,19 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_User" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "emailVerified" BOOLEAN NOT NULL DEFAULT false,
+    "image" TEXT,
+    "role" TEXT NOT NULL DEFAULT 'user',
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+INSERT INTO "new_User" ("createdAt", "email", "emailVerified", "id", "image", "name", "updatedAt") SELECT "createdAt", "email", "emailVerified", "id", "image", "name", "updatedAt" FROM "User";
+DROP TABLE "User";
+ALTER TABLE "new_User" RENAME TO "User";
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -15,6 +15,7 @@ model User {
   email          String          @unique
   emailVerified  Boolean         @default(false)
   image          String?
+  role           String          @default("user") // "user" | "admin"
   createdAt      DateTime        @default(now())
   updatedAt      DateTime        @updatedAt
   sessions       Session[]

--- a/src/lib/admin.server.ts
+++ b/src/lib/admin.server.ts
@@ -1,0 +1,31 @@
+import { prisma } from "./db.server";
+
+export async function isAdmin(userId: string): Promise<boolean> {
+  const user = await prisma.user.findUnique({ where: { id: userId }, select: { role: true } });
+  return user?.role === "admin";
+}
+
+export async function getAdminStats() {
+  const [totalUsers, totalEvents] = await Promise.all([
+    prisma.user.count(),
+    prisma.event.count(),
+  ]);
+  return { totalUsers, totalEvents };
+}
+
+export async function listUsers({ page, pageSize, search }: { page: number; pageSize: number; search?: string }) {
+  const where = search
+    ? { OR: [{ name: { contains: search } }, { email: { contains: search } }, { id: { contains: search } }] }
+    : {};
+  const [users, total] = await Promise.all([
+    prisma.user.findMany({
+      where,
+      select: { id: true, name: true, email: true, role: true, createdAt: true },
+      skip: (page - 1) * pageSize,
+      take: pageSize,
+      orderBy: { createdAt: "desc" },
+    }),
+    prisma.user.count({ where }),
+  ]);
+  return { users, total };
+}

--- a/src/pages/api/admin/stats.ts
+++ b/src/pages/api/admin/stats.ts
@@ -1,0 +1,12 @@
+import type { APIRoute } from "astro";
+import { getSession } from "~/lib/auth.helpers.server";
+import { isAdmin, getAdminStats } from "~/lib/admin.server";
+
+export const GET: APIRoute = async ({ request }) => {
+  const session = await getSession(request);
+  if (!session?.user?.id || !(await isAdmin(session.user.id))) {
+    return new Response("Forbidden", { status: 403 });
+  }
+  const stats = await getAdminStats();
+  return new Response(JSON.stringify(stats), { headers: { "Content-Type": "application/json" } });
+};

--- a/src/pages/api/admin/users.ts
+++ b/src/pages/api/admin/users.ts
@@ -1,0 +1,16 @@
+import type { APIRoute } from "astro";
+import { getSession } from "~/lib/auth.helpers.server";
+import { isAdmin, listUsers } from "~/lib/admin.server";
+
+export const GET: APIRoute = async ({ request, url }) => {
+  const session = await getSession(request);
+  if (!session?.user?.id || !(await isAdmin(session.user.id))) {
+    return new Response("Forbidden", { status: 403 });
+  }
+  const page = Math.max(1, Number(url.searchParams.get("page")) || 1);
+  const pageSize = Math.min(50, Math.max(1, Number(url.searchParams.get("pageSize")) || 20));
+  const search = url.searchParams.get("search") || undefined;
+
+  const result = await listUsers({ page, pageSize, search });
+  return new Response(JSON.stringify(result), { headers: { "Content-Type": "application/json" } });
+};

--- a/src/test/admin.test.ts
+++ b/src/test/admin.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { prisma } from "~/lib/db.server";
+import { isAdmin, getAdminStats, listUsers } from "~/lib/admin.server";
+
+async function seedUser(id: string, role = "user") {
+  await prisma.user.upsert({
+    where: { id },
+    update: { role },
+    create: { id, name: `User ${id}`, email: `${id}@test.com`, emailVerified: true, role, createdAt: new Date(), updatedAt: new Date() },
+  });
+}
+
+async function seedEvent(id: string, ownerId: string) {
+  await prisma.event.upsert({
+    where: { id },
+    update: {},
+    create: { id, title: "Admin Test Game", location: "Field", dateTime: new Date(), maxPlayers: 10, ownerId, createdAt: new Date(), updatedAt: new Date() },
+  });
+}
+
+beforeEach(async () => {
+  await prisma.player.deleteMany();
+  await prisma.event.deleteMany();
+  await prisma.session.deleteMany();
+  await prisma.account.deleteMany();
+  await prisma.user.deleteMany();
+});
+
+describe("isAdmin", () => {
+  it("returns true for admin users", async () => {
+    await seedUser("admin-1", "admin");
+    expect(await isAdmin("admin-1")).toBe(true);
+  });
+
+  it("returns false for regular users", async () => {
+    await seedUser("user-1", "user");
+    expect(await isAdmin("user-1")).toBe(false);
+  });
+
+  it("returns false for non-existent users", async () => {
+    expect(await isAdmin("nonexistent")).toBe(false);
+  });
+});
+
+describe("getAdminStats", () => {
+  it("returns user and event counts", async () => {
+    await seedUser("u1");
+    await seedUser("u2");
+    await seedEvent("e1", "u1");
+
+    const stats = await getAdminStats();
+    expect(stats.totalUsers).toBe(2);
+    expect(stats.totalEvents).toBe(1);
+  });
+
+  it("returns zero counts when empty", async () => {
+    const stats = await getAdminStats();
+    expect(stats.totalUsers).toBe(0);
+    expect(stats.totalEvents).toBe(0);
+  });
+});
+
+describe("listUsers", () => {
+  it("returns paginated users", async () => {
+    await seedUser("u1");
+    await seedUser("u2");
+    await seedUser("u3");
+
+    const result = await listUsers({ page: 1, pageSize: 2 });
+    expect(result.users).toHaveLength(2);
+    expect(result.total).toBe(3);
+  });
+
+  it("filters by search query", async () => {
+    await seedUser("u1");
+    await seedUser("u2");
+
+    const result = await listUsers({ page: 1, pageSize: 10, search: "u1" });
+    expect(result.users).toHaveLength(1);
+    expect(result.users[0].id).toBe("u1");
+  });
+});


### PR DESCRIPTION
Closes #68

- Admin role field on User model
- isAdmin, getAdminStats, listUsers functions
- GET /api/admin/stats and GET /api/admin/users endpoints (admin-protected)
- 397 tests pass (7 new)