### PR TITLE
feat: show ELO ratings to all users when balanced mode is enabled

### DIFF
--- a/.astro/types.d.ts
+++ b/.astro/types.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="astro/client" />
+/// <reference path="content.d.ts" />

--- a/src/components/EventPage.tsx
+++ b/src/components/EventPage.tsx
@@ -1363,7 +1363,7 @@ export default function EventPage({ eventId }: { eventId: string }) {
                         : m.team === event.teamTwoName ? teamTwoName : m.team,
                     }))}
                     onResultChange={handleTeamChange}
-                    ratingsMap={balanced && canEditSettings ? ratingsMap : undefined}
+                    ratingsMap={balanced ? ratingsMap : undefined}
                     onTeamNameSave={canEditSettings ? (teamIdx, newName) => {
                       if (teamIdx === 0) {
                         setTeamOneName(newName);

--- a/src/test/api-extended.test.ts
+++ b/src/test/api-extended.test.ts
@@ -514,6 +514,25 @@ describe("GET /api/events/[id]/ratings", () => {
     const res = await getRatings(ctx({ id: "nonexistent" }));
     expect(res.status).toBe(404);
   });
+
+  it("returns ratings for balanced event without auth (public access)", async () => {
+    const id = await seedEvent({ balanced: true } as any);
+    await prisma.playerRating.create({
+      data: { eventId: id, name: "Bob", rating: 1100, gamesPlayed: 3, wins: 2, draws: 0, losses: 1 },
+    });
+    await prisma.playerRating.create({
+      data: { eventId: id, name: "Carol", rating: 950, gamesPlayed: 3, wins: 1, draws: 0, losses: 2 },
+    });
+    // No auth headers — simulates a non-owner viewing the event
+    const res = await getRatings(ctx({ id }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toHaveLength(2);
+    expect(body.data[0].name).toBe("Bob");
+    expect(body.data[0].rating).toBe(1100);
+    expect(body.data[1].name).toBe("Carol");
+    expect(body.data[1].rating).toBe(950);
+  });
 });
 
 // ─── GET /api/events/[id]/calendar ───────────────────────────────────────────


### PR DESCRIPTION
When an event has balanced mode enabled, player ELO ratings and team average ELO are now visible to **all** users, not just the event owner/admin.

## Changes

- **`src/components/EventPage.tsx`**: Removed `canEditSettings` guard from `ratingsMap` prop — now passed to `TeamPicker` whenever `balanced` is true
- **`src/test/api-extended.test.ts`**: Added test confirming ratings API is publicly accessible for balanced events

## Context

The `TeamPicker` component already supported displaying per-player ELO and team average ELO via the `ratingsMap` prop. The ratings API endpoint (`GET /api/events/[id]/ratings`) was already public. The only issue was the frontend guard that restricted the prop to owners only.

Before: `ratingsMap={balanced && canEditSettings ? ratingsMap : undefined}`
After: `ratingsMap={balanced ? ratingsMap : undefined}`