### PR TITLE
fix: open MB Way app directly instead of app store links

### DIFF
--- a/src/lib/paymentMethods.ts
+++ b/src/lib/paymentMethods.ts
@@ -161,10 +161,13 @@ export function getMbwayAppLink(userAgent: string | undefined): string | null {
   if (!userAgent) return null;
   const ua = userAgent.toLowerCase();
   if (/android/i.test(ua)) {
-    return "intent://#Intent;package=pt.sibs.android.mbway;end";
+    // Intent URI that opens the MB Way app directly; falls back to Play Store if not installed
+    const fallback = encodeURIComponent("https://play.google.com/store/apps/details?id=pt.sibs.android.mbway");
+    return `intent://#Intent;package=pt.sibs.android.mbway;S.browser_fallback_url=${fallback};end`;
   }
   if (/iphone|ipad|ipod/i.test(ua)) {
-    return "https://apps.apple.com/pt/app/mb-way/id918126133";
+    // Custom URL scheme to open the MB Way app directly on iOS
+    return "mbway://";
   }
   return null;
 }

--- a/src/test/paymentMethods.test.ts
+++ b/src/test/paymentMethods.test.ts
@@ -175,14 +175,16 @@ describe("getDisplayValue", () => {
 });
 
 describe("getMbwayAppLink", () => {
-  it("returns Android intent URI for Android user agent", () => {
+  it("returns Android intent URI that opens app with Play Store fallback", () => {
     const link = getMbwayAppLink("Mozilla/5.0 (Linux; Android 13) AppleWebKit/537.36");
-    expect(link).toBe("intent://#Intent;package=pt.sibs.android.mbway;end");
+    expect(link).toBe(
+      "intent://#Intent;package=pt.sibs.android.mbway;S.browser_fallback_url=https%3A%2F%2Fplay.google.com%2Fstore%2Fapps%2Fdetails%3Fid%3Dpt.sibs.android.mbway;end"
+    );
   });
 
-  it("returns App Store link for iOS user agent", () => {
+  it("returns mbway:// custom scheme for iOS to open app directly", () => {
     const link = getMbwayAppLink("Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)");
-    expect(link).toBe("https://apps.apple.com/pt/app/mb-way/id918126133");
+    expect(link).toBe("mbway://");
   });
 
   it("returns null for desktop user agent", () => {


### PR DESCRIPTION
## Summary

The MB Way "Open" button was linking to the Play Store (Android) and App Store (iOS) instead of opening the MB Way app directly.

### Changes

- **Android**: Added `S.browser_fallback_url` to the intent URI so it opens MB Way directly, falling back to the Play Store only if the app isn't installed
- **iOS**: Replaced the App Store link with `mbway://` custom URL scheme to open the app directly

### Tests

Updated `getMbwayAppLink` tests to verify the new deep link behavior. All 769 tests pass, typecheck clean.