### PR TITLE
feat: Improve max players input, add all languages, test bench exclusion

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -14,6 +14,14 @@
 - [x] #66 — Real-time updates via SSE (PR #89 ✅ merged)
 - [x] #68 — Admin dashboard (PR #90 ✅ merged)
 
+## In Progress
+- [ ] #93 — Redirect to event page after login (PR #99 ✅ merged)
+- [ ] #95 — Touch-friendly team picker (PR #98 ✅ merged)
+- [ ] Max players input fix — allow empty field, validate on submit (branch ready)
+- [ ] Increase max players limit from 30 to 100
+- [ ] Enable all available languages in language toggle
+- [ ] Teams should only use active players (not bench) — apply TDD
+
 ## Final verification
 - [x] All 458 tests pass on merged main
 - [x] All 10 PRs merged to main

--- a/src/components/CreateEventForm.tsx
+++ b/src/components/CreateEventForm.tsx
@@ -51,19 +51,26 @@ export default function CreateEventForm() {
   const [recurrenceInterval, setRecurrenceInterval] = useState(1);
   const [recurrenceByDay, setRecurrenceByDay] = useState("");
   const [sport, setSport] = useState("football-5v5");
-  const [maxPlayers, setMaxPlayers] = useState(10);
+  const [maxPlayers, setMaxPlayers] = useState("10");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const handleSportChange = (newSport: string) => {
     setSport(newSport);
-    setMaxPlayers(getDefaultMaxPlayers(newSport));
+    setMaxPlayers(String(getDefaultMaxPlayers(newSport)));
   };
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setSubmitting(true);
     setError(null);
+
+    const parsedMaxPlayers = parseInt(maxPlayers, 10);
+    if (isNaN(parsedMaxPlayers) || parsedMaxPlayers < 2 || parsedMaxPlayers > 100) {
+      setError(t("maxPlayersError"));
+      setSubmitting(false);
+      return;
+    }
 
     const form = e.currentTarget;
     const fd = new FormData(form);
@@ -74,7 +81,7 @@ export default function CreateEventForm() {
       dateTime: fd.get("dateTime"),
       teamOneName: fd.get("teamOneName"),
       teamTwoName: fd.get("teamTwoName"),
-      maxPlayers,
+      maxPlayers: parsedMaxPlayers,
       sport,
       isRecurring,
       recurrenceFreq: isRecurring ? recurrenceFreq : null,
@@ -178,10 +185,11 @@ export default function CreateEventForm() {
                           label={t("maxPlayers")}
                           type="number"
                           value={maxPlayers}
-                          onChange={(e) => setMaxPlayers(Math.max(2, Math.min(30, parseInt(e.target.value) || 10)))}
-                          inputProps={{ min: 2, max: 30 }}
+                          onChange={(e) => setMaxPlayers(e.target.value)}
+                          inputProps={{ min: 2, max: 100 }}
                           helperText={t("maxPlayersHelper")}
                           fullWidth
+                          error={maxPlayers !== "" && (isNaN(parseInt(maxPlayers)) || parseInt(maxPlayers) < 2 || parseInt(maxPlayers) > 100)}
                           InputProps={{
                             startAdornment: (
                               <InputAdornment position="start"><PeopleIcon fontSize="small" /></InputAdornment>

--- a/src/components/ResponsiveLayout.tsx
+++ b/src/components/ResponsiveLayout.tsx
@@ -24,6 +24,10 @@ import { useSession, signOut } from "~/lib/auth.client";
 const LOCALE_OPTIONS: { code: Locale; label: string }[] = [
   { code: "en", label: "English" },
   { code: "pt", label: "Português" },
+  { code: "es", label: "Español" },
+  { code: "fr", label: "Français" },
+  { code: "de", label: "Deutsch" },
+  { code: "it", label: "Italiano" },
 ];
 
 function ElevationScroll({ children }: { children: React.ReactElement<{ elevation?: number }> }) {

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -35,6 +35,7 @@ const de: TranslationKeys = {
   advancedOptions: "Erweiterte Optionen",
   maxPlayers: "Max. Spieler",
   maxPlayersHelper: "Spieler über diesem Limit kommen auf die Bank",
+  maxPlayersError: "Die maximale Spielerzahl muss zwischen 2 und 100 liegen",
   activePlayers: "Spielen ({n}/{max})",
   benchPlayers: "Bank ({n})",
   benchInfo: "Bankspieler werden automatisch befördert, wenn ein Platz frei wird.",

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -37,6 +37,7 @@ const en = {
   advancedOptions: "Advanced options",
   maxPlayers: "Max players",
   maxPlayersHelper: "Players beyond this limit go to the bench",
+  maxPlayersError: "Max players must be between 2 and 100",
 
   // Bench
   activePlayers: "Playing ({n}/{max})",

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -35,6 +35,7 @@ const es: TranslationKeys = {
   advancedOptions: "Opciones avanzadas",
   maxPlayers: "Máx. jugadores",
   maxPlayersHelper: "Los jugadores que excedan este límite van al banco",
+  maxPlayersError: "El máximo de jugadores debe estar entre 2 y 100",
   activePlayers: "Jugando ({n}/{max})",
   benchPlayers: "Banco ({n})",
   benchInfo: "Los jugadores en el banco son promovidos automáticamente cuando se abre un lugar.",

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -35,6 +35,7 @@ const fr: TranslationKeys = {
   advancedOptions: "Options avancées",
   maxPlayers: "Joueurs max",
   maxPlayersHelper: "Les joueurs au-delà de cette limite vont sur le banc",
+  maxPlayersError: "Le nombre de joueurs doit être entre 2 et 100",
   activePlayers: "En jeu ({n}/{max})",
   benchPlayers: "Banc ({n})",
   benchInfo: "Les joueurs sur le banc sont promus automatiquement quand une place se libère.",

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -35,6 +35,7 @@ const it: TranslationKeys = {
   advancedOptions: "Opzioni avanzate",
   maxPlayers: "Max giocatori",
   maxPlayersHelper: "I giocatori oltre questo limite vanno in panchina",
+  maxPlayersError: "Il numero massimo di giocatori deve essere tra 2 e 100",
   activePlayers: "In campo ({n}/{max})",
   benchPlayers: "Panchina ({n})",
   benchInfo: "I giocatori in panchina vengono promossi automaticamente quando si libera un posto.",

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -38,6 +38,7 @@ const pt: TranslationKeys = {
   advancedOptions: "Opções avançadas",
   maxPlayers: "Máx. jogadores",
   maxPlayersHelper: "Jogadores acima deste limite vão para o banco",
+  maxPlayersError: "O máximo de jogadores deve estar entre 2 e 100",
 
   // Bench
   activePlayers: "A jogar ({n}/{max})",

--- a/src/pages/api/events/index.ts
+++ b/src/pages/api/events/index.ts
@@ -29,7 +29,7 @@ export const POST: APIRoute = async ({ request }) => {
   const teamOneName = String(body.teamOneName ?? "Ninjas").trim().slice(0, 50) || "Ninjas";
   const teamTwoName = String(body.teamTwoName ?? "Gunas").trim().slice(0, 50) || "Gunas";
   const maxPlayersRaw = parseInt(String(body.maxPlayers ?? "10"), 10);
-  const maxPlayers = isNaN(maxPlayersRaw) || maxPlayersRaw < 2 ? 10 : Math.min(maxPlayersRaw, 30);
+  const maxPlayers = isNaN(maxPlayersRaw) || maxPlayersRaw < 2 ? 10 : Math.min(maxPlayersRaw, 100);
   const sport = String(body.sport ?? "football-5v5").trim().slice(0, 50) || "football-5v5";
   const isPublic = Boolean(body.isPublic);
   const isRecurring = Boolean(body.isRecurring);

--- a/src/test/api.test.ts
+++ b/src/test/api.test.ts
@@ -248,6 +248,42 @@ describe("POST /api/events/[id]/randomize", () => {
     const res = await randomize(ctx({ id }));
     expect(res.status).toBe(400);
   });
+
+  it("excludes bench players from team randomization", async () => {
+    const id = await seedEvent();
+    await prisma.event.update({ where: { id }, data: { maxPlayers: 4 } });
+
+    await prisma.player.createMany({
+      data: [
+        { name: "Alice", eventId: id, order: 0 },
+        { name: "Bob", eventId: id, order: 1 },
+        { name: "Carol", eventId: id, order: 2 },
+        { name: "Dave", eventId: id, order: 3 },
+        { name: "Eve", eventId: id, order: 4 },
+        { name: "Frank", eventId: id, order: 5 },
+      ],
+    });
+
+    const res = await randomize(ctx({ id }));
+    expect(res.status).toBe(200);
+
+    const teams = await prisma.teamResult.findMany({
+      where: { eventId: id },
+      include: { members: true },
+    });
+
+    const totalMembers = teams.reduce((s, t) => s + t.members.length, 0);
+
+    expect(totalMembers).toBe(4);
+
+    const allNames = teams.flatMap((t) => t.members.map((m) => m.name));
+    expect(allNames).toContain("Alice");
+    expect(allNames).toContain("Bob");
+    expect(allNames).toContain("Carol");
+    expect(allNames).toContain("Dave");
+    expect(allNames).not.toContain("Eve");
+    expect(allNames).not.toContain("Frank");
+  });
 });
 
 // ─── PUT /api/events/[id]/teams ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Allow empty input in max players field with validation on submit
- Increase max players limit from 30 to 100
- Enable all available languages (en, pt, es, fr, de, it) in language toggle
- Add TDD test validating bench players are excluded from team randomization

## Test Plan
- Added test `excludes bench players from team randomization` in `api.test.ts`
- Verified randomize endpoint already takes only `event.maxPlayers` players
- All 463 tests pass