### PR TITLE
feat: add MB Way app deep link for mobile users

### DIFF
--- a/src/components/PaymentSection.tsx
+++ b/src/components/PaymentSection.tsx
@@ -22,6 +22,7 @@ import {
   parsePaymentMethods,
   getDeepLink,
   getDisplayValue,
+  getMbwayAppLink,
 } from "~/lib/paymentMethods";
 
 interface PaymentData {
@@ -354,9 +355,28 @@ export function PaymentSection({
                               {display}
                             </Typography>
                             {m.type === "mbway" && (
-                              <Typography variant="caption" color="text.secondary" sx={{ fontStyle: "italic" }}>
-                                {t("paymentMethodMbwayInstructions")}
-                              </Typography>
+                              <>
+                                <Typography variant="caption" color="text.secondary" sx={{ fontStyle: "italic" }}>
+                                  {t("paymentMethodMbwayInstructions")}
+                                </Typography>
+                                {(() => {
+                                  const mbLink = getMbwayAppLink(typeof navigator !== "undefined" ? navigator.userAgent : undefined);
+                                  return mbLink ? (
+                                    <Button
+                                      size="small"
+                                      variant="outlined"
+                                      color="primary"
+                                      component="a"
+                                      href={mbLink}
+                                      target="_blank"
+                                      rel="noopener noreferrer"
+                                      sx={{ mt: 0.5, textTransform: "none", fontSize: "0.75rem" }}
+                                    >
+                                      {t("paymentMethodOpenMbway")}
+                                    </Button>
+                                  ) : null;
+                                })()}
+                              </>
                             )}
                           </Box>
                           {deepLink && (

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -297,6 +297,7 @@ const de: TranslationKeys = {
   paymentMethodCopy: "Kopieren",
   paymentMethodCallPhone: "Anrufen",
   paymentMethodMbwayInstructions: "Öffne MB Way und sende an diese Nummer",
+  paymentMethodOpenMbway: "MB Way App öffnen",
 
   // Account management (#106, #107, #108)
   changePassword: "Passwort ändern",

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -343,6 +343,7 @@ const en = {
   paymentMethodCopy: "Copy",
   paymentMethodCallPhone: "Call",
   paymentMethodMbwayInstructions: "Open MB Way and send to this number",
+  paymentMethodOpenMbway: "Open MB Way app",
 
   // Account management (#106, #107, #108)
   changePassword: "Change password",

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -297,6 +297,7 @@ const es: TranslationKeys = {
   paymentMethodCopy: "Copiar",
   paymentMethodCallPhone: "Llamar",
   paymentMethodMbwayInstructions: "Abre MB Way y envía a este número",
+  paymentMethodOpenMbway: "Abrir app MB Way",
 
   // Account management (#106, #107, #108)
   changePassword: "Cambiar contraseña",

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -297,6 +297,7 @@ const fr: TranslationKeys = {
   paymentMethodCopy: "Copier",
   paymentMethodCallPhone: "Appeler",
   paymentMethodMbwayInstructions: "Ouvre MB Way et envoie à ce numéro",
+  paymentMethodOpenMbway: "Ouvrir l'app MB Way",
 
   // Account management (#106, #107, #108)
   changePassword: "Changer le mot de passe",

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -297,6 +297,7 @@ const it: TranslationKeys = {
   paymentMethodCopy: "Copia",
   paymentMethodCallPhone: "Chiama",
   paymentMethodMbwayInstructions: "Apri MB Way e invia a questo numero",
+  paymentMethodOpenMbway: "Apri l'app MB Way",
 
   // Account management (#106, #107, #108)
   changePassword: "Cambia password",

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -344,6 +344,7 @@ const pt: TranslationKeys = {
   paymentMethodCopy: "Copiar",
   paymentMethodCallPhone: "Ligar",
   paymentMethodMbwayInstructions: "Abre o MB Way e envia para este número",
+  paymentMethodOpenMbway: "Abrir app MB Way",
 
   // Account management (#106, #107, #108)
   changePassword: "Alterar palavra-passe",

--- a/src/lib/paymentMethods.ts
+++ b/src/lib/paymentMethods.ts
@@ -150,3 +150,21 @@ export function getDisplayValue(method: PaymentMethod): string {
       return method.value;
   }
 }
+
+/**
+ * Get a link to open the MB Way app based on the user's platform.
+ * - Android: intent URI that opens the app or falls back to Play Store
+ * - iOS: App Store link (opens the app if installed via universal links)
+ * - Desktop/unknown: null (no app to open)
+ */
+export function getMbwayAppLink(userAgent: string | undefined): string | null {
+  if (!userAgent) return null;
+  const ua = userAgent.toLowerCase();
+  if (/android/i.test(ua)) {
+    return "intent://#Intent;package=pt.sibs.android.mbway;end";
+  }
+  if (/iphone|ipad|ipod/i.test(ua)) {
+    return "https://apps.apple.com/pt/app/mb-way/id918126133";
+  }
+  return null;
+}

--- a/src/test/paymentMethods.test.ts
+++ b/src/test/paymentMethods.test.ts
@@ -5,6 +5,7 @@ import {
   normalizePaymentMethod,
   parsePaymentMethods,
   getDeepLink,
+  getMbwayAppLink,
   getDisplayValue,
   type PaymentMethod,
 } from "~/lib/paymentMethods";
@@ -135,7 +136,7 @@ describe("getDeepLink", () => {
     expect(getDeepLink({ type: "phone", value: "+351912345678" })).toBe("tel:+351912345678");
   });
 
-  it("returns null for mbway (no deep link)", () => {
+  it("returns null for mbway (no direct deep link)", () => {
     expect(getDeepLink({ type: "mbway", value: "912345678" })).toBeNull();
   });
 
@@ -170,5 +171,27 @@ describe("getDisplayValue", () => {
   it("returns value as-is for phone and mbway", () => {
     expect(getDisplayValue({ type: "phone", value: "+351912345678" })).toBe("+351912345678");
     expect(getDisplayValue({ type: "mbway", value: "912345678" })).toBe("912345678");
+  });
+});
+
+describe("getMbwayAppLink", () => {
+  it("returns Android intent URI for Android user agent", () => {
+    const link = getMbwayAppLink("Mozilla/5.0 (Linux; Android 13) AppleWebKit/537.36");
+    expect(link).toBe("intent://#Intent;package=pt.sibs.android.mbway;end");
+  });
+
+  it("returns App Store link for iOS user agent", () => {
+    const link = getMbwayAppLink("Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)");
+    expect(link).toBe("https://apps.apple.com/pt/app/mb-way/id918126133");
+  });
+
+  it("returns null for desktop user agent", () => {
+    const link = getMbwayAppLink("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)");
+    expect(link).toBeNull();
+  });
+
+  it("returns null for empty user agent", () => {
+    expect(getMbwayAppLink("")).toBeNull();
+    expect(getMbwayAppLink(undefined)).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Adds an "Open MB Way app" button to the payment section that appears only on mobile devices.

### How it works

- **Android**: Uses an intent URI (`intent://#Intent;package=pt.sibs.android.mbway;end`) that opens the MB Way app if installed, or falls back to the Play Store
- **iOS**: Links to the App Store page (`https://apps.apple.com/pt/app/mb-way/id918126133`) which opens the app via universal links if installed
- **Desktop**: Button is hidden — no app to open, users still get the copy-to-clipboard fallback

### Changes

- `src/lib/paymentMethods.ts` — new `getMbwayAppLink(userAgent)` function with platform detection
- `src/components/PaymentSection.tsx` — renders "Open MB Way app" button below the instructions text on mobile
- `src/lib/i18n/*.ts` — added `paymentMethodOpenMbway` key to all 6 locales (en, pt, es, fr, de, it)
- `src/test/paymentMethods.test.ts` — 4 new unit tests for `getMbwayAppLink()`

### Testing

- 608/608 tests pass
- TypeScript typecheck clean