### PR TITLE
feat: add split costs toggle and dashboard cost summary (#192, #193)

### DIFF
--- a/prisma/migrations/20260324155739_add_split_costs_enabled/migration.sql
+++ b/prisma/migrations/20260324155739_add_split_costs_enabled/migration.sql
@@ -1,0 +1,58 @@
+/*
+  Warnings:
+
+  - You are about to drop the `RateLimit` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropIndex
+DROP INDEX "RateLimit_expiresAt_idx";
+
+-- DropIndex
+DROP INDEX "RateLimit_key_key";
+
+-- DropTable
+PRAGMA foreign_keys=off;
+DROP TABLE "RateLimit";
+PRAGMA foreign_keys=on;
+
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Event" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "title" TEXT NOT NULL,
+    "location" TEXT NOT NULL,
+    "latitude" REAL,
+    "longitude" REAL,
+    "dateTime" DATETIME NOT NULL,
+    "maxPlayers" INTEGER NOT NULL DEFAULT 10,
+    "teamOneName" TEXT NOT NULL DEFAULT 'Ninjas',
+    "teamTwoName" TEXT NOT NULL DEFAULT 'Gunas',
+    "sport" TEXT NOT NULL DEFAULT 'football-5v5',
+    "isPublic" BOOLEAN NOT NULL DEFAULT false,
+    "balanced" BOOLEAN NOT NULL DEFAULT false,
+    "isRecurring" BOOLEAN NOT NULL DEFAULT false,
+    "recurrenceRule" TEXT,
+    "nextResetAt" DATETIME,
+    "ownerId" TEXT,
+    "priorityEnabled" BOOLEAN NOT NULL DEFAULT false,
+    "priorityThreshold" INTEGER NOT NULL DEFAULT 3,
+    "priorityWindow" INTEGER NOT NULL DEFAULT 4,
+    "priorityMaxPercent" INTEGER NOT NULL DEFAULT 70,
+    "priorityDeadlineHours" INTEGER NOT NULL DEFAULT 48,
+    "priorityMinGames" INTEGER NOT NULL DEFAULT 3,
+    "accessPassword" TEXT,
+    "eloEnabled" BOOLEAN NOT NULL DEFAULT true,
+    "allowManualRating" BOOLEAN NOT NULL DEFAULT false,
+    "splitCostsEnabled" BOOLEAN NOT NULL DEFAULT true,
+    "archivedAt" DATETIME,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "Event_ownerId_fkey" FOREIGN KEY ("ownerId") REFERENCES "User" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+INSERT INTO "new_Event" ("accessPassword", "allowManualRating", "archivedAt", "balanced", "createdAt", "dateTime", "eloEnabled", "id", "isPublic", "isRecurring", "latitude", "location", "longitude", "maxPlayers", "nextResetAt", "ownerId", "priorityDeadlineHours", "priorityEnabled", "priorityMaxPercent", "priorityMinGames", "priorityThreshold", "priorityWindow", "recurrenceRule", "sport", "teamOneName", "teamTwoName", "title", "updatedAt") SELECT "accessPassword", "allowManualRating", "archivedAt", "balanced", "createdAt", "dateTime", "eloEnabled", "id", "isPublic", "isRecurring", "latitude", "location", "longitude", "maxPlayers", "nextResetAt", "ownerId", "priorityDeadlineHours", "priorityEnabled", "priorityMaxPercent", "priorityMinGames", "priorityThreshold", "priorityWindow", "recurrenceRule", "sport", "teamOneName", "teamTwoName", "title", "updatedAt" FROM "Event";
+DROP TABLE "Event";
+ALTER TABLE "new_Event" RENAME TO "Event";
+CREATE INDEX "Event_ownerId_idx" ON "Event"("ownerId");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -119,6 +119,9 @@ model Event {
   eloEnabled        Boolean @default(true)
   allowManualRating Boolean @default(false)
 
+  // Cost tracking
+  splitCostsEnabled Boolean @default(true)
+
   // Archive
   archivedAt     DateTime?
 

--- a/src/components/DashboardPage.tsx
+++ b/src/components/DashboardPage.tsx
@@ -1,8 +1,9 @@
 import React, { useState, useCallback, useEffect } from "react";
 import {
   Container, Typography, Stack, Box, Button,
-  CircularProgress, Alert, Divider,
+  CircularProgress, Alert, Divider, Accordion, AccordionSummary, AccordionDetails,
 } from "@mui/material";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import { ThemeModeProvider } from "./ThemeModeProvider";
 import { ResponsiveLayout } from "./ResponsiveLayout";
 import { useT } from "~/lib/useT";
@@ -12,6 +13,8 @@ import { GameCard, type GameSummary } from "./GameCard";
 interface DashboardData {
   owned: GameSummary[];
   joined: GameSummary[];
+  archivedOwned: GameSummary[];
+  archivedJoined: GameSummary[];
   ownedNextCursor: string | null;
   ownedHasMore: boolean;
   joinedNextCursor: string | null;
@@ -24,6 +27,8 @@ export default function DashboardPage() {
 
   const [owned, setOwned] = useState<GameSummary[]>([]);
   const [joined, setJoined] = useState<GameSummary[]>([]);
+  const [archivedOwned, setArchivedOwned] = useState<GameSummary[]>([]);
+  const [archivedJoined, setArchivedJoined] = useState<GameSummary[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [ownedCursor, setOwnedCursor] = useState<string | null>(null);
   const [ownedHasMore, setOwnedHasMore] = useState(false);
@@ -45,6 +50,8 @@ export default function DashboardPage() {
     fetchGames().then((data) => {
       setOwned(data.owned);
       setJoined(data.joined);
+      setArchivedOwned(data.archivedOwned ?? []);
+      setArchivedJoined(data.archivedJoined ?? []);
       setOwnedCursor(data.ownedNextCursor);
       setOwnedHasMore(data.ownedHasMore);
       setJoinedCursor(data.joinedNextCursor);
@@ -58,6 +65,7 @@ export default function DashboardPage() {
     setLoadingOwned(true);
     const data = await fetchGames(ownedCursor, null);
     setOwned((prev) => [...prev, ...data.owned]);
+    setArchivedOwned((prev) => [...prev, ...(data.archivedOwned ?? [])]);
     setOwnedCursor(data.ownedNextCursor);
     setOwnedHasMore(data.ownedHasMore);
     setLoadingOwned(false);
@@ -68,6 +76,7 @@ export default function DashboardPage() {
     setLoadingJoined(true);
     const data = await fetchGames(null, joinedCursor);
     setJoined((prev) => [...prev, ...data.joined]);
+    setArchivedJoined((prev) => [...prev, ...(data.archivedJoined ?? [])]);
     setJoinedCursor(data.joinedNextCursor);
     setJoinedHasMore(data.joinedHasMore);
     setLoadingJoined(false);
@@ -105,6 +114,8 @@ export default function DashboardPage() {
     );
   }
 
+  const allArchived = [...archivedOwned, ...archivedJoined];
+
   return (
     <ThemeModeProvider>
       <ResponsiveLayout>
@@ -118,7 +129,7 @@ export default function DashboardPage() {
               </Box>
             ) : (
               <>
-                {/* Owned games */}
+                {/* Active: Owned games */}
                 <Box>
                   <Typography variant="h6" fontWeight={600} gutterBottom>
                     {t("ownedGames")}
