### PR TITLE
fix: add Content-Type header to POST requests for CSRF protection

### DIFF
--- a/src/components/EventPage.tsx
+++ b/src/components/EventPage.tsx
@@ -690,7 +690,10 @@ export default function EventPage({ eventId }: { eventId: string }) {
   }, [eventId, mutate]);
 
   const resetPlayerOrder = useCallback(async () => {
-    const res = await fetch(`/api/events/${eventId}/reset-player-order`, { method: "POST" });
+    const res = await fetch(`/api/events/${eventId}/reset-player-order`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+    });
     if (res.ok) mutate();
   }, [eventId, mutate]);
 
@@ -725,7 +728,10 @@ export default function EventPage({ eventId }: { eventId: string }) {
   const doRandomize = async () => {
     setConfirmOpen(false);
     const qs = balanced ? "?balanced=true" : "";
-    const res = await fetch(`/api/events/${eventId}/randomize${qs}`, { method: "POST" });
+    const res = await fetch(`/api/events/${eventId}/randomize${qs}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+    });
     const json = await res.json();
     if (!res.ok) { setPlayerError(json.error); return; }
     mutate();
@@ -799,7 +805,10 @@ export default function EventPage({ eventId }: { eventId: string }) {
   const canClaimPlayer = isAuthenticated && !userHasLinkedPlayer;
 
   const handleClaimOwnership = async () => {
-    const res = await fetch(`/api/events/${eventId}/claim`, { method: "POST" });
+    const res = await fetch(`/api/events/${eventId}/claim`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+    });
     if (res.ok) {
       mutate();
       setSnackbar(t("claimOwnership"));


### PR DESCRIPTION
## Summary
- Add `Content-Type: application/json` header to three POST requests that were missing it
- Fixes 403 "Cross-site POST form submissions are forbidden" error when clicking reset order, randomize, or claim ownership buttons

## Root Cause
Astro's `security: { checkOrigin: true }` configuration requires POST requests to have proper Content-Type headers. Three endpoints were missing this header while all other POST/PUT requests already included it.

## Changes
- `reset-player-order` - added Content-Type header
- `randomize` - added Content-Type header  
- `claim` - added Content-Type header

## Testing
- All 483 tests pass
- TypeScript type checking passes