### PR TITLE
feat: show ranking button on main page, add ELO toggle, improve UX

### DIFF
--- a/prisma/migrations/20260324105540_add_elo_enabled/migration.sql
+++ b/prisma/migrations/20260324105540_add_elo_enabled/migration.sql
@@ -1,0 +1,40 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Event" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "title" TEXT NOT NULL,
+    "location" TEXT NOT NULL,
+    "latitude" REAL,
+    "longitude" REAL,
+    "dateTime" DATETIME NOT NULL,
+    "maxPlayers" INTEGER NOT NULL DEFAULT 10,
+    "teamOneName" TEXT NOT NULL DEFAULT 'Ninjas',
+    "teamTwoName" TEXT NOT NULL DEFAULT 'Gunas',
+    "sport" TEXT NOT NULL DEFAULT 'football-5v5',
+    "isPublic" BOOLEAN NOT NULL DEFAULT false,
+    "balanced" BOOLEAN NOT NULL DEFAULT false,
+    "isRecurring" BOOLEAN NOT NULL DEFAULT false,
+    "recurrenceRule" TEXT,
+    "nextResetAt" DATETIME,
+    "ownerId" TEXT,
+    "priorityEnabled" BOOLEAN NOT NULL DEFAULT false,
+    "priorityThreshold" INTEGER NOT NULL DEFAULT 3,
+    "priorityWindow" INTEGER NOT NULL DEFAULT 4,
+    "priorityMaxPercent" INTEGER NOT NULL DEFAULT 70,
+    "priorityDeadlineHours" INTEGER NOT NULL DEFAULT 48,
+    "priorityMinGames" INTEGER NOT NULL DEFAULT 3,
+    "accessPassword" TEXT,
+    "eloEnabled" BOOLEAN NOT NULL DEFAULT true,
+    "allowManualRating" BOOLEAN NOT NULL DEFAULT false,
+    "archivedAt" DATETIME,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "Event_ownerId_fkey" FOREIGN KEY ("ownerId") REFERENCES "User" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+INSERT INTO "new_Event" ("accessPassword", "allowManualRating", "archivedAt", "balanced", "createdAt", "dateTime", "id", "isPublic", "isRecurring", "latitude", "location", "longitude", "maxPlayers", "nextResetAt", "ownerId", "priorityDeadlineHours", "priorityEnabled", "priorityMaxPercent", "priorityMinGames", "priorityThreshold", "priorityWindow", "recurrenceRule", "sport", "teamOneName", "teamTwoName", "title", "updatedAt") SELECT "accessPassword", "allowManualRating", "archivedAt", "balanced", "createdAt", "dateTime", "id", "isPublic", "isRecurring", "latitude", "location", "longitude", "maxPlayers", "nextResetAt", "ownerId", "priorityDeadlineHours", "priorityEnabled", "priorityMaxPercent", "priorityMinGames", "priorityThreshold", "priorityWindow", "recurrenceRule", "sport", "teamOneName", "teamTwoName", "title", "updatedAt" FROM "Event";
+DROP TABLE "Event";
+ALTER TABLE "new_Event" RENAME TO "Event";
+CREATE INDEX "Event_ownerId_idx" ON "Event"("ownerId");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -116,6 +116,7 @@ model Event {
   accessPassword        String?               // bcrypt-hashed password (null = no password)
 
   // Rating settings
+  eloEnabled        Boolean @default(true)
   allowManualRating Boolean @default(false)
 
   // Archive

--- a/src/components/EventPage.tsx
+++ b/src/components/EventPage.tsx
@@ -4,7 +4,7 @@ import {
   Alert, IconButton, Tooltip, InputAdornment, Dialog, DialogTitle,
   DialogContent, DialogContentText, DialogActions, Snackbar, alpha, useTheme, Grid2,
   CircularProgress, Divider, Autocomplete,
-  List, ListItem, ListItemText,
+  List, ListItem, ListItemText, Menu, MenuItem, ListItemIcon,
 } from "@mui/material";
 import PersonAddIcon from "@mui/icons-material/PersonAdd";
 import HistoryIcon from "@mui/icons-material/History";
@@ -30,6 +30,9 @@ import DragIndicatorIcon from "@mui/icons-material/DragIndicator";
 import StarIcon from "@mui/icons-material/Star";
 import CalendarMonthIcon from "@mui/icons-material/CalendarMonth";
 import LockIcon from "@mui/icons-material/Lock";
+import EmojiEventsIcon from "@mui/icons-material/EmojiEvents";
+import MoreVertIcon from "@mui/icons-material/MoreVert";
+import AssignmentIcon from "@mui/icons-material/Assignment";
 import { ThemeModeProvider } from "./ThemeModeProvider";
 import { ResponsiveLayout } from "./ResponsiveLayout";
 import { TeamPicker } from "./TeamPicker";
@@ -61,6 +64,7 @@ interface EventData {
   isRecurring: boolean;
   isPublic: boolean;
   balanced: boolean;
+  eloEnabled: boolean;
   sport: string;
   recurrenceRule: string | null;
   ownerId: string | null;
@@ -278,6 +282,61 @@ function NotifyButton({ eventId }: { eventId: string }) {
       onClick={subscribe} disabled={loading} sx={{ flexShrink: 0 }}>
       {t("notifySubscribe")}
     </Button>
+  );
+}
+
+// ── More Actions Menu ─────────────────────────────────────────────────────────
+
+function MoreActionsMenu({ eventId, event, gameDate }: {
+  eventId: string;
+  event: EventData;
+  gameDate: Date;
+}) {
+  const t = useT();
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const open = Boolean(anchorEl);
+
+  return (
+    <>
+      <Button variant="outlined" size="small" startIcon={<MoreVertIcon />}
+        onClick={(e) => setAnchorEl(e.currentTarget)}
+        aria-label={t("moreActions")}
+        sx={{ flexShrink: 0 }}>
+        {t("moreActions")}
+      </Button>
+      <Menu anchorEl={anchorEl} open={open} onClose={() => setAnchorEl(null)}>
+        <MenuItem component="a" href={`/events/${eventId}/log`} onClick={() => setAnchorEl(null)}>
+          <ListItemIcon><AssignmentIcon fontSize="small" /></ListItemIcon>
+          <ListItemText>{t("activityLog")}</ListItemText>
+        </MenuItem>
+        {(gameDate <= new Date() || event.isRecurring) && (
+          <MenuItem component="a" href={`/events/${eventId}/attendance`} onClick={() => setAnchorEl(null)}>
+            <ListItemIcon><EmojiPeopleIcon fontSize="small" /></ListItemIcon>
+            <ListItemText>{t("attendance")}</ListItemText>
+          </MenuItem>
+        )}
+        <MenuItem component="a" href={`/api/events/${eventId}/calendar`} onClick={() => setAnchorEl(null)}>
+          <ListItemIcon><CalendarMonthIcon fontSize="small" /></ListItemIcon>
+          <ListItemText>{t("downloadIcs")}</ListItemText>
+        </MenuItem>
+        <MenuItem component="a"
+          href={googleCalendarUrl({
+            id: eventId,
+            title: event.title,
+            location: event.location,
+            dateTime: new Date(event.dateTime),
+            url: typeof window !== "undefined" ? window.location.href : undefined,
+            recurrence: event.isRecurring && event.recurrenceRule
+              ? JSON.parse(event.recurrenceRule)
+              : undefined,
+          })}
+          target="_blank" rel="noopener noreferrer"
+          onClick={() => setAnchorEl(null)}>
+          <ListItemIcon><CalendarMonthIcon fontSize="small" /></ListItemIcon>
+          <ListItemText>{t("addToGoogleCalendar")}</ListItemText>
+        </MenuItem>
+      </Menu>
+    </>
   );
 }
 
@@ -1017,20 +1076,17 @@ export default function EventPage({ eventId }: { eventId: string }) {
                 <Stack spacing={1}>
                   <ShareBar title={event.title} />
                   <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap", alignItems: "center" }}>
+                    {/* Primary actions — always visible */}
                     {(gameDate <= new Date() || event.isRecurring) && (
                       <Button variant="outlined" size="small" startIcon={<HistoryIcon />}
                         href={`/events/${eventId}/history`} sx={{ flexShrink: 0 }}>
                         {t("history")}
                       </Button>
                     )}
-                    <Button variant="outlined" size="small" startIcon={<HistoryIcon />}
-                      href={`/events/${eventId}/log`} sx={{ flexShrink: 0 }}>
-                      {t("activityLog")}
-                    </Button>
-                    {(gameDate <= new Date() || event.isRecurring) && (
-                      <Button variant="outlined" size="small" startIcon={<EmojiPeopleIcon />}
-                        href={`/events/${eventId}/attendance`} sx={{ flexShrink: 0 }}>
-                        {t("attendance")}
+                    {(event.eloEnabled ?? true) && (
+                      <Button variant="outlined" size="small" startIcon={<EmojiEventsIcon />}
+                        href={`/events/${eventId}/rankings`} sx={{ flexShrink: 0 }}>
+                        {t("ratings")}
                       </Button>
                     )}
                     {canEditSettings && (
@@ -1039,25 +1095,15 @@ export default function EventPage({ eventId }: { eventId: string }) {
                         {t("eventSettings")}
                       </Button>
                     )}
-                    <Button variant="outlined" size="small" startIcon={<CalendarMonthIcon />}
-                      href={`/api/events/${eventId}/calendar`} sx={{ flexShrink: 0 }}>
-                      {t("downloadIcs")}
-                    </Button>
-                    <Button variant="outlined" size="small" startIcon={<CalendarMonthIcon />}
-                      href={googleCalendarUrl({
-                        id: eventId,
-                        title: event.title,
-                        location: event.location,
-                        dateTime: new Date(event.dateTime),
-                        url: typeof window !== "undefined" ? window.location.href : undefined,
-                        recurrence: event.isRecurring && event.recurrenceRule
-                          ? JSON.parse(event.recurrenceRule)
-                          : undefined,
-                      })}
-                      target="_blank" rel="noopener noreferrer" sx={{ flexShrink: 0 }}>
-                      {t("addToGoogleCalendar")}
-                    </Button>
                     <NotifyButton eventId={eventId} />
+
+                    {/* Secondary actions — "More" menu */}
+                    <MoreActionsMenu
+                      eventId={eventId}
+                      event={event}
+                      gameDate={gameDate}
+                    />
+
                     {/* Owner badge — always visible for owners */}
                     {isOwner && (
                       <Chip icon={<StarIcon />} label={t("ownerBadge")} size="small" color="success" variant="outlined" />

--- a/src/components/EventSettingsPage.tsx
+++ b/src/components/EventSettingsPage.tsx
@@ -198,6 +198,11 @@ export default function EventSettingsPage({ eventId }: Props) {
     updateSetting("balanced", { balanced: v });
   };
 
+  const handleToggleElo = (v: boolean) => {
+    setEvent((e: any) => e ? { ...e, eloEnabled: v, ...(v ? {} : { balanced: false }) } : e);
+    updateSetting("elo", { eloEnabled: v });
+  };
+
   const handleToggleManualRating = (v: boolean) => {
     setEvent((e: any) => e ? { ...e, allowManualRating: v } : e);
     updateSetting("manual-rating", { allowManualRating: v });
@@ -467,16 +472,22 @@ export default function EventSettingsPage({ eventId }: Props) {
                 label={<Typography variant="body2">{t("makePublic")}</Typography>}
               />
             </Tooltip>
+            <Tooltip title={t("eloEnabledTooltip")}>
+              <FormControlLabel
+                control={<Switch size="small" checked={event.eloEnabled ?? true} onChange={(e) => handleToggleElo(e.target.checked)} disabled={!canEdit} />}
+                label={<Typography variant="body2">{t("eloEnabled")}</Typography>}
+              />
+            </Tooltip>
             <Tooltip title={t("balancedTeamsTooltip")}>
               <FormControlLabel
-                control={<Switch size="small" checked={event.balanced} onChange={(e) => handleToggleBalanced(e.target.checked)} disabled={!canEdit} />}
-                label={<Typography variant="body2">{t("balancedTeams")}</Typography>}
+                control={<Switch size="small" checked={event.balanced} onChange={(e) => handleToggleBalanced(e.target.checked)} disabled={!canEdit || !(event.eloEnabled ?? true)} />}
+                label={<Typography variant="body2" color={!(event.eloEnabled ?? true) ? "text.disabled" : undefined}>{t("balancedTeams")}</Typography>}
               />
             </Tooltip>
             <Tooltip title={t("allowManualRatingTooltip")}>
               <FormControlLabel
-                control={<Switch size="small" checked={event.allowManualRating ?? false} onChange={(e) => handleToggleManualRating(e.target.checked)} disabled={!canEdit} />}
-                label={<Typography variant="body2">{t("allowManualRating")}</Typography>}
+                control={<Switch size="small" checked={event.allowManualRating ?? false} onChange={(e) => handleToggleManualRating(e.target.checked)} disabled={!canEdit || !(event.eloEnabled ?? true)} />}
+                label={<Typography variant="body2" color={!(event.eloEnabled ?? true) ? "text.disabled" : undefined}>{t("allowManualRating")}</Typography>}
               />
             </Tooltip>
           </Box>

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -135,8 +135,10 @@ const de: TranslationKeys = {
   webhookEndpoint: "Webhook-Endpunkt",
   webhookCopied: "Kopiert!",
   webhookHelp: "Sende einen POST an diese URL, um einen Webhook zu registrieren. Siehe Dokumentation für das Payload-Format.",
-  balancedTeams: "Ausgeglichen",
-  balancedTeamsTooltip: "ELO-Bewertungen verwenden, um Teams auszugleichen",
+  eloEnabled: "ELO-Bewertungen",
+  eloEnabledTooltip: "Spieler-Fähigkeitsbewertungen mit dem ELO-System verfolgen",
+  balancedTeams: "ELO-ausgeglichene Teams",
+  balancedTeamsTooltip: "ELO-Bewertungen verwenden, um Teams beim Zufallsmodus auszugleichen",
   ratings: "Bewertungen",
   rating: "Rating",
   gamesPlayed: "Spiele",
@@ -413,6 +415,7 @@ const de: TranslationKeys = {
   attendanceLow: "Unregelmäßig",
 
   // Event activity log (#122)
+  moreActions: "Mehr",
   activityLog: "Aktivität",
   activityLogTitle: "Aktivitätsprotokoll",
   activityLogDesc: "Alle aufgezeichneten Aktionen für dieses Event.",

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -163,8 +163,10 @@ const en = {
   webhookHelp: "POST to this URL to register a webhook. See docs for payload format.",
 
   // ELO / Ratings
-  balancedTeams: "Balanced",
-  balancedTeamsTooltip: "Use ELO ratings to balance teams",
+  eloEnabled: "ELO ratings",
+  eloEnabledTooltip: "Track player skill ratings using the ELO system",
+  balancedTeams: "ELO-balanced teams",
+  balancedTeamsTooltip: "Use ELO ratings to balance teams when randomizing",
   ratings: "Ratings",
   rating: "Rating",
   gamesPlayed: "Games",
@@ -459,6 +461,7 @@ const en = {
   attendanceLow: "Irregular",
 
   // Event activity log (#122)
+  moreActions: "More",
   activityLog: "Activity",
   activityLogTitle: "Activity Log",
   activityLogDesc: "All actions recorded for this event.",

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -135,8 +135,10 @@ const es: TranslationKeys = {
   webhookEndpoint: "Endpoint del webhook",
   webhookCopied: "¡Copiado!",
   webhookHelp: "Haz POST a esta URL para registrar un webhook. Consulta la documentación para el formato del payload.",
-  balancedTeams: "Equilibrado",
-  balancedTeamsTooltip: "Usar clasificaciones ELO para equilibrar equipos",
+  eloEnabled: "Clasificaciones ELO",
+  eloEnabledTooltip: "Seguir las clasificaciones de habilidad de los jugadores usando el sistema ELO",
+  balancedTeams: "Equipos equilibrados por ELO",
+  balancedTeamsTooltip: "Usar clasificaciones ELO para equilibrar equipos al sortear",
   ratings: "Clasificaciones",
   rating: "Rating",
   gamesPlayed: "Juegos",
@@ -413,6 +415,7 @@ const es: TranslationKeys = {
   attendanceLow: "Irregular",
 
   // Event activity log (#122)
+  moreActions: "Más",
   activityLog: "Actividad",
   activityLogTitle: "Registro de Actividad",
   activityLogDesc: "Todas las acciones registradas para este evento.",

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -135,8 +135,10 @@ const fr: TranslationKeys = {
   webhookEndpoint: "Endpoint du webhook",
   webhookCopied: "Copié !",
   webhookHelp: "Fais un POST à cette URL pour enregistrer un webhook. Consulte la documentation pour le format du payload.",
-  balancedTeams: "Équilibré",
-  balancedTeamsTooltip: "Utiliser les classements ELO pour équilibrer les équipes",
+  eloEnabled: "Classements ELO",
+  eloEnabledTooltip: "Suivre les classements de compétence des joueurs avec le système ELO",
+  balancedTeams: "Équipes équilibrées par ELO",
+  balancedTeamsTooltip: "Utiliser les classements ELO pour équilibrer les équipes lors du tirage",
   ratings: "Classements",
   rating: "Rating",
   gamesPlayed: "Matchs",
@@ -413,6 +415,7 @@ const fr: TranslationKeys = {
   attendanceLow: "Irrégulier",
 
   // Event activity log (#122)
+  moreActions: "Plus",
   activityLog: "Activité",
   activityLogTitle: "Journal d'activité",
   activityLogDesc: "Toutes les actions enregistrées pour cet événement.",

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -135,8 +135,10 @@ const it: TranslationKeys = {
   webhookEndpoint: "Endpoint del webhook",
   webhookCopied: "Copiato!",
   webhookHelp: "Fai POST a questo URL per registrare un webhook. Consulta la documentazione per il formato del payload.",
-  balancedTeams: "Equilibrato",
-  balancedTeamsTooltip: "Usa le classifiche ELO per bilanciare le squadre",
+  eloEnabled: "Classifiche ELO",
+  eloEnabledTooltip: "Traccia le classifiche di abilità dei giocatori usando il sistema ELO",
+  balancedTeams: "Squadre bilanciate per ELO",
+  balancedTeamsTooltip: "Usa le classifiche ELO per bilanciare le squadre durante il sorteggio",
   ratings: "Classifiche",
   rating: "Rating",
   gamesPlayed: "Partite",
@@ -413,6 +415,7 @@ const it: TranslationKeys = {
   attendanceLow: "Irregolare",
 
   // Event activity log (#122)
+  moreActions: "Altro",
   activityLog: "Attività",
   activityLogTitle: "Registro Attività",
   activityLogDesc: "Tutte le azioni registrate per questo evento.",

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -164,8 +164,10 @@ const pt: TranslationKeys = {
   webhookHelp: "Faz POST para este URL para registar um webhook. Consulta a documentação para o formato do payload.",
 
   // ELO / Ratings
-  balancedTeams: "Equilibrado",
-  balancedTeamsTooltip: "Usar classificações ELO para equilibrar equipas",
+  eloEnabled: "Classificações ELO",
+  eloEnabledTooltip: "Acompanhar classificações de habilidade dos jogadores usando o sistema ELO",
+  balancedTeams: "Equipas equilibradas por ELO",
+  balancedTeamsTooltip: "Usar classificações ELO para equilibrar equipas ao sortear",
   ratings: "Classificações",
   rating: "Rating",
   gamesPlayed: "Jogos",
@@ -460,6 +462,7 @@ const pt: TranslationKeys = {
   attendanceLow: "Irregular",
 
   // Event activity log (#122)
+  moreActions: "Mais",
   activityLog: "Atividade",
   activityLogTitle: "Registo de Atividade",
   activityLogDesc: "Todas as ações registadas para este evento.",

--- a/src/pages/api/events/[id]/elo.ts
+++ b/src/pages/api/events/[id]/elo.ts
@@ -1,0 +1,34 @@
+import type { APIRoute } from "astro";
+import { prisma } from "../../../../lib/db.server";
+import { checkOwnership } from "../../../../lib/auth.helpers.server";
+import { rateLimitResponse } from "../../../../lib/apiRateLimit.server";
+import { sseManager } from "../../../../lib/sse.server";
+
+export const PUT: APIRoute = async ({ params, request }) => {
+  const limited = await rateLimitResponse(request, "write");
+  if (limited) return limited;
+
+  const event = await prisma.event.findUnique({ where: { id: params.id } });
+  if (!event) return Response.json({ error: "Not found." }, { status: 404 });
+
+  const { isOwner, isAdmin } = await checkOwnership(request, event.ownerId, undefined, params.id);
+  if (event.ownerId && !isOwner && !isAdmin) {
+    return Response.json({ error: "Only the event owner can do this." }, { status: 403 });
+  }
+
+  const body = await request.json();
+  const eloEnabled = Boolean(body.eloEnabled);
+
+  // When disabling ELO, also disable balanced teams
+  const data: { eloEnabled: boolean; balanced?: boolean } = { eloEnabled };
+  if (!eloEnabled) data.balanced = false;
+
+  await prisma.event.update({
+    where: { id: params.id },
+    data,
+  });
+
+  sseManager.broadcast(params.id!, "update", { action: "elo_updated" });
+
+  return Response.json({ eloEnabled });
+};


### PR DESCRIPTION
Closes #190

## Changes

### Ranking button on main page
- Rankings button is now always visible in the Quick Actions section (no longer gated by game date), since players are auto-added to rankings

### UX improvement — overflow menu
- Moved secondary actions (Activity Log, Attendance, Download .ics, Google Calendar) into a "More" dropdown menu
- Keeps primary actions visible: History, Rankings, Settings, Notifications

### ELO toggle in settings
- Added `eloEnabled` boolean field to Event schema (default `true` for backward compat)
- New `/api/events/[id]/elo` API endpoint — disabling ELO also auto-disables balanced teams
- ELO toggle in General Settings; when off, balanced teams and manual rating toggles are grayed out
- Rankings button hidden on event page when ELO is disabled

### Better naming
- Renamed "Balanced" to "ELO-balanced teams" across all 6 locales
- Updated tooltips for clarity

## Checklist
- [x] All tests pass (977/977)
- [x] Type checking passes
- [x] i18n strings added to all 6 locales
- [x] Database migration included
- [x] Rate limiting applied to new endpoint