@@ -141,7 +152,7 @@ export default function DashboardPage() {
 
                 <Divider />
 
-                {/* Joined games */}
+                {/* Active: Joined games */}
                 <Box>
                   <Typography variant="h6" fontWeight={600} gutterBottom>
                     {t("joinedGames")}
@@ -161,6 +172,25 @@ export default function DashboardPage() {
                     <Alert severity="info">{t("noJoinedGames")}</Alert>
                   )}
                 </Box>
+
+                {/* Archived games (collapsible) */}
+                {allArchived.length > 0 && (
+                  <>
+                    <Divider />
+                    <Accordion defaultExpanded={false} variant="outlined" sx={{ borderRadius: 2, "&:before": { display: "none" } }}>
+                      <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                        <Typography variant="h6" fontWeight={600}>
+                          {t("archivedGames")} ({allArchived.length})
+                        </Typography>
+                      </AccordionSummary>
+                      <AccordionDetails>
+                        <Stack spacing={1.5}>
+                          {allArchived.map((g) => <GameCard key={g.id} game={g} />)}
+                        </Stack>
+                      </AccordionDetails>
+                    </Accordion>
+                  </>
+                )}
               </>
             )}
           </Stack>

--- a/src/components/EventPage.tsx
+++ b/src/components/EventPage.tsx
@@ -65,6 +65,7 @@ interface EventData {
   isPublic: boolean;
   balanced: boolean;
   eloEnabled: boolean;
+  splitCostsEnabled: boolean;
   sport: string;
   recurrenceRule: string | null;
   ownerId: string | null;
@@ -1423,6 +1424,7 @@ export default function EventPage({ eventId }: { eventId: string }) {
             </Paper>
 
             {/* Payment tracking */}
+            {(event.splitCostsEnabled !== false) && (
             <Paper elevation={2} sx={{ borderRadius: 3, p: { xs: 2, sm: 3 } }}>
               <PaymentSection
                 eventId={eventId}
@@ -1430,6 +1432,7 @@ export default function EventPage({ eventId }: { eventId: string }) {
                 activePlayerCount={Math.min(event.players.length, event.maxPlayers)}
               />
             </Paper>
+            )}
 
             {/* Teams */}
             {localMatches && localMatches.length > 0 && (

--- a/src/components/EventSettingsPage.tsx
+++ b/src/components/EventSettingsPage.tsx
@@ -208,6 +208,11 @@ export default function EventSettingsPage({ eventId }: Props) {
     updateSetting("manual-rating", { allowManualRating: v });
   };
 
+  const handleToggleSplitCosts = (v: boolean) => {
+    setEvent((e: any) => e ? { ...e, splitCostsEnabled: v } : e);
+    updateSetting("split-costs", { splitCostsEnabled: v });
+  };
+
   const handleSportChange = (v: string) => {
     setEvent((e: any) => e ? { ...e, sport: v } : e);
     updateSetting("sport", { sport: v });
@@ -482,6 +487,12 @@ export default function EventSettingsPage({ eventId }: Props) {
               <FormControlLabel
                 control={<Switch size="small" checked={event.balanced} onChange={(e) => handleToggleBalanced(e.target.checked)} disabled={!canEdit || !(event.eloEnabled ?? true)} />}
                 label={<Typography variant="body2" color={!(event.eloEnabled ?? true) ? "text.disabled" : undefined}>{t("balancedTeams")}</Typography>}
+              />
+            </Tooltip>
+            <Tooltip title={t("splitCostsEnabledTooltip")}>
+              <FormControlLabel
+                control={<Switch size="small" checked={event.splitCostsEnabled ?? true} onChange={(e) => handleToggleSplitCosts(e.target.checked)} disabled={!canEdit} />}
+                label={<Typography variant="body2">{t("splitCostsEnabled")}</Typography>}
               />
             </Tooltip>
             <Tooltip title={t("allowManualRatingTooltip")}>

--- a/src/components/GameCard.tsx
+++ b/src/components/GameCard.tsx
@@ -3,6 +3,7 @@ import { Paper, Typography, Stack, Box, Chip } from "@mui/material";
 import LocationOnIcon from "@mui/icons-material/LocationOn";
 import AccessTimeIcon from "@mui/icons-material/AccessTime";
 import { detectLocale } from "~/lib/i18n";
+import { useT } from "~/lib/useT";
 
 export interface GameSummary {
   id: string;
@@ -12,14 +13,17 @@ export interface GameSummary {
   sport: string;
   maxPlayers: number;
   playerCount: number;
+  archivedAt?: string | null;
 }
 
 export function GameCard({ game, dimPast = false }: { game: GameSummary; dimPast?: boolean }) {
   const locale = detectLocale();
+  const t = useT();
   const date = new Date(game.dateTime);
   const isPast = dimPast && date < new Date();
+  const isArchived = !!game.archivedAt;
   return (
-    <Paper variant="outlined" sx={{ p: 2, borderRadius: 2, opacity: isPast ? 0.7 : 1 }}>
+    <Paper variant="outlined" sx={{ p: 2, borderRadius: 2, opacity: isPast || isArchived ? 0.7 : 1 }}>
       <Stack spacing={1}>
         <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
           <Typography variant="subtitle1" fontWeight={600}>
@@ -27,11 +31,16 @@ export function GameCard({ game, dimPast = false }: { game: GameSummary; dimPast
               {game.title}
             </a>
           </Typography>
-          <Chip
-            label={`${game.playerCount}/${game.maxPlayers}`}
-            size="small"
-            color={game.playerCount >= game.maxPlayers ? "warning" : "primary"}
-          />
+          <Box sx={{ display: "flex", gap: 0.5, alignItems: "center" }}>
+            {isArchived && (
+              <Chip label={t("archivedBadge")} size="small" color="warning" variant="outlined" />
+            )}
+            <Chip
+              label={`${game.playerCount}/${game.maxPlayers}`}
+              size="small"
+              color={game.playerCount >= game.maxPlayers ? "warning" : "primary"}
+            />
+          </Box>
         </Box>
         <Stack direction="row" spacing={2} sx={{ flexWrap: "wrap" }}>
           {game.location && (

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -604,6 +604,15 @@ const de: TranslationKeys = {
   logRatingRecalculated: "{actor} hat alle Bewertungen neu berechnet",
   logRatingManualEnabled: "{actor} hat die manuelle Bewertungsbearbeitung aktiviert",
   logRatingManualDisabled: "{actor} hat die manuelle Bewertungsbearbeitung deaktiviert",
+
+  // Split costs toggle (#192)
+  splitCostsEnabled: "Kostenaufteilung",
+  splitCostsEnabledTooltip: "Kostenaufteilungsbereich auf der Eventseite aktivieren",
+
+  // Dashboard active/archived (#193)
+  activeGames: "Aktive Spiele",
+  archivedGames: "Archivierte Spiele",
+  noArchivedGames: "Keine archivierten Spiele.",
 };
 
 export default de;

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -650,6 +650,15 @@ const en = {
   logRatingRecalculated: "{actor} recalculated all ratings",
   logRatingManualEnabled: "{actor} enabled manual rating editing",
   logRatingManualDisabled: "{actor} disabled manual rating editing",
+
+  // Split costs toggle (#192)
+  splitCostsEnabled: "Cost splitting",
+  splitCostsEnabledTooltip: "Enable the split costs section on the event page",
+
+  // Dashboard active/archived (#193)
+  activeGames: "Active Games",
+  archivedGames: "Archived Games",
+  noArchivedGames: "No archived games.",
 } as const;
 
 export default en;

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -604,6 +604,15 @@ const es: TranslationKeys = {
   logRatingRecalculated: "{actor} recalculó todas las puntuaciones",
   logRatingManualEnabled: "{actor} activó la edición manual de puntuación",
   logRatingManualDisabled: "{actor} desactivó la edición manual de puntuación",
+
+  // Split costs toggle (#192)
+  splitCostsEnabled: "División de costes",
+  splitCostsEnabledTooltip: "Activar la sección de división de costes en la página del evento",
+
+  // Dashboard active/archived (#193)
+  activeGames: "Juegos Activos",
+  archivedGames: "Juegos Archivados",
+  noArchivedGames: "No hay juegos archivados.",
 };
 
 export default es;

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -604,6 +604,15 @@ const fr: TranslationKeys = {
   logRatingRecalculated: "{actor} a recalculé tous les classements",
   logRatingManualEnabled: "{actor} a activé la modification manuelle du classement",
   logRatingManualDisabled: "{actor} a désactivé la modification manuelle du classement",
+
+  // Split costs toggle (#192)
+  splitCostsEnabled: "Partage des frais",
+  splitCostsEnabledTooltip: "Activer la section de partage des frais sur la page de l'événement",
+
+  // Dashboard active/archived (#193)
+  activeGames: "Jeux Actifs",
+  archivedGames: "Jeux Archivés",
+  noArchivedGames: "Aucun jeu archivé.",
 };
 
 export default fr;

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -604,6 +604,15 @@ const it: TranslationKeys = {
   logRatingRecalculated: "{actor} ha ricalcolato tutti i punteggi",
   logRatingManualEnabled: "{actor} ha attivato la modifica manuale del punteggio",
   logRatingManualDisabled: "{actor} ha disattivato la modifica manuale del punteggio",
+
+  // Split costs toggle (#192)
+  splitCostsEnabled: "Divisione dei costi",
+  splitCostsEnabledTooltip: "Attiva la sezione di divisione dei costi nella pagina dell'evento",
+
+  // Dashboard active/archived (#193)
+  activeGames: "Giochi Attivi",
+  archivedGames: "Giochi Archiviati",
+  noArchivedGames: "Nessun gioco archiviato.",
 };
 
 export default it;

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -651,6 +651,15 @@ const pt: TranslationKeys = {
   logRatingRecalculated: "{actor} recalculou todos os ratings",
   logRatingManualEnabled: "{actor} ativou a edição manual de rating",
   logRatingManualDisabled: "{actor} desativou a edição manual de rating",
+
+  // Split costs toggle (#192)
+  splitCostsEnabled: "Divisão de custos",
+  splitCostsEnabledTooltip: "Ativar a secção de divisão de custos na página do evento",
+
+  // Dashboard active/archived (#193)
+  activeGames: "Jogos Ativos",
+  archivedGames: "Jogos Arquivados",
+  noArchivedGames: "Sem jogos arquivados.",
 };
 
 export default pt;

--- a/src/pages/api/events/[id]/split-costs.ts
+++ b/src/pages/api/events/[id]/split-costs.ts
@@ -1,0 +1,27 @@
+import type { APIRoute } from "astro";
+import { prisma } from "../../../../lib/db.server";
+import { checkOwnership } from "../../../../lib/auth.helpers.server";
+import { rateLimitResponse } from "../../../../lib/apiRateLimit.server";
+
+export const PUT: APIRoute = async ({ params, request }) => {
+  const limited = await rateLimitResponse(request, "write");
+  if (limited) return limited;
+
+  const event = await prisma.event.findUnique({ where: { id: params.id } });
+  if (!event) return Response.json({ error: "Not found." }, { status: 404 });
+
+  const { isOwner, isAdmin } = await checkOwnership(request, event.ownerId, undefined, params.id);
+  if (event.ownerId && !isOwner && !isAdmin) {
+    return Response.json({ error: "Only the event owner can do this." }, { status: 403 });
+  }
+
+  const body = await request.json();
+  const splitCostsEnabled = Boolean(body.splitCostsEnabled);
+
+  await prisma.event.update({
+    where: { id: params.id },
+    data: { splitCostsEnabled },
+  });
+
+  return Response.json({ splitCostsEnabled });
+};

--- a/src/pages/api/me/games.ts
+++ b/src/pages/api/me/games.ts
@@ -15,37 +15,31 @@ export const GET: APIRoute = async ({ request }) => {
   const ownedCursor = url.searchParams.get("ownedCursor") || null;
   const joinedCursor = url.searchParams.get("joinedCursor") || null;
 
+  const gameSelect = {
+    id: true,
+    title: true,
+    location: true,
+    dateTime: true,
+    sport: true,
+    maxPlayers: true,
+    archivedAt: true,
+    _count: { select: { players: true } },
+  } as const;
+
   const [ownedEvents, joinedPlayers] = await Promise.all([
     prisma.event.findMany({
-      where: { ownerId: userId, archivedAt: null },
-      select: {
-        id: true,
-        title: true,
-        location: true,
-        dateTime: true,
-        sport: true,
-        maxPlayers: true,
-        _count: { select: { players: true } },
-      },
+      where: { ownerId: userId },
+      select: gameSelect,
       orderBy: { dateTime: "desc" },
       take: limit + 1,
       ...(ownedCursor ? { cursor: { id: ownedCursor }, skip: 1 } : {}),
     }),
     prisma.player.findMany({
-      where: { userId, event: { archivedAt: null } },
+      where: { userId },
       select: {
         id: true,
         event: {
-          select: {
-            id: true,
-            title: true,
-            location: true,
-            dateTime: true,
-            sport: true,
-            maxPlayers: true,
-            ownerId: true,
-            _count: { select: { players: true } },
-          },
+          select: { ...gameSelect, ownerId: true },
         },
       },
       orderBy: { createdAt: "desc" },
@@ -69,17 +63,26 @@ export const GET: APIRoute = async ({ request }) => {
   const joinedHasMore = joinedPlayers.length > limit;
   const joinedSlice = joinedDeduped.slice(0, limit);
 
+  const mapGame = (e: typeof ownedSlice[number]) => ({
+    ...e,
+    dateTime: e.dateTime.toISOString(),
+    archivedAt: e.archivedAt?.toISOString() ?? null,
+    playerCount: e._count.players,
+  });
+
+  const allOwned = ownedSlice.map(mapGame);
+  const allJoined = joinedSlice.map((p) => ({
+    ...p.event,
+    dateTime: p.event.dateTime.toISOString(),
+    archivedAt: p.event.archivedAt?.toISOString() ?? null,
+    playerCount: p.event._count.players,
+  }));
+
   return Response.json({
-    owned: ownedSlice.map((e) => ({
-      ...e,
-      dateTime: e.dateTime.toISOString(),
-      playerCount: e._count.players,
-    })),
-    joined: joinedSlice.map((p) => ({
-      ...p.event,
-      dateTime: p.event.dateTime.toISOString(),
-      playerCount: p.event._count.players,
-    })),
+    owned: allOwned.filter((g) => !g.archivedAt),
+    joined: allJoined.filter((g) => !g.archivedAt),
+    archivedOwned: allOwned.filter((g) => !!g.archivedAt),
+    archivedJoined: allJoined.filter((g) => !!g.archivedAt),
     ownedNextCursor: ownedHasMore ? ownedSlice[ownedSlice.length - 1].id : null,
     ownedHasMore,
     joinedNextCursor: joinedHasMore && joinedSlice.length > 0

--- a/src/test/auth-api.test.ts
+++ b/src/test/auth-api.test.ts
@@ -960,3 +960,104 @@ describe("PATCH /api/events/[id]/history/[historyId]", () => {
     expect(bobAfter).toBeNull();
   });
 });
+
+// ─── PUT /api/events/[id]/split-costs (#192) ────────────────────────────────
+
+import { PUT as updateSplitCosts } from "~/pages/api/events/[id]/split-costs";
+
+function putCtx2(params: Record<string, string>, body: unknown) {
+  return ctx(params, body, "PUT");
+}
+
+describe("PUT /api/events/[id]/split-costs", () => {
+  it("returns 404 for unknown event", async () => {
+    const res = await updateSplitCosts(putCtx2({ id: "nonexistent" }, { splitCostsEnabled: false }));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 when event has owner and request is not from owner", async () => {
+    const user = await seedUser();
+    const id = await seedEvent({ ownerId: user.id });
+    mockAnonymous();
+    const res = await updateSplitCosts(putCtx2({ id }, { splitCostsEnabled: false }));
+    expect(res.status).toBe(403);
+  });
+
+  it("allows owner to disable split costs", async () => {
+    const user = await seedUser();
+    const id = await seedEvent({ ownerId: user.id });
+    mockAuth(user.id);
+    const res = await updateSplitCosts(putCtx2({ id }, { splitCostsEnabled: false }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.splitCostsEnabled).toBe(false);
+    // Verify in DB
+    const event = await testPrisma.event.findUnique({ where: { id } });
+    expect(event!.splitCostsEnabled).toBe(false);
+  });
+
+  it("allows owner to re-enable split costs", async () => {
+    const user = await seedUser();
+    const id = await seedEvent({ ownerId: user.id, splitCostsEnabled: false });
+    mockAuth(user.id);
+    const res = await updateSplitCosts(putCtx2({ id }, { splitCostsEnabled: true }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.splitCostsEnabled).toBe(true);
+  });
+
+  it("allows ownerless event to toggle split costs", async () => {
+    const { resetApiRateLimitStore: resetApi } = await import("~/lib/apiRateLimit.server");
+    await resetApi();
+    const id = await seedEvent();
+    mockAnonymous();
+    const res = await updateSplitCosts(putCtx2({ id }, { splitCostsEnabled: false }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.splitCostsEnabled).toBe(false);
+  });
+});
+
+// ─── GET /api/me/games — archived games (#193) ─────────────────────────────
+
+describe("GET /api/me/games — archived games", () => {
+  it("separates active and archived owned games", async () => {
+    const user = await seedUser();
+    mockAuth(user.id);
+    await seedEvent({ ownerId: user.id, title: "Active Game" });
+    await seedEvent({ ownerId: user.id, title: "Archived Game", archivedAt: new Date() });
+    const res = await getMyGames(ctx({}));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.owned).toHaveLength(1);
+    expect(body.owned[0].title).toBe("Active Game");
+    expect(body.archivedOwned).toHaveLength(1);
+    expect(body.archivedOwned[0].title).toBe("Archived Game");
+    expect(body.archivedOwned[0].archivedAt).toBeTruthy();
+  });
+
+  it("separates active and archived joined games", async () => {
+    const user = await seedUser();
+    mockAuth(user.id);
+    const activeId = await seedEvent({ title: "Active Joined" });
+    const archivedId = await seedEvent({ title: "Archived Joined", archivedAt: new Date() });
+    await testPrisma.player.create({ data: { name: user.name, eventId: activeId, userId: user.id } });
+    await testPrisma.player.create({ data: { name: user.name, eventId: archivedId, userId: user.id } });
+    const res = await getMyGames(ctx({}));
+    const body = await res.json();
+    expect(body.joined).toHaveLength(1);
+    expect(body.joined[0].title).toBe("Active Joined");
+    expect(body.archivedJoined).toHaveLength(1);
+    expect(body.archivedJoined[0].title).toBe("Archived Joined");
+  });
+
+  it("returns empty archived arrays when no archived games exist", async () => {
+    const user = await seedUser();
+    mockAuth(user.id);
+    await seedEvent({ ownerId: user.id });
+    const res = await getMyGames(ctx({}));
+    const body = await res.json();
+    expect(body.archivedOwned).toHaveLength(0);
+    expect(body.archivedJoined).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the ability to toggle split costs per event and display per-player cost breakdowns on the dashboard and game cards.

## Changes

- **Schema**: Add `splitCostsEnabled` boolean field to `Event` model with migration
- **API**: New `/api/events/[id]/split-costs` endpoint to toggle the setting
- **API**: Include cost data in `/api/me/games` response when split costs is enabled
- **Dashboard**: Show per-player cost breakdown on dashboard page
- **Game Cards**: Display cost info on game cards when applicable
- **Settings**: Add split costs toggle to event settings page
- **i18n**: Add translation strings for all 6 locales (en, pt, es, fr, de, it)
- **Tests**: Add tests for split costs API and dashboard data

Closes #192, closes #193