### PR TITLE
fix: Redirect to event page after login from event

### DIFF
--- a/src/components/ResponsiveLayout.tsx
+++ b/src/components/ResponsiveLayout.tsx
@@ -204,7 +204,7 @@ export const ResponsiveLayout: React.FC<{ children: React.ReactNode }> = ({ chil
               </>
             ) : (
               <Tooltip title={t("signIn")}>
-                <IconButton color="inherit" component="a" href="/auth/signin" aria-label={t("signIn")}>
+                <IconButton color="inherit" component="a" href={`/auth/signin?callbackURL=${encodeURIComponent(window.location.pathname + window.location.search)}`} aria-label={t("signIn")}>
                   <LoginIcon />
                 </IconButton>
               </Tooltip>

--- a/src/components/SignInPage.tsx
+++ b/src/components/SignInPage.tsx
@@ -16,6 +16,10 @@ export default function SignInPage() {
   const [unverified, setUnverified] = useState(false);
   const [loading, setLoading] = useState(false);
 
+  const callbackURL = typeof window !== "undefined"
+    ? new URLSearchParams(window.location.search).get("callbackURL") || "/"
+    : "/";
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
@@ -32,7 +36,7 @@ export default function SignInPage() {
           setError(t("authError"));
         }
       } else {
-        window.location.href = "/";
+        window.location.href = callbackURL;
       }
     } catch {
       setError(t("authError"));
@@ -42,7 +46,7 @@ export default function SignInPage() {
   };
 
   const handleGoogleSignIn = async () => {
-    await signIn.social({ provider: "google", callbackURL: "/" });
+    await signIn.social({ provider: "google", callbackURL });
   };
 
   return (
@@ -109,7 +113,7 @@ export default function SignInPage() {
 
               <Typography variant="body2" textAlign="center" color="text.secondary">
                 {t("noAccount")}{" "}
-                <Link href="/auth/signup" underline="hover">
+                <Link href={`/auth/signup?callbackURL=${encodeURIComponent(callbackURL)}`} underline="hover">
                   {t("signUp")}
                 </Link>
               </Typography>

--- a/src/components/SignUpPage.tsx
+++ b/src/components/SignUpPage.tsx
@@ -17,6 +17,10 @@ export default function SignUpPage() {
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
+  const callbackURL = typeof window !== "undefined"
+    ? new URLSearchParams(window.location.search).get("callbackURL") || "/"
+    : "/";
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
@@ -37,7 +41,7 @@ export default function SignUpPage() {
         console.error("Sign-up error:", result.error);
         setError(result.error.message || t("authSignupError"));
       } else {
-        window.location.href = "/auth/verify-email?email=" + encodeURIComponent(email);
+        window.location.href = "/auth/verify-email?email=" + encodeURIComponent(email) + "&callbackURL=" + encodeURIComponent(callbackURL);
       }
     } catch (err) {
       console.error("Sign-up exception:", err);
@@ -48,7 +52,7 @@ export default function SignUpPage() {
   };
 
   const handleGoogleSignUp = async () => {
-    await signIn.social({ provider: "google", callbackURL: "/" });
+    await signIn.social({ provider: "google", callbackURL });
   };
 
   return (
@@ -127,7 +131,7 @@ export default function SignUpPage() {
 
               <Typography variant="body2" textAlign="center" color="text.secondary">
                 {t("hasAccount")}{" "}
-                <Link href="/auth/signin" underline="hover">
+                <Link href={`/auth/signin?callbackURL=${encodeURIComponent(callbackURL)}`} underline="hover">
                   {t("signIn")}
                 </Link>
               </Typography>

--- a/src/components/VerifyEmailPage.tsx
+++ b/src/components/VerifyEmailPage.tsx
@@ -14,6 +14,7 @@ export default function VerifyEmailPage() {
   const t = useT();
   const params = new URLSearchParams(window.location.search);
   const email = params.get("email") ?? "";
+  const callbackURL = params.get("callbackURL") || "/";
   const [sent, setSent] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -71,7 +72,7 @@ export default function VerifyEmailPage() {
               </Button>
 
               <Typography variant="body2" textAlign="center" color="text.secondary">
-                <Link href="/auth/signin" underline="hover">
+                <Link href={`/auth/signin?callbackURL=${encodeURIComponent(callbackURL)}`} underline="hover">
                   {t("signIn")}
                 </Link>
               </Typography>


### PR DESCRIPTION
## Summary
- Pass current URL as `callbackURL` query parameter when navigating to sign-in page
- Use callback URL for redirects after successful email and Google authentication
- Preserve callback URL through sign-up flow and email verification page
- Fixes issue where users were redirected to home page instead of the event they were viewing

Fixes #93