### PR TITLE
feat: allow event archive (owner-only)

### DIFF
--- a/prisma/migrations/20260321234127_add_event_archived_at/migration.sql
+++ b/prisma/migrations/20260321234127_add_event_archived_at/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Event" ADD COLUMN "archivedAt" DATETIME;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -114,6 +114,9 @@ model Event {
   // Access control
   accessPassword        String?               // bcrypt-hashed password (null = no password)
 
+  // Archive
+  archivedAt     DateTime?
+
   createdAt      DateTime              @default(now())
   updatedAt      DateTime              @updatedAt
 

--- a/src/components/EventLogPage.tsx
+++ b/src/components/EventLogPage.tsx
@@ -10,6 +10,8 @@ import PersonRemoveIcon from "@mui/icons-material/PersonRemove";
 import ShuffleIcon from "@mui/icons-material/Shuffle";
 import SettingsIcon from "@mui/icons-material/Settings";
 import PaymentIcon from "@mui/icons-material/Payment";
+import ArchiveIcon from "@mui/icons-material/Archive";
+import UnarchiveIcon from "@mui/icons-material/Unarchive";
 import { ThemeModeProvider } from "./ThemeModeProvider";
 import { ResponsiveLayout } from "./ResponsiveLayout";
 import { useT } from "~/lib/useT";
@@ -41,6 +43,8 @@ const ACTION_COLORS: Record<string, "success" | "error" | "info" | "warning" | "
   cost_removed: "error",
   payment_updated: "info",
   recurrence_reset: "warning",
