### PR TITLE
feat: configure Litestream backups with Cloudflare R2 (#133)

### DIFF
--- a/docs/disaster-recovery.md
+++ b/docs/disaster-recovery.md
@@ -1,0 +1,139 @@
+# Disaster Recovery Guide
+
+This document covers how Convocados backs up and restores its SQLite database using [Litestream](https://litestream.io/) and Cloudflare R2.
+
+## Architecture
+
+- **Database**: SQLite in WAL mode at `/data/prod.db` (Fly.io persistent volume)
+- **Replication**: Litestream continuously streams WAL changes to Cloudflare R2
+- **Config**: `/app/litestream.yml`
+- **Startup**: `scripts/start.sh` handles restore-on-boot + replicate-on-run
+
+## Automatic Recovery (on boot)
+
+The startup script (`scripts/start.sh`) handles recovery automatically:
+
+1. Checks if `/data/prod.db` exists
+2. If missing, runs `litestream restore -if-replica-exists` to pull the latest snapshot from R2
+3. Runs Prisma migrations to apply any pending schema changes
+4. Starts the app with Litestream replicating in the background
+
+This means a destroyed or fresh Fly machine will self-heal on first boot.
+
+## Manual Recovery
+
+### SSH into the Fly machine
+
+```bash
+fly ssh console
+```
+
+### Stop the app (if running)
+
+```bash
+kill $(pgrep -f "node dist/server/entry.mjs")
+```
+
+### Restore latest backup
+
+```bash
+litestream restore -config /app/litestream.yml /data/prod.db
+```
+
+### Restore to a specific point in time
+
+```bash
+litestream restore -config /app/litestream.yml -timestamp "2026-03-20T12:00:00Z" /data/prod.db
+```
+
+### Verify the restored database
+
+```bash
+sqlite3 /data/prod.db "PRAGMA integrity_check;"
+sqlite3 /data/prod.db "SELECT count(*) FROM Event;"
+```
+
+### Restart the machine
+
+```bash
+fly machines restart
+```
+
+## Local Recovery (download backup)
+
+### 1. Install Litestream
+
+```bash
+brew install litestream  # macOS
+```
+
+### 2. Create a local config (`litestream-local.yml`)
+
+```yaml
+dbs:
+  - path: ./restored.db
+    replicas:
+      - type: s3
+        bucket: convocados
+        endpoint: https://2ffa19ca2d5924a86dd7ea437f22e614.r2.cloudflarestorage.com
+        region: auto
+        force-path-style: true
+        access-key-id: <your-r2-access-key>
+        secret-access-key: <your-r2-secret-key>
+```
+
+### 3. Restore
+
+```bash
+litestream restore -config litestream-local.yml ./restored.db
+```
+
+### 4. Inspect with Prisma Studio
+
+```bash
+DATABASE_URL="file:./restored.db" npx prisma studio
+```
+
+## Listing Available Snapshots
+
+```bash
+fly ssh console -C "litestream snapshots -config /app/litestream.yml /data/prod.db"
+```
+
+## Monitoring
+
+- Check replication is active: `fly logs | grep litestream`
+- Health endpoint reports WAL mode: `curl https://convocados.fly.dev/api/health`
+
+## Fly.io Secrets Reference
+
+The following secrets must be set for Litestream to work:
+
+| Secret | Value |
+|--------|-------|
+| `LITESTREAM_REPLICA_BUCKET` | `convocados` |
+| `LITESTREAM_REPLICA_ENDPOINT` | `https://2ffa19ca2d5924a86dd7ea437f22e614.r2.cloudflarestorage.com` |
+| `LITESTREAM_REPLICA_REGION` | `auto` |
+| `LITESTREAM_ACCESS_KEY_ID` | R2 API token access key |
+| `LITESTREAM_SECRET_ACCESS_KEY` | R2 API token secret key |
+
+To set them:
+
+```bash
+fly secrets set \
+  LITESTREAM_REPLICA_BUCKET=convocados \
+  LITESTREAM_REPLICA_ENDPOINT=https://2ffa19ca2d5924a86dd7ea437f22e614.r2.cloudflarestorage.com \
+  LITESTREAM_REPLICA_REGION=auto \
+  LITESTREAM_ACCESS_KEY_ID=<r2-access-key-id> \
+  LITESTREAM_SECRET_ACCESS_KEY=<r2-secret-access-key>
+```
+
+## Setup Checklist
+
+- [ ] R2 API token created in Cloudflare dashboard (read/write access to `convocados` bucket)
+- [ ] Fly.io secrets set (see table above)
+- [ ] `fly deploy` succeeds
+- [ ] Logs show `Starting app with Litestream replication...`
+- [ ] `fly ssh console -C "litestream snapshots -config /app/litestream.yml /data/prod.db"` shows snapshots
+- [ ] Destroy and recreate machine — DB restores automatically from R2
+- [ ] Health endpoint returns `journalMode: "wal"`

--- a/litestream.yml
+++ b/litestream.yml
@@ -10,6 +10,7 @@ dbs:
         path: convocados/db
         endpoint: ${LITESTREAM_REPLICA_ENDPOINT}
         region: ${LITESTREAM_REPLICA_REGION}
+        force-path-style: true
         access-key-id: ${LITESTREAM_ACCESS_KEY_ID}
         secret-access-key: ${LITESTREAM_SECRET_ACCESS_KEY}
         retention: 168h  # 7 days


### PR DESCRIPTION
## Summary

Configures Litestream for Cloudflare R2 replication and adds disaster recovery documentation.

### Changes
- **`litestream.yml`**: Added `force-path-style: true` required for R2 S3 compatibility
- **`docs/disaster-recovery.md`**: Full guide covering automatic recovery, manual recovery, local recovery, snapshot listing, monitoring, and Fly.io secrets reference

### Blocker: R2 API Token
The R2 bucket `convocados` already exists (account `2ffa19ca2d5924a86dd7ea437f22e614`), but an **R2 API token with read/write access** must be created manually in the [Cloudflare dashboard](https://dash.cloudflare.com/) — the wrangler CLI doesn't support R2 token creation.

### Remaining steps after merge
1. Create R2 API token in Cloudflare dashboard (read/write to `convocados` bucket)
2. Set Fly.io secrets:
   ```bash
   fly secrets set \
     LITESTREAM_REPLICA_BUCKET=convocados \
     LITESTREAM_REPLICA_ENDPOINT=https://2ffa19ca2d5924a86dd7ea437f22e614.r2.cloudflarestorage.com \
     LITESTREAM_REPLICA_REGION=auto \
     LITESTREAM_ACCESS_KEY_ID=<from-dashboard> \
     LITESTREAM_SECRET_ACCESS_KEY=<from-dashboard>
   ```
3. Deploy and verify replication is active (see checklist in `docs/disaster-recovery.md`)

Closes #133