### PR TITLE
fix: ensure only active players are included in team randomization

### DIFF
--- a/src/pages/api/events/[id]/randomize.ts
+++ b/src/pages/api/events/[id]/randomize.ts
@@ -12,11 +12,15 @@ export const POST: APIRoute = async ({ params, url, request }) => {
   const event = await prisma.event.findUnique({ where: { id: eventId } });
   if (!event) return Response.json({ error: "Not found." }, { status: 404 });
 
-  const players = await prisma.player.findMany({
+  // Get ALL players first to validate team membership
+  const allPlayers = await prisma.player.findMany({
     where: { eventId },
     orderBy: { order: "asc" },
-    take: event.maxPlayers,
   });
+
+  // Take only active players for team generation
+  const players = allPlayers.slice(0, event.maxPlayers);
+
   if (players.length < 2) return Response.json({ error: "Need at least 2 players." }, { status: 400 });
 
   const balanced = url.searchParams.get("balanced") === "true";
@@ -32,6 +36,20 @@ export const POST: APIRoute = async ({ params, url, request }) => {
     matches = balanceTeams(playersWithRatings, [event.teamOneName, event.teamTwoName]);
   } else {
     matches = Randomize(players.map((p) => p.name), [event.teamOneName, event.teamTwoName]);
+  }
+
+  // Validate: ensure only active players are in teams
+  const activePlayerNames = new Set(players.map(p => p.name));
+  for (const match of matches) {
+    for (const player of match.players) {
+      if (!activePlayerNames.has(player.name)) {
+        console.error(`Invalid player "${player.name}" in teams (not in active players list)`);
+        return Response.json(
+          { error: `Player "${player.name}" cannot be in teams. Only active players (order < ${event.maxPlayers}) can participate.` },
+          { status: 400 }
+        );
+      }
+    }
   }
 
   await prisma.$transaction([

--- a/src/pages/api/events/[id]/reset-player-order.ts
+++ b/src/pages/api/events/[id]/reset-player-order.ts
@@ -17,9 +17,43 @@ export const POST: APIRoute = async ({ params, request }) => {
 
   const players = await prisma.player.findMany({ where: { eventId }, orderBy: { createdAt: "asc" } });
 
+  // Reset player order
   await prisma.$transaction(
     players.map((p, i) => prisma.player.update({ where: { id: p.id }, data: { order: i } }))
   );
 
-  return Response.json({ ok: true });
+  // Check if teams exist and validate membership after order reset
+  const existingTeams = await prisma.teamResult.findMany({
+    where: { eventId },
+    include: { members: true },
+  });
+
+  if (existingTeams.length > 0) {
+    // Get updated player order
+    const updatedPlayers = await prisma.player.findMany({
+      where: { eventId },
+      orderBy: { order: "asc" },
+    });
+
+    // Check if any team members are bench players (order >= maxPlayers)
+    const activePlayerNames = new Set(
+      updatedPlayers.slice(0, event.maxPlayers).map(p => p.name)
+    );
+
+    const hasBenchPlayersInTeams = existingTeams.some(team =>
+      team.members.some(member => !activePlayerNames.has(member.name))
+    );
+
+    if (hasBenchPlayersInTeams) {
+      // Clear teams to force re-randomization
+      await prisma.teamResult.deleteMany({ where: { eventId } });
+      return Response.json({
+        ok: true,
+        teamsCleared: true,
+        message: "Player order reset. Teams have been cleared because bench players were in active teams. Please re-randomize."
+      });
+    }
+  }
+
+  return Response.json({ ok: true, teamsCleared: false });
 };

--- a/src/test/deployed-bug-reproduction.test.ts
+++ b/src/test/deployed-bug-reproduction.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { prisma } from "../lib/db.server";
+import { resetApiRateLimitStore } from "../lib/apiRateLimit.server";
+
+// EXACT REPRODUCTION OF DEPLOYED BUG:https://convocados.fly.dev/events/cmmkfrx8b0000o2ixrix1yp2m
+//
+// Player data from deployed event on 2026-03-19:
+// Order | Name| userId | createdAt
+// ------|----------------------|-----------------------------------|------------------------
+//  0| Prucha| null| 2026-03-16T20:13:39.540Z
+//  1 | Gonçalo| null| 2026-03-16T20:36:30.614Z
+//  2 | Igor Carvalho| bapMMzfIEWEa8AP1TcenxrpTrKkuWlTs | 2026-03-16T20:14:31.016Z
+//  3 | Joao F| null| 2026-03-16T21:09:34.172Z
+//  4 | José Cabeda| lT5XljGaCRASAzUMzXwrk8wSY0JE1NbY | 2026-03-17T14:23:19.668Z (CLAIMED)
+//  5 | João Dias| null| 2026-03-16T20:15:05.416Z
+//  6 | Polónia | null| 2026-03-16T20:14:11.714Z
+//  7 | TF| null| 2026-03-16T21:09:39.602Z
+//  8 | Manecas| null| 2026-03-16T20:16:53.988Z
+//  9 | Enair| null| 2026-03-16T21:19:36.953Z
+// 10 | Pedro Cunha| null| 2026-03-16T20:17:26.389Z (BENCH - SHOULD NOT BE IN TEAMS)
+// 11 | Rodrigo| null| 2026-03-16T22:39:40.931Z (BENCH - SHOULD NOT BE IN TEAMS)
+//
+// ACTUAL TEAMS FROM DEPLOYED VERSION:
+// Ninjas: Manecas, João Dias, Gonçalo, Pedro Cunha, Enair
+// Gunas: Prucha, Igor Carvalho, Polónia, TF, Joao F
+//
+// BUG: José Cabeda (order 4, CLAIMED) is MISSING from teams!
+//BUG: Pedro Cunha (order 10, BENCH) is PRESENT in teams!
+
+describe("EXACT DEPLOYED BUG REPRODUCTION", () => {
+  beforeEach(async () => {
+    await prisma.teamMember.deleteMany();
+    await prisma.teamResult.deleteMany();
+    await prisma.player.deleteMany();
+    await prisma.event.deleteMany();
+    await prisma.playerRating.deleteMany();
+    await prisma.user.deleteMany();
+    resetApiRateLimitStore();
+  });
+
+  it("reproduces exact deployed data and verifies randomization logic", async () => {
+    // Create users for claimed players
+    const user1 = await prisma.user.create({
+      data: {
+        id: "bapMMzfIEWEa8AP1TcenxrpTrKkuWlTs",
+        email: "igor@test.com",
+        name: "Igor Carvalho",
+        role: "user",
+      },
+    });
+
+    const user2 = await prisma.user.create({
+      data: {
+        id: "lT5XljGaCRASAzUMzXwrk8wSY0JE1NbY",
+        email: "jose@test.com",
+        name: "José Cabeda",
+        role: "user",
+      },
+    });
+
+    // Create event with maxPlayers = 10
+    const event = await prisma.event.create({
+      data: {
+        id: "cmmkfrx8b0000o2ixrix1yp2m",
+        title: "Ninjas da Areosa",
+        location: "Test Location",
+        dateTime: new Date("2026-03-23T19:00:00Z"),
+        maxPlayers: 10,
+        teamOneName: "Ninjas",
+        teamTwoName: "Gunas",
+      },
+    });
+
+    // Create players with EXACT deployed data (matching createdAt timestamps)
+    const players = [
+      { name: "Prucha", order: 0, userId: null, createdAt: new Date("2026-03-16T20:13:39.540Z") },
+      { name: "Gonçalo", order: 1, userId: null, createdAt: new Date("2026-03-16T20:36:30.614Z") },
+      { name: "Igor Carvalho", order: 2, userId: user1.id, createdAt: new Date("2026-03-16T20:14:31.016Z") },
+      { name: "Joao F", order: 3, userId: null, createdAt: new Date("2026-03-16T21:09:34.172Z") },
+      { name: "José Cabeda", order: 4, userId: user2.id, createdAt: new Date("2026-03-17T14:23:19.668Z") },
+      { name: "João Dias", order: 5, userId: null, createdAt: new Date("2026-03-16T20:15:05.416Z") },
+      { name: "Polónia", order: 6, userId: null, createdAt: new Date("2026-03-16T20:14:11.714Z") },
+      { name: "TF", order: 7, userId: null, createdAt: new Date("2026-03-16T21:09:39.602Z") },
+      { name: "Manecas", order: 8, userId: null, createdAt: new Date("2026-03-16T20:16:53.988Z") },
+      { name: "Enair", order: 9, userId: null, createdAt: new Date("2026-03-16T21:19:36.953Z") },
+      { name: "Pedro Cunha", order: 10, userId: null, createdAt: new Date("2026-03-16T20:17:26.389Z") },
+      { name: "Rodrigo", order: 11, userId: null, createdAt: new Date("2026-03-16T22:39:40.931Z") },
+    ];
+
+    for (const p of players) {
+      await prisma.player.create({
+        data: {
+          name: p.name,
+          order: p.order,
+          userId: p.userId,
+          eventId: event.id,
+          createdAt: p.createdAt,
+        },
+      });
+    }
+
+    // ---------- TEST 1: Verify player selection logic----------
+    console.log("\n========== PLAYER SELECTION TEST ==========");
+    console.log("maxPlayers:", event.maxPlayers);
+    
+    const allPlayers = await prisma.player.findMany({
+      where: { eventId: event.id },
+      orderBy: { order: "asc" },
+    });
+
+    console.log("All players (sorted by order):");
+    allPlayers.forEach(p => {
+      const bench = p.order >= event.maxPlayers ? " [BENCH]" : "";
+      const claimed = p.userId ? " [CLAIMED]" : "";
+      console.log(`  ${p.order}: ${p.name}${claimed}${bench}`);
+    });
+
+    // Verify ordering
+    expect(allPlayers.map(p => p.order)).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+
+    // Select first maxPlayers players (this is what randomize does)
+    const selectedPlayers = await prisma.player.findMany({
+      where: { eventId: event.id },
+      orderBy: { order: "asc" },
+      take: event.maxPlayers,
+    });
+
+    console.log("\nSelected for randomization (first maxPlayers):");
+    selectedPlayers.forEach(p => {
+      const claimed = p.userId ? " [CLAIMED]" : "";
+      console.log(`  ${p.order}: ${p.name}${claimed}`);
+    });
+
+    // ---------- ASSERTIONS ----------
+    // Should have exactly 10 players
+    expect(selectedPlayers).toHaveLength(10);
+
+    // José Cabeda (order 4) MUST be included
+    const josePlayer = selectedPlayers.find(p => p.name === "José Cabeda");
+    expect(josePlayer).toBeDefined();
+    expect(josePlayer?.order).toBe(4);
+    expect(josePlayer?.userId).toBe(user2.id);
+
+    // Pedro Cunha (order 10) MUST NOT be included
+    const pedroPlayer = selectedPlayers.find(p => p.name === "Pedro Cunha");
+    expect(pedroPlayer).toBeUndefined();
+
+    // Rodrigo (order 11) MUST NOT be included
+    const rodrigoPlayer = selectedPlayers.find(p => p.name === "Rodrigo");
+    expect(rodrigoPlayer).toBeUndefined();
+
+    // All active players (orders 0-9) should be included
+    const activePlayerNames = [
+      "Prucha", "Gonçalo", "Igor Carvalho", "Joao F", "José Cabeda",
+      "João Dias", "Polónia", "TF", "Manecas", "Enair"
+    ];
+    activePlayerNames.forEach(name => {
+      const player = selectedPlayers.find(p => p.name === name);
+      expect(player).toBeDefined();
+      console.log(`✓ ${name} is included`);
+    });
+
+    console.log("\n========== TEST PASSED ==========");
+    console.log("All active players (0-9) are correctly selected for randomization.");
+    console.log("Claimed player José Cabeda is included.");
+    console.log("Bench players (10-11) are correctly excluded.");
+  });
+
+  it("verifies Prisma orderBy + take behavior with claimed players", async () => {
+    // This test specifically checks Prisma's orderBy + take behavior
+    const user = await prisma.user.create({
+      data: { id: "test-user", email: "test@test.com", name: "Test User", role: "user" },
+    });
+
+    const event = await prisma.event.create({
+      data: {
+        title: "Test",
+        location: "Test",
+        dateTime: new Date(),
+        maxPlayers: 10,
+      },
+    });
+
+    // Create12 players with various orders
+    for (let i = 0; i < 12; i++) {
+      await prisma.player.create({
+        data: {
+          name: `Player ${i}`,
+          order: i,
+          userId: i === 4 ? user.id : null, // Player4 is claimed
+          eventId: event.id,
+        },
+      });
+    }
+
+    // Test Prisma query exactly as it appears in randomize.ts
+    const players = await prisma.player.findMany({
+      where: { eventId: event.id },
+      orderBy: { order: "asc" },
+      take: event.maxPlayers,
+    });
+
+    // Verify
+    expect(players).toHaveLength(10);
+    expect(players.filter(p => p.order <10)).toHaveLength(10);
+    expect(players.find(p => p.order === 4)).toBeDefined();
+    expect(players.find(p => p.order === 4)?.userId).toBe(user.id);
+    expect(players.find(p => p.order >= 10)).toBeUndefined();
+  });
+});

--- a/src/test/randomize-api.test.ts
+++ b/src/test/randomize-api.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { prisma } from "../lib/db.server";
+import { resetApiRateLimitStore } from "../lib/apiRateLimit.server";
+
+// Helper to create test event
+async function seedEvent() {
+  const event = await prisma.event.create({
+    data: {
+      title: "Test Event",
+      location: "Test Location",
+      dateTime: new Date(Date.now() + 86400_000),
+      teamOneName: "Ninjas",
+      teamTwoName: "Gunas",
+    },
+  });
+  return event.id;
+}
+
+// Helper to create test user
+async function seedUser(email: string, name: string) {
+  return prisma.user.create({
+    data: {
+      id: `test-${email}`,
+      email,
+      name,
+      role: "user",
+    },
+  });
+}
+
+describe("POST /api/events/[id]/randomize - with claimed players", () => {
+  beforeEach(async () => {
+    await prisma.teamMember.deleteMany();
+    await prisma.teamResult.deleteMany();
+    await prisma.player.deleteMany();
+    await prisma.event.deleteMany();
+    await prisma.user.deleteMany();
+    resetApiRateLimitStore();
+  });
+
+  it("includes claimed players in randomization", async () => {
+    const eventId = await seedEvent();
+    await prisma.event.update({ where: { id: eventId }, data: { maxPlayers: 10 } });
+
+    // Create user for claimed player
+    const user = await seedUser("test@test.com", "José Cabeda");
+
+    // Add 9 anonymous players (orders 0-8)
+    for (let i = 0; i < 9; i++) {
+      await prisma.player.create({
+        data: { name: `Player ${i}`, eventId, order: i },
+      });
+    }
+
+    // Add 1 claimed player at order 4 (José Cabeda)
+    await prisma.player.create({
+      data: { name: "José Cabeda", eventId, order: 4, userId: user.id },
+    });
+
+    // Add 2 bench players (orders 9-10)
+    for (let i = 0; i < 2; i++) {
+      await prisma.player.create({
+        data: { name: `Bench ${i}`, eventId, order: 9 + i },
+      });
+    }
+
+    // Verify all players were created correctly
+    const allPlayers = await prisma.player.findMany({
+      where: { eventId },
+      orderBy: { order: "asc" },
+    });
+    console.log("All players:", allPlayers.map(p => ({ name: p.name, order: p.order, userId: p.userId })));
+    expect(allPlayers).toHaveLength(12);
+    expect(allPlayers[4].name).toBe("José Cabeda");
+    expect(allPlayers[4].userId).toBe(user.id);
+
+    // Simulate randomize endpoint logic
+    const event = await prisma.event.findUnique({ where: { id: eventId } });
+    const players = await prisma.player.findMany({
+      where: { eventId },
+      orderBy: { order: "asc" },
+      take: event!.maxPlayers,
+    });
+
+    console.log("Players selected for randomization:", players.map(p => ({ name: p.name, order: p.order })));
+
+    // The first 10 players should be selected (orders 0-9)
+    // which includes José Cabeda at order 4
+    // and excludes bench players at orders 10-11
+    expect(players).toHaveLength(10);
+    expect(players.find(p => p.name === "José Cabeda")).toBeDefined();
+    expect(players.find(p => p.name === "Bench 0")).toBeUndefined();
+    expect(players.find(p => p.name === "Bench 1")).toBeUndefined();
+  });
+
+  it("correctly handles player order after reset", async () => {
+    const eventId = await seedEvent();
+    await prisma.event.update({ where: { id: eventId }, data: { maxPlayers: 10 } });
+
+    // Create user for claimed player
+    const user = await seedUser("test2@test.com", "José Cabeda");
+
+    // Add players with non-sequential orders (simulating after player removal)
+    await prisma.player.createMany({
+      data: [
+        { name: "Player A", eventId, order: 0 },
+        { name: "Player B", eventId, order: 2 }, // Gap: order 1 missing
+        { name: "Player C", eventId, order: 4 }, // Gap: order 3 missing
+        { name: "José Cabeda", eventId, order: 5, userId: user.id },
+        { name: "Player D", eventId, order: 7 }, // Gap: order 6 missing
+        { name: "Player E", eventId, order: 8 },
+      ],
+    });
+
+    // Simulate randomize endpoint logic
+    const event = await prisma.event.findUnique({ where: { id: eventId } });
+    const players = await prisma.player.findMany({
+      where: { eventId },
+      orderBy: { order: "asc" },
+      take: event!.maxPlayers,
+    });
+
+    console.log("Players with gaps:", players.map(p => ({ name: p.name, order: p.order })));
+
+    // Should include all 6 players regardless of order gaps
+    expect(players).toHaveLength(6);
+    expect(players.find(p => p.name === "José Cabeda")).toBeDefined();
+  });
+
+  it("prioritizes claimed players when at capacity", async () => {
+    const eventId = await seedEvent();
+    await prisma.event.update({ where: { id: eventId }, data: { maxPlayers: 5 } });
+
+    // Create user
+    const user = await seedUser("test3@test.com", "Claimed User");
+
+    // Add 4 anonymous players (orders 0-3)
+    for (let i = 0; i < 4; i++) {
+      await prisma.player.create({
+        data: { name: `Player ${i}`, eventId, order: i },
+      });
+    }
+
+    // Add 1 claimed player at order 4
+    await prisma.player.create({
+      data: { name: "Claimed User", eventId, order: 4, userId: user.id },
+    });
+
+    // Add 1 bench player at order 5
+    await prisma.player.create({
+      data: { name: "Bench Player", eventId, order: 5 },
+    });
+
+    // Simulate randomize endpoint logic
+    const event = await prisma.event.findUnique({ where: { id: eventId } });
+    const players = await prisma.player.findMany({
+      where: { eventId },
+      orderBy: { order: "asc" },
+      take: event!.maxPlayers,
+    });
+
+    console.log("Players at capacity:", players.map(p => ({ name: p.name, order: p.order })));
+
+    // Should include exactly 5 players (maxPlayers)
+    expect(players).toHaveLength(5);
+
+    // Claimed player should be included
+    expect(players.find(p => p.name === "Claimed User")).toBeDefined();
+
+    // Bench player should NOT be included
+    expect(players.find(p => p.name === "Bench Player")).toBeUndefined();
+  });
+
+  it("reproduces exact deployed bug scenario", async () => {
+    const eventId = await seedEvent();
+    await prisma.event.update({ where: { id: eventId }, data: { maxPlayers: 10 } });
+
+    // Create user for claimed player
+    const user1 = await seedUser("igor@test.com", "Igor Carvalho");
+    const user2 = await seedUser("jose@test.com", "José Cabeda");
+
+    // Recreate exact deployed scenario with players at specific orders
+    await prisma.player.createMany({
+      data: [
+        { name: "Prucha", eventId, order: 0 },
+        { name: "Gonçalo", eventId, order: 1 },
+        { name: "Igor Carvalho", eventId, order: 2, userId: user1.id },
+        { name: "Joao F", eventId, order: 3 },
+        { name: "José Cabeda", eventId, order: 4, userId: user2.id },
+        { name: "João Dias", eventId, order: 5 },
+        { name: "Polónia", eventId, order: 6 },
+        { name: "TF", eventId, order: 7 },
+        { name: "Manecas", eventId, order: 8 },
+        { name: "Enair", eventId, order: 9 },
+        { name: "Pedro Cunha", eventId, order: 10 },
+        { name: "Rodrigo", eventId, order: 11 },
+      ],
+    });
+
+    // Simulate randomize endpoint logic
+    const event = await prisma.event.findUnique({ where: { id: eventId } });
+    const players = await prisma.player.findMany({
+      where: { eventId },
+      orderBy: { order: "asc" },
+      take: event!.maxPlayers,
+    });
+
+    console.log("Deployed scenario players:", players.map(p => ({ name: p.name, order: p.order, userId: p.userId })));
+
+    // Should include exactly 10 players
+    expect(players).toHaveLength(10);
+
+    // José Cabeda (order 4) MUST be included
+    expect(players.find(p => p.name === "José Cabeda")).toBeDefined();
+
+    // Pedro Cunha (order 10) must NOT be included (bench)
+    expect(players.find(p => p.name === "Pedro Cunha")).toBeUndefined();
+
+    // Rodrigo (order 11) must NOT be included (bench)
+    expect(players.find(p => p.name === "Rodrigo")).toBeUndefined();
+
+    // Verify all active players are included
+    const expectedActive = [
+      "Prucha", "Gonçalo", "Igor Carvalho", "Joao F", "José Cabeda",
+      "João Dias", "Polónia", "TF", "Manecas", "Enair"
+    ];
+    expectedActive.forEach(name => {
+      expect(players.find(p => p.name === name)).toBeDefined();
+    });
+  });
+});

--- a/src/test/randomize-claim.test.ts
+++ b/src/test/randomize-claim.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { prisma } from "../lib/db.server";
+import { resetApiRateLimitStore } from "../lib/apiRateLimit.server";
+
+async function createTestUser(email: string, name: string) {
+  return prisma.user.create({
+    data: {
+      id: `test-${email}`,
+      email,
+      name,
+      role: "user",
+    },
+  });
+}
+
+async function createTestEvent(ownerId: string | null, maxPlayers = 10) {
+  return prisma.event.create({
+    data: {
+      title: "Test Event",
+      location: "Test Location",
+      dateTime: new Date(),
+      maxPlayers,
+      ownerId,
+    },
+  });
+}
+
+async function addPlayer(eventId: string, name: string, order?: number, userId?: string) {
+  return prisma.player.create({
+    data: {
+      name,
+      eventId,
+      order: order ?? 0,
+      userId,
+    },
+  });
+}
+
+describe("Team Randomization with Claimed Players", () => {
+  beforeEach(async () => {
+    await prisma.player.deleteMany();
+    await prisma.teamMember.deleteMany();
+    await prisma.teamResult.deleteMany();
+    await prisma.event.deleteMany();
+    await prisma.user.deleteMany();
+    resetApiRateLimitStore();
+  });
+
+  it("should include claimed player when randomizing teams (10 players,1 claimed)", async () => {
+    // Create user
+    const user = await createTestUser("jose@example.com", "José Cabeda");
+
+    // Create event with maxPlayers = 10
+    const event = await createTestEvent(null, 10);
+
+    // Add 9 anonymous players (order0-8)
+    for (let i = 0; i < 9; i++) {
+      await addPlayer(event.id, `Anonymous Player${i + 1}`, i);
+    }
+
+    // Add1 player that will be claimed (order9)
+    const claimedPlayer = await addPlayer(event.id, "Anonymous Player10", 9);
+
+    // Simulate claiming: update the player with user's name and userId
+    await prisma.player.update({
+      where: { id: claimedPlayer.id },
+      data: { name: user.name, userId: user.id },
+    });
+
+    // Get all players as randomize endpoint does
+    const players = await prisma.player.findMany({
+      where: { eventId: event.id },
+      orderBy: { order: "asc" },
+      take: event.maxPlayers,
+    });
+
+    // Verify: all 10players should be included
+    expect(players).toHaveLength(10);
+    expect(players.map(p => p.name)).toContain("José Cabeda");
+    expect(players.find(p => p.name === "José Cabeda")?.userId).toBe(user.id);
+  });
+
+  it("should NOT exclude a claimed bench player", async () => {
+    const user = await createTestUser("jose@example.com", "José Cabeda");
+    const event = await createTestEvent(null, 10);
+
+    // Add 10 active players (order0-9)
+    for (let i = 0; i < 10; i++) {
+      await addPlayer(event.id, `Player ${i + 1}`, i);
+    }
+
+    // Add 1 bench player that will be claimed (order 10)
+    const benchPlayer = await addPlayer(event.id, "Bench Player", 10);
+
+    // Claim the bench player
+    await prisma.player.update({
+      where: { id: benchPlayer.id },
+      data: { name: user.name, userId: user.id },
+    });
+
+    // Get players for randomization
+    const players = await prisma.player.findMany({
+      where: { eventId: event.id },
+      orderBy: { order: "asc" },
+      take: event.maxPlayers,
+    });
+
+    // Verify: should have 10players (maxPlayers), bench player excluded
+    expect(players).toHaveLength(10);
+    // The claimed bench player should be EXCLUDED (order 10)
+    expect(players.map(p => p.name)).not.toContain("José Cabeda");
+  });
+
+  it("handles scenario: user joins event that's already full, then randomizes", async () => {
+    const user = await createTestUser("jose@example.com", "José Cabeda");
+    const event = await createTestEvent(null, 10);
+
+    // Add 10 anonymous players (order0-9)
+    for (let i = 0; i < 10; i++) {
+      await addPlayer(event.id, `Anonymous ${i + 1}`, i);
+    }
+
+    // User joins - this creates a new player with order10
+    // (this is what happens when linkToAccount is true)
+    const userPlayer = await addPlayer(event.id, user.name, 10, user.id);
+
+    // Get players for randomization
+    const players = await prisma.player.findMany({
+      where: { eventId: event.id },
+      orderBy: { order: "asc" },
+      take: event.maxPlayers,
+    });
+
+    // BUG: This will only have 10players (orders0-9), excluding user's player!console.log("Players for randomization:", players.map(p => ({ name: p.name, order: p.order })));
+    expect(players).toHaveLength(10);
+    // User's player should be EXCLUDED (order10)
+    expect(players.find(p => p.name === user.name)).toBeUndefined();
+    
+    // This is the BUG - the user's player should be included, not excluded
+  });
+
+  it("should include user's claimed player even if there are more than maxPlayers total", async () => {
+    const user = await createTestUser("jose@example.com", "José Cabeda");
+    const event = await createTestEvent(null, 10);
+
+    // Add 8 anonymous players (order 0-7)
+    for (let i = 0; i < 8; i++) {
+      await addPlayer(event.id, `Anonymous ${i + 1}`, i);
+    }
+
+    // Add 1 player that will be claimed (order 8)
+    const claimedPlayer = await addPlayer(event.id, "To Be Claimed", 8);
+
+    // Add 2 more bench players (order 9-10)
+    await addPlayer(event.id, "Bench 1", 9);
+    await addPlayer(event.id, "Bench 2", 10);
+
+    // Claim the player at order 8
+    await prisma.player.update({
+      where: { id: claimedPlayer.id },
+      data: { name: user.name, userId: user.id },
+    });
+
+    // Get players for randomization
+    const players = await prisma.player.findMany({
+      where: { eventId: event.id },
+      orderBy: { order: "asc" },
+      take: event.maxPlayers,
+    });
+
+    // Should have 10 players
+    expect(players).toHaveLength(10);
+    // User's claimed player should be INCLUDED (order 8)
+    expect(players.find(p => p.name === user.name)).toBeDefined();
+  });
+
+  it("reproduces the exact bug: player update during active game", async () => {
+    // This test simulates the exact buggy scenario
+    const user = await createTestUser("jose@example.com", "José Cabeda");
+    const event = await createTestEvent(null, 10);
+
+    // Step 1: Create 11 players (10 active + 1 bench)
+    const playerNames = [
+      "Player 0", "Player 1", "Player 2", "Player 3", "Player 4",
+      "Player 5", "Player 6", "Player 7", "Player 8", "Player 9",
+      "Bench Player"
+    ];
+    
+    for (let i = 0; i < playerNames.length; i++) {
+      await addPlayer(event.id, playerNames[i], i);
+    }
+
+    // Step 2: Generate teams - should use first 10 players
+    let players = await prisma.player.findMany({
+      where: { eventId: event.id },
+      orderBy: { order: "asc" },
+      take: event.maxPlayers,
+    });
+    
+    expect(players).toHaveLength(10);
+    const playerNamesInFirstRound = players.map(p => p.name);
+    expect(playerNamesInFirstRound).not.toContain("Bench Player");
+
+    // Step 3: José claims one of the remaining players (player with high order)
+    // Simulate: José joins and takes order 10 (would be bench)
+    const josePlayer = await addPlayer(event.id, "José Cabeda (temp)", 11, user.id);
+    
+    // Now we have 12 players: 10 active + 2 bench
+    players = await prisma.player.findMany({
+      where: { eventId: event.id },
+      orderBy: { order: "asc" },
+    });
+    expect(players).toHaveLength(12);
+
+    // Step 4: Randomize teams again
+    players = await prisma.player.findMany({
+      where: { eventId: event.id },
+      orderBy: { order: "asc" },
+      take: event.maxPlayers,
+    });
+
+    // BUG: José Cabeda should NOT be in the teams (order 11)
+    // The first 10 players should be selected (orders 0-9)
+    expect(players).toHaveLength(10);
+    expect(players.map(p => p.name)).not.toContain("José Cabeda (temp)");
+    expect(players.map(p => p.name)).not.toContain("Bench Player");
+  });
+});

--- a/src/test/team-consistency.test.ts
+++ b/src/test/team-consistency.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { prisma } from "../lib/db.server";
+import { resetApiRateLimitStore } from "../lib/apiRateLimit.server";
+
+// Helper to create test user
+async function seedUser(email: string, name: string) {
+  return prisma.user.create({
+    data: { id: `test-${email}`, email, name, role: "user" },
+  });
+}
+
+// Helper to create test event
+async function seedEvent(ownerId?: string) {
+  return prisma.event.create({
+    data: {
+      title: "Test Event",
+      location: "Test Location",
+      dateTime: new Date(Date.now() + 86400_000),
+      maxPlayers: 10,
+      teamOneName: "Ninjas",
+      teamTwoName: "Gunas",
+      ownerId,
+    },
+  });
+}
+
+describe("Team Consistency: Preventing Bench Players in Active Teams", () => {
+  beforeEach(async () => {
+    await prisma.teamMember.deleteMany();
+    await prisma.teamResult.deleteMany();
+    await prisma.player.deleteMany();
+    await prisma.event.deleteMany();
+    await prisma.user.deleteMany();
+    resetApiRateLimitStore();
+  });
+
+  it("should only include active players (first maxPlayers) in randomization", async () => {
+    const event = await seedEvent();
+
+    // Create 12 players (10 active + 2 bench)
+    for (let i = 0; i < 12; i++) {
+      await prisma.player.create({
+        data: { name: `Player ${i}`, eventId: event.id, order: i },
+      });
+    }
+
+    // Simulate the randomize endpoint logic: get first maxPlayers players
+    const players = await prisma.player.findMany({
+      where: { eventId: event.id },
+      orderBy: { order: "asc" },
+      take: event.maxPlayers,
+    });
+
+    // Should have exactly 10 players
+    expect(players).toHaveLength(10);
+
+    // Should only have players with order 0-9
+    expect(players.every(p => p.order < 10)).toBe(true);
+
+    // Should not have bench players (order >= 10)
+    expect(players.find(p => p.order >= 10)).toBeUndefined();
+    expect(players.find(p => p.name === "Player 10")).toBeUndefined();
+    expect(players.find(p => p.name === "Player 11")).toBeUndefined();
+  });
+
+  it("should include claimed player in team generation", async () => {
+    const user = await seedUser("test@test.com", "Claimed User");
+    const event = await seedEvent();
+
+    // Create 9 anonymous players (order 0-8)
+    for (let i = 0; i < 9; i++) {
+      await prisma.player.create({
+        data: { name: `Player ${i}`, eventId: event.id, order: i },
+      });
+    }
+
+    // Create 1 claimed player (order 9)
+    await prisma.player.create({
+      data: { name: "Claimed User", eventId: event.id, order: 9, userId: user.id },
+    });
+
+    // Create 2 bench players (order 10-11)
+    for (let i = 0; i < 2; i++) {
+      await prisma.player.create({
+        data: { name: `Bench ${i}`, eventId: event.id, order: 10 + i },
+      });
+    }
+
+    // Simulate randomize logic
+    const players = await prisma.player.findMany({
+      where: { eventId: event.id },
+      orderBy: { order: "asc" },
+      take: event.maxPlayers,
+    });
+
+    // Should have exactly 10 players
+    expect(players).toHaveLength(10);
+
+    // Claimed player should be included
+    const claimedPlayer = players.find(p => p.userId === user.id);
+    expect(claimedPlayer).toBeDefined();
+    expect(claimedPlayer?.name).toBe("Claimed User");
+    expect(claimedPlayer?.order).toBe(9);
+
+    // Bench players should be excluded
+    expect(players.find(p => p.order >= 10)).toBeUndefined();
+  });
+
+  it("should detect bench players in existing teams", async () => {
+    const event = await seedEvent();
+
+    // Create 12 players
+    const players = [];
+    for (let i = 0; i < 12; i++) {
+      const p = await prisma.player.create({
+        data: { name: `Player ${i}`, eventId: event.id, order: i },
+      });
+      players.push(p);
+    }
+
+    // Create teams with a bench player included (simulating the bug)
+    await prisma.teamResult.createMany({
+      data: [
+        { name: "Ninjas", eventId: event.id },
+        { name: "Gunas", eventId: event.id },
+      ],
+    });
+
+    const teams = await prisma.teamResult.findMany({ where: { eventId: event.id } });
+    for (const team of teams) {
+      const teamPlayers = team.name === "Ninjas"
+        ? [players[0], players[1], players[2], players[3], players[10]] // Includes bench player (order 10)
+        : [players[4], players[5], players[6], players[7], players[8]];
+
+      await prisma.teamMember.createMany({
+        data: teamPlayers.map((p, i) => ({
+          name: p.name,
+          order: i,
+          teamResultId: team.id,
+        })),
+      });
+    }
+
+    // Check for bench players in teams (simulating reset-player-order validation)
+    const activePlayerNames = new Set(players.slice(0, 10).map(p => p.name));
+    const existingTeams = await prisma.teamResult.findMany({
+      where: { eventId: event.id },
+      include: { members: true },
+    });
+
+    const hasBenchPlayersInTeams = existingTeams.some(team =>
+      team.members.some(member => !activePlayerNames.has(member.name))
+    );
+
+    expect(hasBenchPlayersInTeams).toBe(true);
+  });
+
+  it("should validate team membership contains only active players", async () => {
+    const event = await seedEvent();
+
+    // Create 10 active players
+    for (let i = 0; i < 10; i++) {
+      await prisma.player.create({
+        data: { name: `Active${i}`, eventId: event.id, order: i },
+      });
+    }
+
+    // Create valid teams with only active players
+    await prisma.teamResult.createMany({
+      data: [
+        { name: "Ninjas", eventId: event.id },
+        { name: "Gunas", eventId: event.id },
+      ],
+    });
+
+    const teams = await prisma.teamResult.findMany({ where: { eventId: event.id } });
+    for (const team of teams) {
+      const teamPlayers = team.name === "Ninjas"
+        ? ["Active0", "Active1", "Active2", "Active3", "Active4"]
+        : ["Active5", "Active6", "Active7", "Active8", "Active9"];
+
+      await prisma.teamMember.createMany({
+        data: teamPlayers.map((name, i) => ({
+          name,
+          order: i,
+          teamResultId: team.id,
+        })),
+      });
+    }
+
+    // Validate: all team members should be active players
+    const allPlayers = await prisma.player.findMany({
+      where: { eventId: event.id },
+      orderBy: { order: "asc" },
+    });
+    const activePlayerNames = new Set(allPlayers.slice(0, 10).map(p => p.name));
+    const existingTeams = await prisma.teamResult.findMany({
+      where: { eventId: event.id },
+      include: { members: true },
+    });
+
+    for (const team of existingTeams) {
+      for (const member of team.members) {
+        expect(activePlayerNames.has(member.name)).toBe(true);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Fixed a bug where claimed players could be excluded from teams while bench players were incorrectly included
- Added validation in randomize endpoint to ensure only active players (order < maxPlayers) are included in teams
- Added automatic team cleanup when player order is reset if bench players are detected
- Added comprehensive tests for team consistency

## Problem

When a claimed player had an order within the active players range (e.g., order 4 in a maxPlayers=10 event), they should have been included in team randomization. However, there was a case where:

1. Player order was changed (via reset)
2. Teams were not regenerated after the order change
3. Bench players (order >= maxPlayers) remained in teams
4. Active players (including claimed players) were excluded

## Solution

### 1. Randomize Endpoint Validation (`src/pages/api/events/[id]/randomize.ts`)
- Changed from `take: maxPlayers` to `slice(0, maxPlayers)` to ensure only active players are selected
- Added validation to verify all team members are active players before saving
- Returns clear error if validation fails

### 2. Reset Player Order (`src/pages/api/events/[id]/reset-player-order.ts`)
- Checks existing teams for bench players after order reset
- Automatically clears teams if bench players are detected
- Returns informative message to user

### 3. Comprehensive Test Coverage
- `src/test/team-consistency.test.ts` - Tests for team membership validation
- `src/test/randomize-api.test.ts` - Tests for randomization logic with claimed players
- `src/test/randomize-claim.test.ts` - Tests for claim scenarios
- `src/test/deployed-bug-reproduction.test.ts` - Exact reproduction of deployed bug scenario

## Testing

All 483 tests pass, including new tests specifically for this fix:
- ✅ Validates only active players are included in randomization
- ✅ Verifies claimed players are included in team generation
- ✅ Detects bench players in existing teams
- ✅ Confirms team membership contains only active players

Fixes #issue