### PR TITLE
feat: reorganize event management UI with progressive disclosure

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "db:migrate": "prisma migrate dev",
     "db:push": "prisma db push",
     "db:studio": "prisma studio",
+    "db:seed": "npx tsx prisma/seed.ts",
     "lhci": "lhci autorun --config=lighthouserc.cjs"
   },
   "dependencies": {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,177 @@
+/**
+ * Seed script — inserts 100 sample events into the dev SQLite database.
+ *
+ * Usage:  npm run db:seed
+ *
+ * Each event gets a random sport, 4-12 players, a location, and a date
+ * spread across the next 30 days (some in the past for history testing).
+ */
+
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+const SPORTS = [
+  "football-5v5",
+  "football-7v7",
+  "football-11v11",
+  "futsal",
+  "basketball",
+  "volleyball",
+  "tennis-singles",
+  "tennis-doubles",
+  "padel",
+  "other",
+];
+
+const LOCATIONS = [
+  "Riverside Astro, Pitch 1",
+  "Central Park Courts",
+  "Downtown Sports Hall",
+  "Beachside Arena",
+  "University Gym",
+  "Olympic Stadium, Field B",
+  "Sunset Recreation Center",
+  "Hilltop Tennis Club",
+  "Padel World, Court 3",
+  "Community Center Gym",
+  "Eastside Football Ground",
+  "Lakefront Sports Complex",
+  "",
+];
+
+const FIRST_NAMES = [
+  "Alex", "Bruno", "Carlos", "Diana", "Elena", "Fábio", "Gonçalo", "Helena",
+  "Igor", "Joana", "Kevin", "Lara", "Miguel", "Nuno", "Olga", "Pedro",
+  "Quim", "Rita", "Sofia", "Tiago", "Ursula", "Vasco", "Wanda", "Xavier",
+  "Yara", "Zé", "André", "Beatriz", "Catarina", "Diogo", "Eva", "Filipe",
+  "Gustavo", "Inês", "Jorge", "Kátia", "Luís", "Marta", "Nelson", "Patrícia",
+];
+
+const TITLE_TEMPLATES = [
+  "{day} {sport} session",
+  "{sport} — {location}",
+  "Weekly {sport}",
+  "{sport} pickup game",
+  "Casual {sport} match",
+  "{day} night {sport}",
+  "Lunchtime {sport}",
+  "{sport} tournament",
+  "Friendly {sport}",
+  "{sport} league game",
+];
+
+const DAYS = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"];
+
+const SPORT_LABELS: Record<string, string> = {
+  "football-5v5": "Football 5v5",
+  "football-7v7": "Football 7v7",
+  "football-11v11": "Football 11v11",
+  futsal: "Futsal",
+  basketball: "Basketball",
+  volleyball: "Volleyball",
+  "tennis-singles": "Tennis",
+  "tennis-doubles": "Tennis Doubles",
+  padel: "Padel",
+  other: "Sports",
+};
+
+const SPORT_MAX_PLAYERS: Record<string, number> = {
+  "football-5v5": 10,
+  "football-7v7": 14,
+  "football-11v11": 22,
+  futsal: 10,
+  basketball: 10,
+  volleyball: 12,
+  "tennis-singles": 2,
+  "tennis-doubles": 4,
+  padel: 4,
+  other: 10,
+};
+
+function pick<T>(arr: T[]): T {
+  return arr[Math.floor(Math.random() * arr.length)];
+}
+
+function randInt(min: number, max: number): number {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+function generateTitle(sport: string, location: string): string {
+  const template = pick(TITLE_TEMPLATES);
+  const day = pick(DAYS);
+  const sportLabel = SPORT_LABELS[sport] ?? "Sports";
+  const loc = location || "TBD";
+  return template
+    .replace("{day}", day)
+    .replace("{sport}", sportLabel)
+    .replace("{location}", loc);
+}
+
+function uniqueNames(count: number): string[] {
+  const shuffled = [...FIRST_NAMES].sort(() => Math.random() - 0.5);
+  return shuffled.slice(0, Math.min(count, shuffled.length));
+}
+
+async function main() {
+  console.log("Seeding 100 sample events...\n");
+
+  const now = Date.now();
+
+  for (let i = 0; i < 100; i++) {
+    const sport = pick(SPORTS);
+    const location = pick(LOCATIONS);
+    const maxPlayers = SPORT_MAX_PLAYERS[sport] ?? 10;
+
+    // Spread dates: ~30% in the past, ~70% in the future
+    const offsetDays = randInt(-10, 30);
+    const offsetHours = randInt(8, 22); // games between 8am and 10pm
+    const dateTime = new Date(now + offsetDays * 86400000);
+    dateTime.setHours(offsetHours, 0, 0, 0);
+
+    const title = generateTitle(sport, location);
+    const isPublic = Math.random() < 0.4;
+    const isRecurring = Math.random() < 0.25;
+    const balanced = Math.random() < 0.2;
+
+    const recurrenceRule = isRecurring
+      ? JSON.stringify({ freq: "weekly", interval: 1 })
+      : null;
+
+    const playerCount = randInt(Math.min(4, maxPlayers), maxPlayers);
+    const playerNames = uniqueNames(playerCount);
+
+    const event = await prisma.event.create({
+      data: {
+        title,
+        location,
+        dateTime,
+        maxPlayers,
+        sport,
+        isPublic,
+        isRecurring,
+        balanced,
+        recurrenceRule,
+        teamOneName: "Ninjas",
+        teamTwoName: "Gunas",
+        players: {
+          create: playerNames.map((name, order) => ({ name, order })),
+        },
+      },
+    });
+
+    const status = offsetDays < 0 ? "(past)" : offsetDays === 0 ? "(today)" : "(upcoming)";
+    console.log(
+      `  [${String(i + 1).padStart(3)}] ${event.id}  ${title.padEnd(40)} ${playerCount}/${maxPlayers} players  ${status}`
+    );
+  }
+
+  console.log("\nDone — 100 events created.");
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());

--- a/src/components/EventPage.tsx
+++ b/src/components/EventPage.tsx
@@ -32,6 +32,7 @@ import RestartAltIcon from "@mui/icons-material/RestartAlt";
 import DragIndicatorIcon from "@mui/icons-material/DragIndicator";
 import StarIcon from "@mui/icons-material/Star";
 import CalendarMonthIcon from "@mui/icons-material/CalendarMonth";
+import SettingsIcon from "@mui/icons-material/Settings";
 import { ThemeModeProvider } from "./ThemeModeProvider";
 import { ResponsiveLayout } from "./ResponsiveLayout";
 import { TeamPicker } from "./TeamPicker";
@@ -982,6 +983,8 @@ export default function EventPage({ eventId }: { eventId: string }) {
                 </Box>
 
                 <Divider />
+
+                {/* ── Quick Actions — always visible ── */}
                 <Stack spacing={1}>
                   <ShareBar title={event.title} />
                   <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap", alignItems: "center" }}>
@@ -1010,48 +1013,9 @@ export default function EventPage({ eventId }: { eventId: string }) {
                       {t("addToGoogleCalendar")}
                     </Button>
                     <NotifyButton eventId={eventId} />
-                    {canEditSettings && (
-                      <Tooltip title={t("makePublicTooltip")}>
-                        <FormControlLabel
-                          control={
-                            <Switch size="small" checked={isPublic}
-                              onChange={(e) => handleTogglePublic(e.target.checked)} />
-                          }
-                          label={
-                            <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
-                              <PublicIcon fontSize="small" />
-                              <Typography variant="body2">{t("makePublic")}</Typography>
-                            </Box>
-                          }
-                          sx={{ ml: 0 }}
-                        />
-                      </Tooltip>
-                    )}
-                    {canEditSettings && (
-                      <FormControl size="small" sx={{ minWidth: 140 }}>
-                        <Select
-                          value={sport}
-                          onChange={(e) => handleSportChange(e.target.value)}
-                          sx={{ fontSize: "0.85rem" }}
-                        >
-                          {SPORT_PRESETS.map((s) => (
-                            <MenuItem key={s.id} value={s.id} sx={{ fontSize: "0.85rem" }}>
-                              {t(s.labelKey as any)}
-                            </MenuItem>
-                          ))}
-                        </Select>
-                      </FormControl>
-                    )}
-                    {/* Owner badge + relinquish */}
+                    {/* Owner badge — always visible for owners */}
                     {isOwner && (
-                      <>
-                        <Chip icon={<StarIcon />} label={t("ownerBadge")} size="small" color="success" variant="outlined" />
-                        <Tooltip title={t("relinquishOwnershipDesc")}>
-                          <Button variant="text" size="small" color="warning" onClick={() => setRelinquishConfirmOpen(true)}>
-                            {t("relinquishOwnership")}
-                          </Button>
-                        </Tooltip>
-                      </>
+                      <Chip icon={<StarIcon />} label={t("ownerBadge")} size="small" color="success" variant="outlined" />
                     )}
                     {/* Claim ownership for authenticated users on ownerless events */}
                     {isAuthenticated && isOwnerless && (
@@ -1062,8 +1026,82 @@ export default function EventPage({ eventId }: { eventId: string }) {
                   </Box>
                 </Stack>
 
-                {/* Integrations — hidden by default, for developers */}
-                {canEditSettings && <WebhookInfo eventId={eventId} />}
+                {/* ── Event Settings — collapsed accordion for owner/advanced controls ── */}
+                {canEditSettings && (
+                  <Accordion
+                    disableGutters
+                    elevation={0}
+                    sx={{
+                      "&:before": { display: "none" },
+                      backgroundColor: "transparent",
+                    }}
+                  >
+                    <AccordionSummary
+                      expandIcon={<ExpandMoreIcon />}
+                      sx={{ px: 0, minHeight: 0, "& .MuiAccordionSummary-content": { my: 0.5 } }}
+                    >
+                      <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+                        <SettingsIcon fontSize="small" color="action" />
+                        <Typography variant="body2" color="text.secondary">
+                          {t("eventSettings")}
+                        </Typography>
+                      </Box>
+                    </AccordionSummary>
+                    <AccordionDetails sx={{ px: 0, pt: 0 }}>
+                      <Stack spacing={2}>
+                        <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap", alignItems: "center" }}>
+                          <Tooltip title={t("makePublicTooltip")}>
+                            <FormControlLabel
+                              control={
+                                <Switch size="small" checked={isPublic}
+                                  onChange={(e) => handleTogglePublic(e.target.checked)} />
+                              }
+                              label={
+                                <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+                                  <PublicIcon fontSize="small" />
+                                  <Typography variant="body2">{t("makePublic")}</Typography>
+                                </Box>
+                              }
+                              sx={{ ml: 0 }}
+                            />
+                          </Tooltip>
+                          <FormControl size="small" sx={{ minWidth: 140 }}>
+                            <Select
+                              value={sport}
+                              onChange={(e) => handleSportChange(e.target.value)}
+                              sx={{ fontSize: "0.85rem" }}
+                            >
+                              {SPORT_PRESETS.map((s) => (
+                                <MenuItem key={s.id} value={s.id} sx={{ fontSize: "0.85rem" }}>
+                                  {t(s.labelKey as any)}
+                                </MenuItem>
+                              ))}
+                            </Select>
+                          </FormControl>
+                        </Box>
+                        {/* Balanced teams toggle */}
+                        <Tooltip title={t("balancedTeamsTooltip")}>
+                          <FormControlLabel
+                            control={<Switch size="small" checked={balanced} onChange={(e) => handleToggleBalanced(e.target.checked)} />}
+                            label={t("balancedTeams")}
+                          />
+                        </Tooltip>
+                        {/* Owner controls — relinquish */}
+                        {isOwner && (
+                          <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap", alignItems: "center" }}>
+                            <Tooltip title={t("relinquishOwnershipDesc")}>
+                              <Button variant="text" size="small" color="warning" onClick={() => setRelinquishConfirmOpen(true)}>
+                                {t("relinquishOwnership")}
+                              </Button>
+                            </Tooltip>
+                          </Box>
+                        )}
+                        {/* Integrations */}
+                        <WebhookInfo eventId={eventId} />
+                      </Stack>
+                    </AccordionDetails>
+                  </Accordion>
+                )}
               </Stack>
             </Paper>
 
@@ -1312,14 +1350,6 @@ export default function EventPage({ eventId }: { eventId: string }) {
                       )}
 
                       <Box sx={{ display: "flex", justifyContent: "center", alignItems: "center", gap: 2 }}>
-                        {canEditSettings && (
-                          <Tooltip title={t("balancedTeamsTooltip")}>
-                            <FormControlLabel
-                              control={<Switch size="small" checked={balanced} onChange={(e) => handleToggleBalanced(e.target.checked)} />}
-                              label={t("balancedTeams")}
-                            />
-                          </Tooltip>
-                        )}
                         <Button variant="contained" size="large" startIcon={<ShuffleIcon />}
                           disabled={active.length < 2} sx={{ px: 4, py: 1.5 }}
                           onClick={() => localMatches && localMatches.length > 0 ? setConfirmOpen(true) : doRandomize()}>

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -247,6 +247,11 @@ const de: TranslationKeys = {
   changeEmailBtn: "Bestätigung senden",
   changeEmailSent: "Bestätigungs-E-Mail an deine neue Adresse gesendet. Prüfe deinen Posteingang.",
   resetPlayerOrder: "Reihenfolge auf Anmeldereihenfolge zurücksetzen",
+
+  // Event management sections
+  quickActions: "Schnellaktionen",
+  eventSettings: "Event-Einstellungen",
+  eventSettingsDesc: "Sichtbarkeit, Sportart, ausgeglichene Teams und Integrationen",
 };
 
 export default de;

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -293,6 +293,11 @@ const en = {
   changeEmailBtn: "Send verification",
   changeEmailSent: "Verification email sent to your new address. Check your inbox.",
   resetPlayerOrder: "Reset order to sign-up order",
+
+  // Event management sections
+  quickActions: "Quick Actions",
+  eventSettings: "Event Settings",
+  eventSettingsDesc: "Visibility, sport, balanced teams, and integrations",
 } as const;
 
 export default en;

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -247,6 +247,11 @@ const es: TranslationKeys = {
   changeEmailBtn: "Enviar verificación",
   changeEmailSent: "Email de verificación enviado a tu nueva dirección. Revisa tu bandeja de entrada.",
   resetPlayerOrder: "Restablecer orden de inscripción",
+
+  // Event management sections
+  quickActions: "Acciones Rápidas",
+  eventSettings: "Configuración del Evento",
+  eventSettingsDesc: "Visibilidad, deporte, equipos equilibrados e integraciones",
 };
 
 export default es;

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -247,6 +247,11 @@ const fr: TranslationKeys = {
   changeEmailBtn: "Envoyer la vérification",
   changeEmailSent: "Email de vérification envoyé à ta nouvelle adresse. Vérifie ta boîte de réception.",
   resetPlayerOrder: "Réinitialiser l'ordre d'inscription",
+
+  // Event management sections
+  quickActions: "Actions Rapides",
+  eventSettings: "Paramètres de l'Événement",
+  eventSettingsDesc: "Visibilité, sport, équipes équilibrées et intégrations",
 };
 
 export default fr;

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -247,6 +247,11 @@ const it: TranslationKeys = {
   changeEmailBtn: "Invia verifica",
   changeEmailSent: "Email di verifica inviata al tuo nuovo indirizzo. Controlla la tua casella di posta.",
   resetPlayerOrder: "Ripristina ordine di iscrizione",
+
+  // Event management sections
+  quickActions: "Azioni Rapide",
+  eventSettings: "Impostazioni Evento",
+  eventSettingsDesc: "Visibilità, sport, squadre equilibrate e integrazioni",
 };
 
 export default it;

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -294,6 +294,11 @@ const pt: TranslationKeys = {
   changeEmailBtn: "Enviar verificação",
   changeEmailSent: "Email de verificação enviado para o novo endereço. Verifica a tua caixa de entrada.",
   resetPlayerOrder: "Repor ordem de inscrição",
+
+  // Event management sections
+  quickActions: "Ações Rápidas",
+  eventSettings: "Definições do Evento",
+  eventSettingsDesc: "Visibilidade, desporto, equipas equilibradas e integrações",
 };
 
 export default pt;


### PR DESCRIPTION
Closes #111

## Changes

Reorganizes the event management UI in EventPage with progressive disclosure:

**Quick Actions (always visible):**
- Share bar, History, Calendar buttons, Notifications
- Owner badge chip, Claim ownership button

**Event Settings (collapsed accordion, owner-only):**
- Public/private visibility toggle
- Sport selector
- Balanced teams toggle (moved from players section)
- Relinquish ownership
- Webhook integrations

**Seed script:**
- Added `npm run db:seed` to insert 100 sample events into the dev SQLite database for local testing

**i18n:**
- Added `quickActions`, `eventSettings`, `eventSettingsDesc` to all 6 locales (en, pt, es, fr, de, it)

## Testing
- All 483 tests pass
- TypeScript typecheck clean
- i18n key parity verified across all locales