### PR TITLE
fix: checkout release tag in deploy job to ensure correct version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,6 +172,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: v${{ needs.release.outputs.version }}
 
       - uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
The deploy job was checking out the triggering commit ref instead of the version-bumped commit. This caused the deployed app to show the previous version (e.g. 3.26.0 instead of 3.27.0).

Fix: checkout the exact release tag `v<version>` created by the release job, ensuring the deployed build always has the correct version in `package.json`.