### PR TITLE
fix: Random game titles only use correct language for English and Portuguese

### DIFF
--- a/src/components/CreateEventForm.tsx
+++ b/src/components/CreateEventForm.tsx
@@ -15,7 +15,7 @@ import { ResponsiveLayout } from "./ResponsiveLayout";
 import { useT } from "~/lib/useT";
 import { detectLocale } from "~/lib/i18n";
 import { SPORT_PRESETS, getDefaultMaxPlayers } from "~/lib/sports";
-import { getRandomTitle } from "~/lib/randomTitles";
+import { getRandomTitle, type TitleLocale } from "~/lib/randomTitles";
 
 const DAYS = [
   { value: "MO", key: "monday" },
@@ -45,7 +45,7 @@ function minDateTime() {
 export default function CreateEventForm() {
   const t = useT();
   const locale = detectLocale();
-  const [title, setTitle] = useState(() => getRandomTitle(locale === "pt" ? "pt" : "en"));
+  const [title, setTitle] = useState(() => getRandomTitle(locale as TitleLocale));
   const [isRecurring, setIsRecurring] = useState(false);
   const [recurrenceFreq, setRecurrenceFreq] = useState<"weekly" | "monthly">("weekly");
   const [recurrenceInterval, setRecurrenceInterval] = useState(1);
@@ -134,7 +134,7 @@ export default function CreateEventForm() {
                           <Tooltip title={t("randomizeTitle")}>
                             <IconButton
                               size="small"
-                              onClick={() => setTitle(getRandomTitle(locale === "pt" ? "pt" : "en"))}
+                              onClick={() => setTitle(getRandomTitle(locale as TitleLocale))}
                               sx={{
                                 transition: "transform 0.2s",
                                 "&:hover": { transform: "rotate(180deg)" },

--- a/src/lib/randomTitles.ts
+++ b/src/lib/randomTitles.ts
@@ -1,7 +1,7 @@
 // Funny, engaging random game titles per locale.
 // Each title works as a standalone event name that makes people smile.
 
-const titles = {
+export const titles = {
   en: [
     // Epic & dramatic
     "The Battle of the Legends",

--- a/src/test/i18n.test.ts
+++ b/src/test/i18n.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 import { createT, detectLocale, setStoredLocale, translations } from "~/lib/i18n";
+import { titles, type TitleLocale } from "~/lib/randomTitles";
 
 describe("createT", () => {
   it("returns English string for 'en'", () => {
@@ -189,5 +190,28 @@ describe("setStoredLocale", () => {
     setStoredLocale("pt");
     setStoredLocale("en");
     expect(localStorage.getItem("convocados-locale")).toBe("en");
+  });
+});
+
+describe("random titles i18n coverage", () => {
+  const supportedLocales: TitleLocale[] = ["en", "pt", "es", "fr", "de", "it"];
+
+  it("every supported locale has a random titles pool", () => {
+    for (const locale of supportedLocales) {
+      expect(titles[locale]).toBeDefined();
+      expect(titles[locale].length).toBeGreaterThan(0);
+    }
+  });
+
+  it("no non-English locale has a title pool identical to English", () => {
+    const enSet = new Set<string>(titles.en);
+    for (const locale of supportedLocales.filter((l) => l !== "en")) {
+      const localeSet = new Set<string>(titles[locale]);
+      // Pools should not be identical — that would mean missing translations
+      const identical =
+        enSet.size === localeSet.size &&
+        [...enSet].every((t) => localeSet.has(t));
+      expect(identical).toBe(false);
+    }
   });
 });

--- a/src/test/randomTitles.test.ts
+++ b/src/test/randomTitles.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { getRandomTitle, getRandomTitles } from "~/lib/randomTitles";
+import { getRandomTitle, getRandomTitles, titles, type TitleLocale } from "~/lib/randomTitles";
 
 describe("getRandomTitle", () => {
   it("returns a non-empty string for 'en'", () => {
@@ -39,10 +39,40 @@ describe("getRandomTitle", () => {
     expect(title.length).toBeGreaterThan(0);
   });
 
+  it("returns a title from the correct locale pool for each locale", () => {
+    const locales: TitleLocale[] = ["en", "pt", "es", "fr", "de", "it"];
+    for (const locale of locales) {
+      const pool = titles[locale] as readonly string[];
+      // Run multiple times to reduce flakiness
+      for (let i = 0; i < 20; i++) {
+        const title = getRandomTitle(locale);
+        expect(pool).toContain(title);
+      }
+    }
+  });
+
+  it("returns titles from the locale pool, not the English pool, for non-en locales", () => {
+    const nonEnLocales: TitleLocale[] = ["pt", "es", "fr", "de", "it"];
+    const enPool = new Set<string>(titles.en);
+    for (const locale of nonEnLocales) {
+      const localePool = titles[locale] as readonly string[];
+      // Collect many samples — at least some should NOT be in the English pool
+      const samples = Array.from({ length: 50 }, () => getRandomTitle(locale));
+      const allInEnPool = samples.every((t) => enPool.has(t));
+      // The locale pools are distinct from English, so not all titles should match English
+      expect(allInEnPool).toBe(false);
+      // And every sample must be in the locale's own pool
+      for (const s of samples) {
+        expect(localePool).toContain(s);
+      }
+    }
+  });
+
   it("falls back to English for unknown locale", () => {
     // @ts-expect-error testing unknown locale
     const title = getRandomTitle("unknown");
     expect(title).toBeTruthy();
+    expect(titles.en as readonly string[]).toContain(title);
   });
 
   it("returns different titles across multiple calls (not always the same)", () => {


### PR DESCRIPTION
Closes #154

## What changed

- **`src/components/CreateEventForm.tsx`** — Replaced hardcoded `locale === "pt" ? "pt" : "en"` with `locale as TitleLocale` on both line 48 (initial state) and line 137 (re-randomize button), so all 6 locales get their correct random titles.
- **`src/lib/randomTitles.ts`** — Exported the `titles` object so tests can verify locale pools.
- **`src/test/randomTitles.test.ts`** — Added tests verifying each locale returns titles from its own pool and that non-English locales don't return English titles.
- **`src/test/i18n.test.ts`** — Added tests verifying every supported locale has a random titles pool and none are identical to English.

## Testing

- All 773 tests pass
- TypeScript typecheck passes clean