+  event_archived: "warning",
+  event_unarchived: "info",
 };
 
 const ACTION_ICONS: Record<string, React.ReactNode> = {
@@ -50,6 +54,8 @@ const ACTION_ICONS: Record<string, React.ReactNode> = {
   event_updated: <SettingsIcon fontSize="small" />,
   cost_set: <PaymentIcon fontSize="small" />,
   payment_updated: <PaymentIcon fontSize="small" />,
+  event_archived: <ArchiveIcon fontSize="small" />,
+  event_unarchived: <UnarchiveIcon fontSize="small" />,
 };
 
 const ACTION_I18N: Record<string, string> = {
@@ -69,6 +75,8 @@ const ACTION_I18N: Record<string, string> = {
   cost_removed: "logCostRemoved",
   payment_updated: "logPaymentUpdated",
   recurrence_reset: "logRecurrenceReset",
+  event_archived: "logEventArchived",
+  event_unarchived: "logEventUnarchived",
 };
 
 function LogEntryRow({ entry }: { entry: LogEntry }) {

--- a/src/components/EventPage.tsx
+++ b/src/components/EventPage.tsx
@@ -70,6 +70,7 @@ interface EventData {
   wasReset?: boolean;
   hasPassword?: boolean;
   locked?: boolean;
+  archivedAt?: string | null;
 }
 
 // ── Countdown ─────────────────────────────────────────────────────────────────
@@ -1066,6 +1067,10 @@ export default function EventPage({ eventId }: { eventId: string }) {
                     {/* Owner badge — always visible for owners */}
                     {isOwner && (
                       <Chip icon={<StarIcon />} label={t("ownerBadge")} size="small" color="success" variant="outlined" />
+                    )}
+                    {/* Archived badge */}
+                    {event.archivedAt && (
+                      <Chip label={t("archivedBadge")} size="small" color="warning" variant="outlined" />
                     )}
                     {/* Claim ownership for authenticated users on ownerless events */}
                     {isAuthenticated && isOwnerless && (

--- a/src/components/EventSettingsPage.tsx
+++ b/src/components/EventSettingsPage.tsx
@@ -22,6 +22,8 @@ import LockIcon from "@mui/icons-material/Lock";
 import PersonAddIcon from "@mui/icons-material/PersonAdd";
 import DeleteIcon from "@mui/icons-material/Delete";
 import GroupIcon from "@mui/icons-material/Group";
+import ArchiveIcon from "@mui/icons-material/Archive";
+import UnarchiveIcon from "@mui/icons-material/Unarchive";
 import { useT } from "~/lib/useT";
 import { SPORT_PRESETS, getSportPreset } from "~/lib/sports";
 import { useSession } from "~/lib/auth.client";
@@ -379,6 +381,23 @@ export default function EventSettingsPage({ eventId }: Props) {
     if (res.ok) {
       setAdmins((prev) => prev.filter((a) => a.userId !== userId));
       setMessage({ type: "success", text: t("adminRemoved") });
+    }
+  };
+
+  // ── Archive handler ───────────────────────────────────────────────────
+
+  const handleArchiveToggle = async () => {
+    const archive = !event.archivedAt;
+    const res = await fetch(`/api/events/${eventId}/archive`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ archive }),
+    });
+    if (res.ok) {
+      await fetchEvent();
+      setMessage({ type: "success", text: archive ? t("eventArchived") : t("eventUnarchived") });
+    } else {
+      setMessage({ type: "error", text: t("somethingWentWrong") });
     }
   };
 
@@ -820,6 +839,30 @@ export default function EventSettingsPage({ eventId }: Props) {
           </Paper>
         </Stack>
       </SectionCard>
+
+      {/* ── Archive ── */}
+      {isOwner && (
+        <SectionCard title={t("archiveEvent")} icon={<ArchiveIcon color="action" />}>
+          <Stack spacing={1}>
+            <Typography variant="body2" color="text.secondary">
+              {t("archiveEventDesc")}
+            </Typography>
+            {event.archivedAt && (
+              <Chip label={t("archivedBadge")} color="warning" size="small" sx={{ alignSelf: "flex-start" }} />
+            )}
+            <Button
+              variant="outlined"
+              color={event.archivedAt ? "primary" : "warning"}
+              size="small"
+              startIcon={event.archivedAt ? <UnarchiveIcon /> : <ArchiveIcon />}
+              onClick={handleArchiveToggle}
+              sx={{ alignSelf: "flex-start" }}
+            >
+              {event.archivedAt ? t("unarchiveEventBtn") : t("archiveEventBtn")}
+            </Button>
+          </Stack>
+        </SectionCard>
+      )}
 
       {/* ── Ownership ── */}
       {isOwner && (

--- a/src/lib/eventLog.server.ts
+++ b/src/lib/eventLog.server.ts
@@ -17,7 +17,9 @@ export type EventAction =
   | "ownership_claimed"
   | "ownership_relinquished"
   | "ownership_transferred"
-  | "recurrence_reset";
+  | "recurrence_reset"
+  | "event_archived"
+  | "event_unarchived";
 
 /**
  * Append an entry to the event activity log.

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -526,6 +526,17 @@ const de: TranslationKeys = {
   adminRange1y: "1 Jahr",
   adminRangeAll: "Gesamter Zeitraum",
   adminNoGrowthData: "Noch keine Wachstumsdaten verfügbar.",
+
+  // Event archive (#161)
+  archiveEvent: "Event archivieren",
+  archiveEventDesc: "Archivierte Events werden in öffentlichen Listen und deinem Dashboard ausgeblendet. Du kannst sie jederzeit wiederherstellen.",
+  archiveEventBtn: "Archivieren",
+  unarchiveEventBtn: "Wiederherstellen",
+  eventArchived: "Event archiviert.",
+  eventUnarchived: "Event wiederhergestellt.",
+  archivedBadge: "Archiviert",
+  logEventArchived: "{actor} hat das Event archiviert",
+  logEventUnarchived: "{actor} hat das Event wiederhergestellt",
 };
 
 export default de;

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -572,6 +572,17 @@ const en = {
   adminRange1y: "1 year",
   adminRangeAll: "All time",
   adminNoGrowthData: "No growth data available yet.",
+
+  // Event archive (#161)
+  archiveEvent: "Archive event",
+  archiveEventDesc: "Archived events are hidden from public listings and your dashboard. You can unarchive at any time.",
+  archiveEventBtn: "Archive",
+  unarchiveEventBtn: "Unarchive",
+  eventArchived: "Event archived.",
+  eventUnarchived: "Event unarchived.",
+  archivedBadge: "Archived",
+  logEventArchived: "{actor} archived the event",
+  logEventUnarchived: "{actor} unarchived the event",
 } as const;
 
 export default en;

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -526,6 +526,17 @@ const es: TranslationKeys = {
   adminRange1y: "1 año",
   adminRangeAll: "Todo el período",
   adminNoGrowthData: "Aún no hay datos de crecimiento.",
+
+  // Event archive (#161)
+  archiveEvent: "Archivar evento",
+  archiveEventDesc: "Los eventos archivados se ocultan de las listas públicas y tu panel. Puedes desarchivar en cualquier momento.",
+  archiveEventBtn: "Archivar",
+  unarchiveEventBtn: "Desarchivar",
+  eventArchived: "Evento archivado.",
+  eventUnarchived: "Evento desarchivado.",
+  archivedBadge: "Archivado",
+  logEventArchived: "{actor} archivó el evento",
+  logEventUnarchived: "{actor} desarchivó el evento",
 };
 
 export default es;

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -526,6 +526,17 @@ const fr: TranslationKeys = {
   adminRange1y: "1 an",
   adminRangeAll: "Toute la période",
   adminNoGrowthData: "Pas encore de données de croissance.",
+
+  // Event archive (#161)
+  archiveEvent: "Archiver l'événement",
+  archiveEventDesc: "Les événements archivés sont masqués des listes publiques et de votre tableau de bord. Vous pouvez désarchiver à tout moment.",
+  archiveEventBtn: "Archiver",
+  unarchiveEventBtn: "Désarchiver",
+  eventArchived: "Événement archivé.",
+  eventUnarchived: "Événement désarchivé.",
+  archivedBadge: "Archivé",
+  logEventArchived: "{actor} a archivé l'événement",
+  logEventUnarchived: "{actor} a désarchivé l'événement",
 };
 
 export default fr;

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -526,6 +526,17 @@ const it: TranslationKeys = {
   adminRange1y: "1 anno",
   adminRangeAll: "Tutto il periodo",
   adminNoGrowthData: "Nessun dato di crescita disponibile.",
+
+  // Event archive (#161)
+  archiveEvent: "Archivia evento",
+  archiveEventDesc: "Gli eventi archiviati sono nascosti dalle liste pubbliche e dalla tua dashboard. Puoi ripristinarli in qualsiasi momento.",
+  archiveEventBtn: "Archivia",
+  unarchiveEventBtn: "Ripristina",
+  eventArchived: "Evento archiviato.",
+  eventUnarchived: "Evento ripristinato.",
+  archivedBadge: "Archiviato",
+  logEventArchived: "{actor} ha archiviato l'evento",
+  logEventUnarchived: "{actor} ha ripristinato l'evento",
 };
 
 export default it;

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -573,6 +573,17 @@ const pt: TranslationKeys = {
   adminRange1y: "1 ano",
   adminRangeAll: "Todo o período",
   adminNoGrowthData: "Ainda não há dados de crescimento.",
+
+  // Event archive (#161)
+  archiveEvent: "Arquivar evento",
+  archiveEventDesc: "Eventos arquivados ficam ocultos das listagens públicas e do teu painel. Podes desarquivar a qualquer momento.",
+  archiveEventBtn: "Arquivar",
+  unarchiveEventBtn: "Desarquivar",
+  eventArchived: "Evento arquivado.",
+  eventUnarchived: "Evento desarquivado.",
+  archivedBadge: "Arquivado",
+  logEventArchived: "{actor} arquivou o evento",
+  logEventUnarchived: "{actor} desarquivou o evento",
 };
 
 export default pt;

--- a/src/pages/api/events/[id]/archive.ts
+++ b/src/pages/api/events/[id]/archive.ts
@@ -1,0 +1,42 @@
+import type { APIRoute } from "astro";
+import { prisma } from "../../../../lib/db.server";
+import { checkOwnership } from "../../../../lib/auth.helpers.server";
+import { rateLimitResponse } from "../../../../lib/apiRateLimit.server";
+import { logEvent } from "../../../../lib/eventLog.server";
+import { sseManager } from "../../../../lib/sse.server";
+
+export const PUT: APIRoute = async ({ params, request }) => {
+  const limited = await rateLimitResponse(request, "write");
+  if (limited) return limited;
+
+  const event = await prisma.event.findUnique({ where: { id: params.id } });
+  if (!event) return Response.json({ error: "Not found." }, { status: 404 });
+
+  // Owner-only — admins cannot archive
+  const { isOwner, session } = await checkOwnership(request, event.ownerId, undefined, params.id);
+  if (!isOwner) {
+    return Response.json({ error: "Only the event owner can do this." }, { status: 403 });
+  }
+
+  const body = await request.json();
+  const archive = Boolean(body.archive);
+
+  const archivedAt = archive ? new Date() : null;
+
+  await prisma.event.update({
+    where: { id: params.id },
+    data: { archivedAt },
+  });
+
+  const action = archive ? "event_archived" : "event_unarchived";
+  await logEvent(
+    event.id,
+    action,
+    session?.user?.name ?? null,
+    session?.user?.id ?? null,
+  );
+
+  sseManager.broadcast(params.id!, "update", { action });
+
+  return Response.json({ archivedAt: archivedAt?.toISOString() ?? null });
+};

--- a/src/pages/api/events/[id]/index.ts
+++ b/src/pages/api/events/[id]/index.ts
@@ -155,6 +155,7 @@ export const GET: APIRoute = async ({ params, request }) => {
     createdAt: event.createdAt.toISOString(),
     updatedAt: event.updatedAt.toISOString(),
     nextResetAt: event.nextResetAt?.toISOString() ?? null,
+    archivedAt: event.archivedAt?.toISOString() ?? null,
     players: event.players.map((p) => ({ ...p, userId: p.userId ?? null, createdAt: p.createdAt.toISOString() })),
   });
 };

--- a/src/pages/api/events/public.ts
+++ b/src/pages/api/events/public.ts
@@ -7,7 +7,7 @@ export const GET: APIRoute = async ({ request }) => {
   const { limit, cursor } = parsePaginationParams(url);
 
   const events = await prisma.event.findMany({
-    where: { isPublic: true },
+    where: { isPublic: true, archivedAt: null },
     include: {
       players: { orderBy: { order: "asc" } },
     },

--- a/src/pages/api/me/games.ts
+++ b/src/pages/api/me/games.ts
@@ -17,7 +17,7 @@ export const GET: APIRoute = async ({ request }) => {
 
   const [ownedEvents, joinedPlayers] = await Promise.all([
     prisma.event.findMany({
-      where: { ownerId: userId },
+      where: { ownerId: userId, archivedAt: null },
       select: {
         id: true,
         title: true,
@@ -32,7 +32,7 @@ export const GET: APIRoute = async ({ request }) => {
       ...(ownedCursor ? { cursor: { id: ownedCursor }, skip: 1 } : {}),
     }),
     prisma.player.findMany({
-      where: { userId },
+      where: { userId, event: { archivedAt: null } },
       select: {
         id: true,
         event: {

--- a/src/test/archive-api.test.ts
+++ b/src/test/archive-api.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { prisma } from "~/lib/db.server";
+import { resetApiRateLimitStore } from "~/lib/apiRateLimit.server";
+
+// Mock auth
+vi.mock("~/lib/auth.helpers.server", () => ({
+  getSession: vi.fn().mockResolvedValue(null),
+  checkOwnership: vi.fn(),
+  checkEventAdmin: vi.fn(),
+}));
+
+import { checkOwnership } from "~/lib/auth.helpers.server";
+const mockCheckOwnership = vi.mocked(checkOwnership);
+
+import { PUT as archiveEvent } from "~/pages/api/events/[id]/archive";
+
+function putCtx(params: Record<string, string>, body: unknown) {
+  const request = new Request("http://localhost/api/test", {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  return { request, params } as any;
+}
+
+async function seedOwner() {
+  await prisma.user.upsert({
+    where: { id: "owner1" },
+    create: { id: "owner1", name: "Owner", email: "owner@test.com", emailVerified: true },
+    update: {},
+  });
+}
+
+async function seedEvent(ownerId: string | null = "owner1") {
+  return prisma.event.create({
+    data: {
+      title: "Test Event",
+      location: "Pitch A",
+      dateTime: new Date(Date.now() + 86400_000),
+      ownerId,
+    },
+  });
+}
+
+beforeEach(async () => {
+  await resetApiRateLimitStore();
+  await prisma.eventLog.deleteMany();
+  await prisma.player.deleteMany();
+  await prisma.event.deleteMany();
+  await prisma.user.deleteMany();
+});
+
+describe("PUT /api/events/[id]/archive", () => {
+  it("returns 404 for non-existent event", async () => {
+    const res = await archiveEvent(putCtx({ id: "nonexistent" }, { archive: true }));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 when non-owner tries to archive", async () => {
+    await seedOwner();
+    const event = await seedEvent("owner1");
+
+    mockCheckOwnership.mockResolvedValueOnce({
+      isOwner: false,
+      isAdmin: false,
+      session: { user: { id: "other" } } as any,
+    });
+
+    const res = await archiveEvent(putCtx({ id: event.id }, { archive: true }));
+    expect(res.status).toBe(403);
+  });
+
+  it("allows owner to archive an event", async () => {
+    await seedOwner();
+    const event = await seedEvent("owner1");
+
+    mockCheckOwnership.mockResolvedValueOnce({
+      isOwner: true,
+      isAdmin: false,
+      session: { user: { id: "owner1", name: "Owner" } } as any,
+    });
+
+    const res = await archiveEvent(putCtx({ id: event.id }, { archive: true }));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.archivedAt).toBeTruthy();
+
+    // Verify in DB
+    const updated = await prisma.event.findUnique({ where: { id: event.id } });
+    expect(updated?.archivedAt).toBeTruthy();
+  });
+
+  it("allows owner to unarchive an event", async () => {
+    await seedOwner();
+    const event = await seedEvent("owner1");
+
+    // First archive it
+    await prisma.event.update({
+      where: { id: event.id },
+      data: { archivedAt: new Date() },
+    });
+
+    mockCheckOwnership.mockResolvedValueOnce({
+      isOwner: true,
+      isAdmin: false,
+      session: { user: { id: "owner1", name: "Owner" } } as any,
+    });
+
+    const res = await archiveEvent(putCtx({ id: event.id }, { archive: false }));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.archivedAt).toBeNull();
+
+    const updated = await prisma.event.findUnique({ where: { id: event.id } });
+    expect(updated?.archivedAt).toBeNull();
+  });
+
+  it("does not allow admins to archive (owner-only)", async () => {
+    await seedOwner();
+    const event = await seedEvent("owner1");
+
+    mockCheckOwnership.mockResolvedValueOnce({
+      isOwner: false,
+      isAdmin: true,
+      session: { user: { id: "admin1" } } as any,
+    });
+
+    const res = await archiveEvent(putCtx({ id: event.id }, { archive: true }));
+    expect(res.status).toBe(403);
+  });
+
+  it("creates an event log entry when archiving", async () => {
+    await seedOwner();
+    const event = await seedEvent("owner1");
+
+    mockCheckOwnership.mockResolvedValueOnce({
+      isOwner: true,
+      isAdmin: false,
+      session: { user: { id: "owner1", name: "Owner" } } as any,
+    });
+
+    await archiveEvent(putCtx({ id: event.id }, { archive: true }));
+
+    const logs = await prisma.eventLog.findMany({ where: { eventId: event.id } });
+    expect(logs).toHaveLength(1);
+    expect(logs[0].action).toBe("event_archived");
+  });
+
+  it("creates an event log entry when unarchiving", async () => {
+    await seedOwner();
+    const event = await seedEvent("owner1");
+    await prisma.event.update({
+      where: { id: event.id },
+      data: { archivedAt: new Date() },
+    });
+
+    mockCheckOwnership.mockResolvedValueOnce({
+      isOwner: true,
+      isAdmin: false,
+      session: { user: { id: "owner1", name: "Owner" } } as any,
+    });
+
+    await archiveEvent(putCtx({ id: event.id }, { archive: false }));
+
+    const logs = await prisma.eventLog.findMany({ where: { eventId: event.id } });
+    expect(logs).toHaveLength(1);
+    expect(logs[0].action).toBe("event_unarchived");
+  });
+
+  it("does not allow archiving ownerless events", async () => {
+    const event = await seedEvent(null);
+
+    mockCheckOwnership.mockResolvedValueOnce({
+      isOwner: false,
+      isAdmin: false,
+      session: null,
+    });
+
+    const res = await archiveEvent(putCtx({ id: event.id }, { archive: true }));
+    expect(res.status).toBe(403);
+  });
+});


### PR DESCRIPTION
Closes #161

## Summary

Adds the ability for event owners to archive and unarchive events.

### Changes

- **Schema**: Added `archivedAt` nullable DateTime field to the Event model with migration
- **API**: `PUT /api/events/[id]/archive` — owner-only endpoint, accepts `{ archive: true/false }`
- **Filtering**: Archived events are excluded from public listings (`/api/events/public`) and the dashboard (`/api/me/games`)
- **Event log**: Added `event_archived` / `event_unarchived` actions with icons and i18n display
- **UI**: Archive/Unarchive section in EventSettingsPage (owner-only), "Archived" badge on EventPage
- **i18n**: Added 11 translation keys to all 6 locales (en, pt, es, fr, de, it)
- **Tests**: 8 tests covering authorization, archive/unarchive, event logging, and edge cases

### Testing

- All 847 tests pass
- TypeScript typecheck passes