### PR TITLE
feat: reset player order + Fly.io deploy workflow (#91)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,34 @@
+name: Deploy to Fly.io
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npx vitest run
+
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Deploy to Fly.io
+        run: flyctl deploy --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/src/pages/api/events/[id]/reset-player-order.ts
+++ b/src/pages/api/events/[id]/reset-player-order.ts
@@ -1,0 +1,25 @@
+import type { APIRoute } from "astro";
+import { prisma } from "../../../../lib/db.server";
+import { checkOwnership } from "../../../../lib/auth.helpers.server";
+import { rateLimitResponse } from "../../../../lib/apiRateLimit.server";
+
+/** POST — reset player order to original signup order (createdAt). Owner-only. */
+export const POST: APIRoute = async ({ params, request }) => {
+  const limited = rateLimitResponse(request, "write");
+  if (limited) return limited;
+
+  const eventId = params.id!;
+  const event = await prisma.event.findUnique({ where: { id: eventId } });
+  if (!event) return Response.json({ error: "Not found." }, { status: 404 });
+
+  const { isOwner } = await checkOwnership(request, event.ownerId);
+  if (!isOwner) return Response.json({ error: "Only the event owner can reset player order." }, { status: 403 });
+
+  const players = await prisma.player.findMany({ where: { eventId }, orderBy: { createdAt: "asc" } });
+
+  await prisma.$transaction(
+    players.map((p, i) => prisma.player.update({ where: { id: p.id }, data: { order: i } }))
+  );
+
+  return Response.json({ ok: true });
+};

--- a/src/test/resetPlayerOrder.test.ts
+++ b/src/test/resetPlayerOrder.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { prisma } from "~/lib/db.server";
+import { POST as resetPlayerOrder } from "~/pages/api/events/[id]/reset-player-order";
+
+// Stub auth — default: no session (anonymous)
+let mockSession: any = null;
+vi.mock("~/lib/auth.helpers.server", () => ({
+  checkOwnership: vi.fn(async (_req: Request, ownerId: string | null) => ({
+    isOwner: mockSession?.user?.id != null && mockSession.user.id === ownerId,
+  })),
+  getSession: vi.fn(async () => mockSession),
+}));
+
+function ctx(params: Record<string, string>) {
+  return {
+    request: new Request("http://localhost/api/test", { method: "POST" }),
+    params,
+  } as any;
+}
+
+async function seedEvent(ownerId?: string) {
+  return prisma.event.create({
+    data: { title: "Test", location: "Field", dateTime: new Date(), ownerId },
+  });
+}
+
+beforeEach(async () => {
+  mockSession = null;
+  await prisma.player.deleteMany();
+  await prisma.event.deleteMany();
+  await prisma.session.deleteMany();
+  await prisma.account.deleteMany();
+  await prisma.user.deleteMany();
+});
+
+async function seedUser(id = "owner-1") {
+  await prisma.user.upsert({
+    where: { id },
+    update: {},
+    create: { id, name: "Owner", email: `${id}@test.com`, emailVerified: true, createdAt: new Date(), updatedAt: new Date() },
+  });
+  return id;
+}
+
+describe("POST /api/events/[id]/reset-player-order", () => {
+  it("resets player order to signup order (createdAt)", async () => {
+    const ownerId = await seedUser();
+    const event = await seedEvent(ownerId);
+    mockSession = { user: { id: ownerId } };
+
+    // Create players with staggered createdAt, then scramble order
+    const p1 = await prisma.player.create({ data: { name: "First", eventId: event.id, order: 2, createdAt: new Date("2026-01-01T10:00:00Z") } });
+    const p2 = await prisma.player.create({ data: { name: "Second", eventId: event.id, order: 0, createdAt: new Date("2026-01-01T11:00:00Z") } });
+    const p3 = await prisma.player.create({ data: { name: "Third", eventId: event.id, order: 1, createdAt: new Date("2026-01-01T12:00:00Z") } });
+
+    const res = await resetPlayerOrder(ctx({ id: event.id }));
+    expect(res.status).toBe(200);
+
+    const players = await prisma.player.findMany({ where: { eventId: event.id }, orderBy: { order: "asc" } });
+    expect(players.map((p) => p.name)).toEqual(["First", "Second", "Third"]);
+    expect(players.map((p) => p.order)).toEqual([0, 1, 2]);
+  });
+
+  it("returns 404 for unknown event", async () => {
+    const res = await resetPlayerOrder(ctx({ id: "nonexistent" }));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 for non-owner", async () => {
+    const ownerId = await seedUser();
+    const event = await seedEvent(ownerId);
+    mockSession = { user: { id: "someone-else" } };
+
+    const res = await resetPlayerOrder(ctx({ id: event.id }));
+    expect(res.status).toBe(403);
+  });
+
+  it("handles event with no players", async () => {
+    const ownerId = await seedUser();
+    const event = await seedEvent(ownerId);
+    mockSession = { user: { id: ownerId } };
+
+    const res = await resetPlayerOrder(ctx({ id: event.id }));
+    expect(res.status).toBe(200);
+  });
+});


### PR DESCRIPTION
Closes #91

## Reset player order
- `POST /api/events/[id]/reset-player-order` — owner-only endpoint
- Resets all players' `order` field to match their `createdAt` signup timestamps
- Same auth pattern as `reorder-players` (owner check + rate limiting)
- 4 new tests

## Fly.io deploy workflow
- `.github/workflows/deploy.yml` — triggers on release publish
- Runs full test suite before deploying
- Uses `FLY_API_TOKEN` secret for auth
- Deploys with `flyctl deploy --remote-only`

### Setup required
Add `FLY_API_TOKEN` as a repository secret in GitHub Settings → Secrets → Actions.

All 462 tests pass.