### PR TITLE
feat: watch PWA with responsive layout and back-navigation fix

### DIFF
--- a/src/components/EventPage.tsx
+++ b/src/components/EventPage.tsx
@@ -33,6 +33,7 @@ import LockIcon from "@mui/icons-material/Lock";
 import EmojiEventsIcon from "@mui/icons-material/EmojiEvents";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
 import AssignmentIcon from "@mui/icons-material/Assignment";
+import WatchIcon from "@mui/icons-material/Watch";
 import { ThemeModeProvider } from "./ThemeModeProvider";
 import { ResponsiveLayout } from "./ResponsiveLayout";
 import { TeamPicker } from "./TeamPicker";
@@ -337,6 +338,77 @@ function MoreActionsMenu({ eventId, event, gameDate }: {
           <ListItemText>{t("addToGoogleCalendar")}</ListItemText>
         </MenuItem>
       </Menu>
+    </>
+  );
+}
+
+// ── Watch score button ────────────────────────────────────────────────────────
+
+function WatchScoreButton({ eventId }: { eventId: string }) {
+  const t = useT();
+  const [open, setOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const watchUrl = typeof window !== "undefined"
+    ? `${window.location.origin}/watch/${eventId}`
+    : `/watch/${eventId}`;
+  const canShare = typeof navigator !== "undefined" && !!navigator.share;
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(watchUrl);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2500);
+  };
+
+  const handleShare = async () => {
+    if (canShare) {
+      try {
+        await navigator.share({ title: t("watchScore"), url: watchUrl });
+        return;
+      } catch { /* cancelled */ }
+    }
+    handleCopy();
+  };
+
+  return (
+    <>
+      <Button variant="outlined" size="small" startIcon={<WatchIcon />}
+        onClick={() => setOpen(true)} sx={{ flexShrink: 0 }}>
+        {t("watchScore")}
+      </Button>
+      <Dialog open={open} onClose={() => setOpen(false)} maxWidth="xs" fullWidth>
+        <DialogTitle>{t("watchScore")}</DialogTitle>
+        <DialogContent>
+          <DialogContentText sx={{ mb: 2 }}>{t("watchScoreDesc")}</DialogContentText>
+          <Paper variant="outlined" sx={{ borderRadius: 2, p: 1.5, display: "flex", alignItems: "center", gap: 1 }}>
+            <Typography variant="body2" sx={{
+              flexGrow: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap",
+              fontFamily: "monospace", fontSize: "0.75rem", minWidth: 0,
+            }}>
+              {watchUrl}
+            </Typography>
+            <Button
+              variant={copied ? "outlined" : "contained"}
+              size="small"
+              color={copied ? "success" : "primary"}
+              startIcon={copied ? <CheckIcon /> : <ContentCopyIcon />}
+              onClick={handleCopy}
+              sx={{ flexShrink: 0 }}
+            >
+              {copied ? t("watchLinkCopied") : t("watchCopyLink")}
+            </Button>
+          </Paper>
+        </DialogContent>
+        <DialogActions>
+          {canShare && (
+            <Button onClick={handleShare} startIcon={<ShareIcon />}>
+              {t("shareGameMobile")}
+            </Button>
+          )}
+          <Button href={watchUrl} target="_blank" rel="noopener noreferrer" variant="contained">
+            {t("watchScore")}
+          </Button>
+        </DialogActions>
+      </Dialog>
     </>
   );
 }
@@ -1090,6 +1162,9 @@ export default function EventPage({ eventId }: { eventId: string }) {
                       </Button>
                     )}
                     <NotifyButton eventId={eventId} />
+                    {localMatches && localMatches.length > 0 && (
+                      <WatchScoreButton eventId={eventId} />
+                    )}
 
                     {/* Secondary actions — "More" menu */}
                     <MoreActionsMenu

--- a/src/components/watch/WatchGameList.tsx
+++ b/src/components/watch/WatchGameList.tsx
@@ -1,0 +1,238 @@
+import { useState, useEffect } from "react";
+import type { WatchEvent, WatchEventsResponse } from "./watchTypes";
+import { flushPendingSyncs, getPendingSyncs } from "./watchTypes";
+import { t, watchBase, card, TAP_MIN_CSS } from "./watchTheme";
+
+/**
+ * Game list screen — M3 dark theme, optimised for round & square smartwatches.
+ * Shows today's events; tappable only when teams are assigned.
+ */
+export default function WatchGameList() {
+  const [events, setEvents] = useState<WatchEvent[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [pendingCount, setPendingCount] = useState(0);
+
+  useEffect(() => {
+    // Skip auto-select when the user navigated back from a game screen
+    const cameFromGame = document.referrer && new URL(document.referrer, location.origin).pathname.startsWith("/watch/") && new URL(document.referrer, location.origin).pathname !== "/watch/";
+
+    fetch("/api/watch/events")
+      .then((r) => {
+        if (!r.ok) throw new Error("Failed to load");
+        return r.json() as Promise<WatchEventsResponse>;
+      })
+      .then((data) => {
+        setEvents(data.events);
+        if (data.autoSelectId && !cameFromGame) {
+          window.location.href = `/watch/${data.autoSelectId}`;
+        }
+      })
+      .catch(() => setError("Offline — no cached data"))
+      .finally(() => setLoading(false));
+
+    getPendingSyncs().then((p) => setPendingCount(p.length));
+  }, []);
+
+  useEffect(() => {
+    const flush = () => {
+      flushPendingSyncs().then((n) => {
+        if (n > 0) getPendingSyncs().then((p) => setPendingCount(p.length));
+      });
+    };
+    window.addEventListener("online", flush);
+    flush();
+    return () => window.removeEventListener("online", flush);
+  }, []);
+
+  return (
+    <div style={{ ...watchBase, gap: "clamp(4px, 3vw, 8px)" }}>
+      {/* Header */}
+      <div style={styles.header}>
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" style={{ marginRight: 6 }}>
+          <circle cx="12" cy="12" r="10" stroke={t.primary} strokeWidth="2" />
+          <path d="M12 6v6l4 2" stroke={t.primary} strokeWidth="2" strokeLinecap="round" />
+        </svg>
+        <span style={styles.headerText}>Today</span>
+      </div>
+
+      {/* Pending sync banner */}
+      {pendingCount > 0 && (
+        <div style={styles.pendingBanner}>
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" style={{ marginRight: 4, flexShrink: 0 }}>
+            <path d="M12 2v4m0 12v4M4.93 4.93l2.83 2.83m8.48 8.48l2.83 2.83M2 12h4m12 0h4M4.93 19.07l2.83-2.83m8.48-8.48l2.83-2.83" stroke={t.warning} strokeWidth="2" strokeLinecap="round" />
+          </svg>
+          {pendingCount} pending
+        </div>
+      )}
+
+      {/* States */}
+      {loading && <p style={styles.statusMsg}>Loading…</p>}
+      {error && <p style={{ ...styles.statusMsg, color: t.error }}>{error}</p>}
+      {!loading && !error && events.length === 0 && (
+        <div style={styles.emptyState}>
+          <svg width="32" height="32" viewBox="0 0 24 24" fill="none">
+            <rect x="3" y="4" width="18" height="16" rx="3" stroke={t.outline} strokeWidth="1.5" />
+            <path d="M3 9h18" stroke={t.outline} strokeWidth="1.5" />
+            <circle cx="12" cy="14.5" r="1" fill={t.outline} />
+          </svg>
+          <span style={{ color: t.onSurfaceVariant, fontSize: "clamp(10px, 6vw, 12px)", marginTop: 4 }}>No games today</span>
+        </div>
+      )}
+
+      {/* Event cards */}
+      {events.map((ev) => (
+        <EventCard key={ev.id} event={ev} />
+      ))}
+    </div>
+  );
+}
+
+function EventCard({ event: ev }: { event: WatchEvent }) {
+  const disabled = !ev.hasTeams;
+  const Wrapper = disabled ? "div" : "a";
+
+  return (
+    <Wrapper
+      {...(disabled ? {} : { href: `/watch/${ev.id}` })}
+      style={{
+        ...card,
+        ...(ev.isHappeningNow && !disabled ? { borderColor: t.primary } : {}),
+        ...(disabled ? { opacity: 0.45, pointerEvents: "none" as const } : {}),
+        minHeight: TAP_MIN_CSS,
+      }}
+      aria-disabled={disabled}
+    >
+      {/* Top row: title + live badge */}
+      <div style={styles.cardTop}>
+        <span style={styles.cardTitle}>{ev.title}</span>
+        {ev.isHappeningNow && (
+          <span style={styles.liveBadge}>
+            <span style={styles.liveDot} />
+            LIVE
+          </span>
+        )}
+      </div>
+
+      {/* Bottom row: score or status */}
+      {disabled ? (
+        <span style={styles.cardSub}>No teams yet</span>
+      ) : ev.latestGame ? (
+        <div style={styles.scoreRow}>
+          <span style={styles.scoreTeam}>{ev.latestGame.teamOneName}</span>
+          <span style={styles.scoreBig}>
+            {ev.latestGame.scoreOne} – {ev.latestGame.scoreTwo}
+          </span>
+          <span style={styles.scoreTeam}>{ev.latestGame.teamTwoName}</span>
+        </div>
+      ) : (
+        <span style={styles.cardSub}>Tap to start scoring</span>
+      )}
+    </Wrapper>
+  );
+}
+
+/* ── Styles ─────────────────────────────────────────────────────── */
+
+const styles: Record<string, React.CSSProperties> = {
+  header: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    paddingTop: "clamp(2px, 1vw, 4px)",
+    paddingBottom: 2,
+  },
+  headerText: {
+    fontSize: "clamp(12px, 8vw, 15px)",
+    fontWeight: 700,
+    letterSpacing: "0.02em",
+    color: t.onSurface,
+  },
+  pendingBanner: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    background: t.warningContainer,
+    color: t.warning,
+    fontSize: "clamp(9px, 6vw, 11px)",
+    fontWeight: 600,
+    borderRadius: 9999,
+    padding: "clamp(2px, 1.5vw, 4px) clamp(8px, 5vw, 12px)",
+    width: "fit-content",
+  },
+  statusMsg: {
+    textAlign: "center",
+    color: t.onSurfaceVariant,
+    fontSize: "clamp(11px, 7vw, 13px)",
+    margin: "clamp(8px, 5vw, 16px) 0",
+  },
+  emptyState: {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    justifyContent: "center",
+    flex: 1,
+    gap: 2,
+    marginTop: "clamp(12px, 8vw, 24px)",
+  },
+  cardTop: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: "clamp(3px, 2vw, 6px)",
+  },
+  cardTitle: {
+    fontWeight: 600,
+    fontSize: "clamp(10px, 7vw, 13px)",
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+    flex: 1,
+  },
+  liveBadge: {
+    display: "inline-flex",
+    alignItems: "center",
+    gap: "clamp(2px, 1.5vw, 4px)",
+    fontSize: "clamp(7px, 5vw, 9px)",
+    fontWeight: 700,
+    letterSpacing: "0.06em",
+    color: t.error,
+    background: t.errorContainer,
+    borderRadius: 9999,
+    padding: "2px clamp(4px, 3vw, 7px) 2px clamp(3px, 2vw, 5px)",
+    flexShrink: 0,
+  },
+  liveDot: {
+    width: "clamp(4px, 2.5vw, 5px)",
+    height: "clamp(4px, 2.5vw, 5px)",
+    borderRadius: "50%",
+    background: t.error,
+    animation: "pulse 1.5s infinite",
+  },
+  scoreRow: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: "clamp(2px, 1.5vw, 4px)",
+    marginTop: 2,
+  },
+  scoreTeam: {
+    fontSize: "clamp(8px, 5vw, 10px)",
+    color: t.onSurfaceVariant,
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+    maxWidth: "30%",
+  },
+  scoreBig: {
+    fontWeight: 700,
+    fontSize: "clamp(12px, 8vw, 16px)",
+    color: t.primary,
+    letterSpacing: "0.04em",
+  },
+  cardSub: {
+    fontSize: "clamp(9px, 6vw, 11px)",
+    color: t.onSurfaceVariant,
+    marginTop: 2,
+  },
+};

--- a/src/components/watch/WatchScoreTracker.tsx
+++ b/src/components/watch/WatchScoreTracker.tsx
@@ -1,0 +1,435 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+import type { WatchEvent } from "./watchTypes";
+import { savePendingSync, flushPendingSyncs } from "./watchTypes";
+import { t, watchBase, surfaceBtn, TAP_MIN_CSS } from "./watchTheme";
+
+interface Props {
+  eventId: string;
+}
+
+/** Auto-save debounce delay in ms */
+const SAVE_DELAY = 800;
+
+/**
+ * Score tracker screen — M3 dark theme, optimised for round & square watches.
+ * Large circular +/- buttons, centered layout safe for round bezels.
+ * Auto-saves on every score change (debounced).
+ */
+export default function WatchScoreTracker({ eventId }: Props) {
+  const [event, setEvent] = useState<WatchEvent | null>(null);
+  const [scoreOne, setScoreOne] = useState(0);
+  const [scoreTwo, setScoreTwo] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [syncStatus, setSyncStatus] = useState<"idle" | "saving" | "saved" | "offline">("idle");
+  const [error, setError] = useState<string | null>(null);
+
+  // Refs for debounced auto-save
+  const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const latestScores = useRef({ scoreOne: 0, scoreTwo: 0 });
+  const initialLoad = useRef(true);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadEvent() {
+      try {
+        const r = await fetch(`/api/watch/events?eventId=${eventId}`);
+        if (!r.ok) throw new Error("Not found");
+        const data: WatchEvent = await r.json();
+
+        // If the event has teams but no history, auto-create a game history record
+        if (data.hasTeams && !data.latestGame) {
+          const createRes = await fetch("/api/watch/events", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ eventId }),
+          });
+
+          if (createRes.ok) {
+            const created = await createRes.json();
+            data.latestGame = {
+              id: created.id,
+              scoreOne: created.scoreOne,
+              scoreTwo: created.scoreTwo,
+              teamOneName: created.teamOneName,
+              teamTwoName: created.teamTwoName,
+              editable: created.editable,
+            };
+          }
+        }
+
+        if (!cancelled) {
+          setEvent(data);
+          const s1 = data.latestGame?.scoreOne ?? 0;
+          const s2 = data.latestGame?.scoreTwo ?? 0;
+          setScoreOne(s1);
+          setScoreTwo(s2);
+          latestScores.current = { scoreOne: s1, scoreTwo: s2 };
+          // Mark initial load done after a tick so the first setState doesn't trigger save
+          setTimeout(() => { initialLoad.current = false; }, 50);
+        }
+      } catch {
+        if (!cancelled) setError("Could not load event");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    loadEvent();
+    return () => { cancelled = true; };
+  }, [eventId]);
+
+  // Auto-save whenever scores change (debounced)
+  const doSave = useCallback(async () => {
+    if (!event?.latestGame) return;
+    const { scoreOne: s1, scoreTwo: s2 } = latestScores.current;
+    const historyId = event.latestGame.id;
+
+    setSyncStatus("saving");
+
+    try {
+      const res = await fetch(`/api/events/${eventId}/history/${historyId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ scoreOne: s1, scoreTwo: s2 }),
+      });
+
+      if (res.ok) {
+        setSyncStatus("saved");
+      } else {
+        throw new Error("Server error");
+      }
+    } catch {
+      await savePendingSync({
+        eventId,
+        historyId,
+        scoreOne: s1,
+        scoreTwo: s2,
+        timestamp: Date.now(),
+      });
+      setSyncStatus("offline");
+    }
+  }, [event, eventId]);
+
+  // Trigger debounced save on score change
+  useEffect(() => {
+    if (initialLoad.current) return;
+    if (!event?.latestGame) return;
+
+    latestScores.current = { scoreOne, scoreTwo };
+    setSyncStatus("idle");
+
+    if (saveTimer.current) clearTimeout(saveTimer.current);
+    saveTimer.current = setTimeout(() => { doSave(); }, SAVE_DELAY);
+
+    return () => {
+      if (saveTimer.current) clearTimeout(saveTimer.current);
+    };
+  }, [scoreOne, scoreTwo, doSave, event]);
+
+  // Flush pending syncs when coming online
+  useEffect(() => {
+    const flush = () => { flushPendingSyncs(); };
+    window.addEventListener("online", flush);
+    return () => window.removeEventListener("online", flush);
+  }, []);
+
+  const inc = useCallback((team: 1 | 2) => {
+    if (team === 1) setScoreOne((s) => s + 1);
+    else setScoreTwo((s) => s + 1);
+  }, []);
+
+  const dec = useCallback((team: 1 | 2) => {
+    if (team === 1) setScoreOne((s) => Math.max(0, s - 1));
+    else setScoreTwo((s) => Math.max(0, s - 1));
+  }, []);
+
+  /* ── Loading / error states ─────────────────────────────────── */
+
+  if (loading) {
+    return (
+      <div style={{ ...watchBase, justifyContent: "center" }}>
+        <div style={styles.spinner} />
+        <p style={styles.statusMsg}>Loading…</p>
+      </div>
+    );
+  }
+
+  if (error && !event) {
+    return (
+      <div style={{ ...watchBase, justifyContent: "center" }}>
+        <p style={{ ...styles.statusMsg, color: t.error }}>{error}</p>
+        <a href="/watch/" style={styles.backLink}>Back</a>
+      </div>
+    );
+  }
+
+  if (!event) {
+    return (
+      <div style={{ ...watchBase, justifyContent: "center" }}>
+        <p style={styles.statusMsg}>Event not found</p>
+        <a href="/watch/" style={styles.backLink}>Back</a>
+      </div>
+    );
+  }
+
+  const teamA = event.latestGame?.teamOneName ?? event.teamOneName;
+  const teamB = event.latestGame?.teamTwoName ?? event.teamTwoName;
+  const noGame = !event.latestGame;
+
+  /* ── Main UI ────────────────────────────────────────────────── */
+
+  return (
+    <div style={{ ...watchBase, justifyContent: "center", gap: 2 }}>
+      {/* Back button — top-left, safe for round bezels */}
+      <a href="/watch/" style={styles.backBtn} aria-label="Back to game list">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none">
+          <path d="M15 19l-7-7 7-7" stroke={t.primary} strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+      </a>
+
+      {/* Sync status indicator — top-right */}
+      <div style={styles.syncIndicator}>
+        {syncStatus === "saving" && <div style={{ ...styles.spinnerSmall }} />}
+        {syncStatus === "saved" && (
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none">
+            <path d="M5 13l4 4L19 7" stroke={t.primary} strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        )}
+        {syncStatus === "offline" && (
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none">
+            <circle cx="12" cy="12" r="10" stroke={t.warning} strokeWidth="2" />
+            <path d="M12 8v4m0 4h.01" stroke={t.warning} strokeWidth="2" strokeLinecap="round" />
+          </svg>
+        )}
+      </div>
+
+      {/* No-game warning */}
+      {noGame && (
+        <div style={styles.warningChip}>
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" style={{ flexShrink: 0 }}>
+            <path d="M12 9v4m0 4h.01M12 2L2 20h20L12 2z" stroke={t.warning} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+          <span>Start game from main app</span>
+        </div>
+      )}
+
+      {/* ── Team A ──────────────────────────────────────────── */}
+      <TeamScoreRow
+        teamName={teamA}
+        score={scoreOne}
+        onInc={() => inc(1)}
+        onDec={() => dec(1)}
+        disabled={noGame}
+        ariaPrefix={teamA}
+      />
+
+      {/* Divider */}
+      <div style={styles.divider}>
+        <span style={styles.vs}>VS</span>
+      </div>
+
+      {/* ── Team B ──────────────────────────────────────────── */}
+      <TeamScoreRow
+        teamName={teamB}
+        score={scoreTwo}
+        onInc={() => inc(2)}
+        onDec={() => dec(2)}
+        disabled={noGame}
+        ariaPrefix={teamB}
+      />
+
+      {/* Offline note at bottom */}
+      {syncStatus === "offline" && (
+        <span style={styles.offlineChip}>Saved offline — will sync later</span>
+      )}
+    </div>
+  );
+}
+
+/* ── Team score row sub-component ──────────────────────────────── */
+
+function TeamScoreRow({
+  teamName,
+  score,
+  onInc,
+  onDec,
+  disabled,
+  ariaPrefix,
+}: {
+  teamName: string;
+  score: number;
+  onInc: () => void;
+  onDec: () => void;
+  disabled: boolean;
+  ariaPrefix: string;
+}) {
+  return (
+    <div style={styles.teamBlock}>
+      <span style={styles.teamName}>{teamName}</span>
+      <div style={styles.controlRow}>
+        <button
+          style={{
+            ...surfaceBtn,
+            width: TAP_MIN_CSS,
+            height: TAP_MIN_CSS,
+            fontSize: "clamp(16px, 12vw, 22px)",
+            ...(disabled || score === 0 ? { opacity: 0.3, pointerEvents: "none" as const } : {}),
+          }}
+          onClick={onDec}
+          disabled={disabled || score === 0}
+          aria-label={`Decrease ${ariaPrefix} score`}
+        >
+          −
+        </button>
+
+        <span style={styles.scoreDisplay}>{score}</span>
+
+        <button
+          style={{
+            ...surfaceBtn,
+            width: TAP_MIN_CSS,
+            height: TAP_MIN_CSS,
+            fontSize: "clamp(16px, 12vw, 22px)",
+            ...(disabled ? { opacity: 0.3, pointerEvents: "none" as const } : {}),
+          }}
+          onClick={onInc}
+          disabled={disabled}
+          aria-label={`Increase ${ariaPrefix} score`}
+        >
+          +
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/* ── Styles ─────────────────────────────────────────────────────── */
+
+const styles: Record<string, React.CSSProperties> = {
+  statusMsg: {
+    textAlign: "center",
+    color: t.onSurfaceVariant,
+    fontSize: "clamp(11px, 7vw, 13px)",
+  },
+  backBtn: {
+    position: "absolute",
+    top: "env(safe-area-inset-top, 8px)",
+    left: "env(safe-area-inset-left, 8px)",
+    width: "clamp(28px, 18vw, 36px)",
+    height: "clamp(28px, 18vw, 36px)",
+    borderRadius: "50%",
+    background: t.surfaceContainerHigh,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    textDecoration: "none",
+    zIndex: 10,
+  },
+  backLink: {
+    color: t.primary,
+    textDecoration: "none",
+    fontSize: "clamp(11px, 7vw, 13px)",
+    fontWeight: 600,
+    marginTop: 8,
+  },
+  syncIndicator: {
+    position: "absolute",
+    top: "env(safe-area-inset-top, 8px)",
+    right: "env(safe-area-inset-right, 8px)",
+    width: "clamp(22px, 14vw, 28px)",
+    height: "clamp(22px, 14vw, 28px)",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    zIndex: 10,
+  },
+  warningChip: {
+    display: "flex",
+    alignItems: "center",
+    gap: "clamp(3px, 2vw, 5px)",
+    background: t.warningContainer,
+    color: t.warning,
+    fontSize: "clamp(8px, 5vw, 10px)",
+    fontWeight: 600,
+    borderRadius: 9999,
+    padding: "2px clamp(6px, 4vw, 10px)",
+    marginBottom: 2,
+  },
+  teamBlock: {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    gap: "clamp(0px, 0.5vw, 2px)",
+    width: "100%",
+    maxWidth: "min(220px, 92vw)",
+  },
+  teamName: {
+    fontWeight: 600,
+    fontSize: "clamp(9px, 6vw, 12px)",
+    color: t.onSurfaceVariant,
+    textAlign: "center",
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+    maxWidth: "90%",
+    letterSpacing: "0.02em",
+    textTransform: "uppercase",
+  },
+  controlRow: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: "clamp(4px, 3vw, 12px)",
+  },
+  scoreDisplay: {
+    fontWeight: 800,
+    fontSize: "clamp(24px, 20vw, 36px)",
+    color: t.primary,
+    minWidth: "clamp(32px, 22vw, 48px)",
+    textAlign: "center",
+    lineHeight: 1,
+    fontVariantNumeric: "tabular-nums",
+  },
+  divider: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    width: "100%",
+    maxWidth: "min(200px, 85vw)",
+    margin: "0 auto",
+    position: "relative",
+  },
+  vs: {
+    fontSize: "clamp(8px, 5vw, 10px)",
+    fontWeight: 700,
+    color: t.outline,
+    letterSpacing: "0.1em",
+    background: t.surface,
+    padding: "0 clamp(4px, 3vw, 8px)",
+    zIndex: 1,
+  },
+  offlineChip: {
+    display: "inline-flex",
+    alignItems: "center",
+    fontSize: "clamp(8px, 5vw, 10px)",
+    color: t.warning,
+    marginTop: "clamp(2px, 1vw, 4px)",
+  },
+  spinner: {
+    width: 20,
+    height: 20,
+    border: `3px solid ${t.outlineVariant}`,
+    borderTopColor: t.primary,
+    borderRadius: "50%",
+    animation: "spin 0.8s linear infinite",
+  },
+  spinnerSmall: {
+    width: 14,
+    height: 14,
+    border: `2px solid ${t.outlineVariant}`,
+    borderTopColor: t.primary,
+    borderRadius: "50%",
+    animation: "spin 0.8s linear infinite",
+  },
+};

--- a/src/components/watch/watchTheme.ts
+++ b/src/components/watch/watchTheme.ts
@@ -1,0 +1,115 @@
+/**
+ * Watch PWA theme tokens — M3-inspired, dark-only (OLED-friendly).
+ *
+ * Designed for round and square smartwatches:
+ * - High contrast on dark backgrounds
+ * - Large touch targets (≥48px)
+ * - Safe area insets for round displays
+ * - Tonal surface hierarchy from the main app's green palette
+ */
+
+export const t = {
+  // Surfaces (dark, tonal hierarchy)
+  surface: "#111412",
+  surfaceContainer: "#1a1d1b",
+  surfaceContainerHigh: "#242724",
+  surfaceContainerHighest: "#2e312e",
+
+  // Primary (green from main app)
+  primary: "#7edcab",
+  primaryContainer: "#1b6b4a",
+  onPrimary: "#003822",
+  onPrimaryContainer: "#a8ecc8",
+
+  // Secondary
+  secondary: "#b2ccbf",
+  secondaryContainer: "#3a5347",
+  onSecondaryContainer: "#cee8da",
+
+  // Error
+  error: "#ffb4ab",
+  errorContainer: "#93000a",
+  onErrorContainer: "#ffdad6",
+
+  // Warning / amber
+  warning: "#f5bf48",
+  warningContainer: "#5c4300",
+
+  // Text
+  onSurface: "#e1e3de",
+  onSurfaceVariant: "#c2c9c1",
+  outline: "#8c9389",
+  outlineVariant: "#3a3f3b",
+
+  // Misc
+  scrim: "rgba(0,0,0,0.6)",
+  shadow: "rgba(0,0,0,0.3)",
+} as const;
+
+/** Shared style helpers for watch components */
+export const watchBase: React.CSSProperties = {
+  background: t.surface,
+  color: t.onSurface,
+  minHeight: "100vh",
+  fontFamily: "-apple-system, 'SF Pro Rounded', 'Roboto', sans-serif",
+  fontSize: "clamp(12px, 7vw, 14px)",
+  WebkitFontSmoothing: "antialiased",
+  // Safe area for round watches — content stays inside the inscribed square
+  padding: "env(safe-area-inset-top, clamp(4px, 3vw, 8px)) env(safe-area-inset-right, clamp(4px, 3vw, 8px)) env(safe-area-inset-bottom, clamp(4px, 3vw, 8px)) env(safe-area-inset-left, clamp(4px, 3vw, 8px))",
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+};
+
+/**
+ * Minimum touch target — scales from 36px on tiny watches to 48px on normal ones.
+ * Uses clamp() so CSS handles the scaling; the constant is kept for non-CSS contexts.
+ */
+export const TAP_MIN = 48;
+export const TAP_MIN_CSS = "clamp(36px, 25vw, 48px)";
+
+/** Pill-shaped button base */
+export const pillBtn: React.CSSProperties = {
+  minWidth: TAP_MIN_CSS,
+  minHeight: TAP_MIN_CSS,
+  border: "none",
+  borderRadius: 9999,
+  fontWeight: 700,
+  cursor: "pointer",
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  transition: "background 0.15s, transform 0.1s",
+  WebkitTapHighlightColor: "transparent",
+  userSelect: "none",
+};
+
+/** Tonal filled button (primary container) */
+export const tonalBtn: React.CSSProperties = {
+  ...pillBtn,
+  background: t.primaryContainer,
+  color: t.onPrimaryContainer,
+};
+
+/** Surface-variant button (score +/-) */
+export const surfaceBtn: React.CSSProperties = {
+  ...pillBtn,
+  background: t.surfaceContainerHigh,
+  color: t.onSurface,
+};
+
+/** Card / list-item surface */
+export const card: React.CSSProperties = {
+  background: t.surfaceContainer,
+  borderRadius: 16,
+  padding: "clamp(6px, 4vw, 12px) clamp(8px, 5vw, 16px)",
+  width: "100%",
+  maxWidth: "min(220px, 90vw)",
+  textDecoration: "none",
+  color: t.onSurface,
+  display: "flex",
+  flexDirection: "column",
+  gap: "clamp(2px, 1vw, 4px)",
+  border: `1px solid ${t.outlineVariant}`,
+  transition: "border-color 0.15s",
+};

--- a/src/components/watch/watchTypes.ts
+++ b/src/components/watch/watchTypes.ts
@@ -1,0 +1,105 @@
+/** Shared types for the watch PWA */
+export interface WatchEvent {
+  id: string;
+  title: string;
+  sport: string;
+  dateTime: string;
+  teamOneName: string;
+  teamTwoName: string;
+  hasTeams: boolean;
+  isHappeningNow: boolean;
+  hasHistory: boolean;
+  latestGame: {
+    id: string;
+    scoreOne: number;
+    scoreTwo: number;
+    teamOneName: string;
+    teamTwoName: string;
+    editable: boolean;
+  } | null;
+}
+
+/** Response from GET /api/watch/events (list mode) */
+export interface WatchEventsResponse {
+  events: WatchEvent[];
+  /** Event ID to auto-navigate to (only set for logged-in users) */
+  autoSelectId: string | null;
+}
+
+/** IndexedDB helpers for offline score sync */
+export interface PendingSync {
+  eventId: string;
+  historyId: string;
+  scoreOne: number;
+  scoreTwo: number;
+  timestamp: number;
+}
+
+const DB_NAME = "convocados-watch";
+const STORE_NAME = "pending-syncs";
+
+function openDB(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, 1);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME, { keyPath: "historyId" });
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+export async function savePendingSync(sync: PendingSync): Promise<void> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, "readwrite");
+    tx.objectStore(STORE_NAME).put(sync);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+export async function getPendingSyncs(): Promise<PendingSync[]> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, "readonly");
+    const req = tx.objectStore(STORE_NAME).getAll();
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+export async function removePendingSync(historyId: string): Promise<void> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, "readwrite");
+    tx.objectStore(STORE_NAME).delete(historyId);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+/** Flush all pending syncs to the server. Returns count of successful syncs. */
+export async function flushPendingSyncs(): Promise<number> {
+  const pending = await getPendingSyncs();
+  let synced = 0;
+  for (const p of pending) {
+    try {
+      const res = await fetch(`/api/events/${p.eventId}/history/${p.historyId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ scoreOne: p.scoreOne, scoreTwo: p.scoreTwo }),
+      });
+      if (res.ok) {
+        await removePendingSync(p.historyId);
+        synced++;
+      }
+    } catch {
+      // Still offline, skip
+    }
+  }
+  return synced;
+}

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -81,6 +81,13 @@ const de: TranslationKeys = {
   noSuggestions: "Neuen Namen eingeben",
   createNewPlayer: "Neuen Spieler erstellen: {name}",
   nGamesPlayed: "{n} Spiele",
+
+  // Watch
+  watchScore: "Ergebnis auf Uhr",
+  watchScoreDesc: "Öffne diesen Link auf deiner Smartwatch, um das Ergebnis live zu verfolgen.",
+  watchCopyLink: "Uhr-Link kopieren",
+  watchLinkCopied: "Uhr-Link kopiert!",
+
   history: "Verlauf",
   viewHistory: "Verlauf anzeigen",
   noHistory: "Noch keine vergangenen Spiele.",

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -94,6 +94,12 @@ const en = {
   createNewPlayer: "Create new player: {name}",
   nGamesPlayed: "{n} games",
 
+  // Watch
+  watchScore: "Watch Score",
+  watchScoreDesc: "Open this link on your smartwatch to track the score live.",
+  watchCopyLink: "Copy watch link",
+  watchLinkCopied: "Watch link copied!",
+
   // History
   history: "History",
   viewHistory: "View history",

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -81,6 +81,13 @@ const es: TranslationKeys = {
   noSuggestions: "Escribe un nuevo nombre",
   createNewPlayer: "Crear nuevo jugador: {name}",
   nGamesPlayed: "{n} juegos",
+
+  // Watch
+  watchScore: "Marcador en Reloj",
+  watchScoreDesc: "Abre este enlace en tu smartwatch para seguir el marcador en vivo.",
+  watchCopyLink: "Copiar enlace del reloj",
+  watchLinkCopied: "¡Enlace del reloj copiado!",
+
   history: "Historial",
   viewHistory: "Ver historial",
   noHistory: "Aún no hay juegos anteriores.",

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -81,6 +81,13 @@ const fr: TranslationKeys = {
   noSuggestions: "Tape un nouveau nom",
   createNewPlayer: "Créer un nouveau joueur : {name}",
   nGamesPlayed: "{n} matchs",
+
+  // Watch
+  watchScore: "Score sur Montre",
+  watchScoreDesc: "Ouvre ce lien sur ta montre connectée pour suivre le score en direct.",
+  watchCopyLink: "Copier le lien montre",
+  watchLinkCopied: "Lien montre copié !",
+
   history: "Historique",
   viewHistory: "Voir l'historique",
   noHistory: "Pas encore de matchs passés.",

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -81,6 +81,13 @@ const it: TranslationKeys = {
   noSuggestions: "Scrivi un nuovo nome",
   createNewPlayer: "Crea nuovo giocatore: {name}",
   nGamesPlayed: "{n} partite",
+
+  // Watch
+  watchScore: "Punteggio su Orologio",
+  watchScoreDesc: "Apri questo link sul tuo smartwatch per seguire il punteggio in tempo reale.",
+  watchCopyLink: "Copia link orologio",
+  watchLinkCopied: "Link orologio copiato!",
+
   history: "Cronologia",
   viewHistory: "Vedi cronologia",
   noHistory: "Nessuna partita passata.",

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -95,6 +95,12 @@ const pt: TranslationKeys = {
   createNewPlayer: "Criar novo jogador: {name}",
   nGamesPlayed: "{n} jogos",
 
+  // Watch
+  watchScore: "Resultado no Relógio",
+  watchScoreDesc: "Abre este link no teu smartwatch para acompanhar o resultado em tempo real.",
+  watchCopyLink: "Copiar link do relógio",
+  watchLinkCopied: "Link do relógio copiado!",
+
   // History
   history: "Histórico",
   viewHistory: "Ver histórico",

--- a/src/pages/api/watch/events.ts
+++ b/src/pages/api/watch/events.ts
@@ -1,0 +1,275 @@
+import type { APIRoute } from "astro";
+import { prisma } from "../../../lib/db.server";
+import { getSession } from "../../../lib/auth.helpers.server";
+
+/** How many minutes before/after the event dateTime we consider it "happening now" */
+const HAPPENING_WINDOW_MS = 90 * 60 * 1000; // 90 minutes
+
+/**
+ * POST /api/watch/events
+ * Auto-creates a GameHistory record for an event that has teams but no history yet.
+ * This allows the watch to start tracking scores without waiting for recurrence rollover.
+ */
+export const POST: APIRoute = async ({ request }) => {
+  const session = await getSession(request);
+  if (!session?.user) {
+    return Response.json({ error: "Authentication required." }, { status: 401 });
+  }
+
+  const body = await request.json();
+  const eventId = body.eventId;
+  if (!eventId || typeof eventId !== "string") {
+    return Response.json({ error: "eventId is required." }, { status: 400 });
+  }
+
+  const event = await prisma.event.findUnique({
+    where: { id: eventId },
+    include: {
+      teamResults: {
+        select: { id: true, name: true, members: { select: { name: true, order: true } } },
+      },
+      history: {
+        where: { status: "played" },
+        orderBy: { dateTime: "desc" },
+        take: 1,
+      },
+    },
+  });
+
+  if (!event) {
+    return Response.json({ error: "Event not found." }, { status: 404 });
+  }
+
+  if (event.teamResults.length < 2) {
+    return Response.json({ error: "Teams must be assigned first." }, { status: 400 });
+  }
+
+  // Check if there's already a history record for today
+  const startOfDay = new Date();
+  startOfDay.setHours(0, 0, 0, 0);
+  const existingToday = await prisma.gameHistory.findFirst({
+    where: {
+      eventId,
+      dateTime: { gte: startOfDay },
+      status: "played",
+    },
+  });
+
+  if (existingToday) {
+    // Already has a history record — return it
+    return Response.json({
+      id: existingToday.id,
+      scoreOne: existingToday.scoreOne ?? 0,
+      scoreTwo: existingToday.scoreTwo ?? 0,
+      teamOneName: existingToday.teamOneName,
+      teamTwoName: existingToday.teamTwoName,
+      editable: existingToday.editableUntil > new Date(),
+      created: false,
+    });
+  }
+
+  // Create a new history record
+  const teamsSnapshot = JSON.stringify(
+    event.teamResults.map((tr) => ({
+      team: tr.name,
+      players: tr.members.map((m) => ({ name: m.name, order: m.order })),
+    }))
+  );
+
+  const editableUntil = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+
+  const history = await prisma.gameHistory.create({
+    data: {
+      eventId: event.id,
+      dateTime: event.dateTime,
+      teamOneName: event.teamOneName,
+      teamTwoName: event.teamTwoName,
+      teamsSnapshot,
+      editableUntil,
+    },
+  });
+
+  return Response.json({
+    id: history.id,
+    scoreOne: history.scoreOne ?? 0,
+    scoreTwo: history.scoreTwo ?? 0,
+    teamOneName: history.teamOneName,
+    teamTwoName: history.teamTwoName,
+    editable: history.editableUntil > new Date(),
+    created: true,
+  });
+};
+
+/**
+ * GET /api/watch/events
+ * Returns today's events that have teams assigned, with current scores.
+ *
+ * For logged-in users: filters to events where the user is a player.
+ * For anonymous users: returns all today's events with teams.
+ *
+ * Response includes `autoSelectId` — the event to auto-navigate to when:
+ *   - There is exactly one event, OR
+ *   - Exactly one event is "happening now" (within ±90 min of dateTime)
+ */
+export const GET: APIRoute = async ({ request }) => {
+  const url = new URL(request.url);
+  const eventId = url.searchParams.get("eventId");
+
+  // If eventId is provided, return just that event's data
+  if (eventId) {
+    return getSingleEvent(eventId);
+  }
+
+  const session = await getSession(request);
+  const userId = session?.user?.id ?? null;
+
+  const startOfDay = new Date();
+  startOfDay.setHours(0, 0, 0, 0);
+  const endOfDay = new Date();
+  endOfDay.setHours(23, 59, 59, 999);
+
+  const where: Record<string, unknown> = {
+    dateTime: { gte: startOfDay, lte: endOfDay },
+    archivedAt: null,
+  };
+
+  // For logged-in users, only show events they participate in
+  if (userId) {
+    where.players = { some: { userId } };
+  }
+
+  const events = await prisma.event.findMany({
+    where,
+    select: {
+      id: true,
+      title: true,
+      sport: true,
+      dateTime: true,
+      teamOneName: true,
+      teamTwoName: true,
+      teamResults: {
+        select: { id: true, name: true, members: { select: { name: true } } },
+      },
+      history: {
+        where: {
+          dateTime: { gte: startOfDay, lte: endOfDay },
+          status: "played",
+        },
+        orderBy: { dateTime: "desc" },
+        take: 1,
+        select: {
+          id: true,
+          scoreOne: true,
+          scoreTwo: true,
+          teamOneName: true,
+          teamTwoName: true,
+          editableUntil: true,
+        },
+      },
+    },
+    orderBy: { dateTime: "asc" },
+  });
+
+  const now = Date.now();
+
+  const mapped = events.map((e) => {
+    const diff = Math.abs(e.dateTime.getTime() - now);
+    const hasTeams = e.teamResults.length >= 2;
+    return {
+      id: e.id,
+      title: e.title,
+      sport: e.sport,
+      dateTime: e.dateTime.toISOString(),
+      teamOneName: e.teamOneName,
+      teamTwoName: e.teamTwoName,
+      hasTeams,
+      isHappeningNow: diff <= HAPPENING_WINDOW_MS,
+      hasHistory: e.history.length > 0,
+      latestGame: e.history[0]
+        ? {
+            id: e.history[0].id,
+            scoreOne: e.history[0].scoreOne ?? 0,
+            scoreTwo: e.history[0].scoreTwo ?? 0,
+            teamOneName: e.history[0].teamOneName,
+            teamTwoName: e.history[0].teamTwoName,
+            editable: e.history[0].editableUntil > new Date(),
+          }
+        : null,
+    };
+  });
+
+  // Auto-select logic (only for logged-in users, only events with teams)
+  let autoSelectId: string | null = null;
+  if (userId) {
+    const ready = mapped.filter((e) => e.hasTeams);
+    const happeningNow = ready.filter((e) => e.isHappeningNow);
+    if (happeningNow.length === 1) {
+      autoSelectId = happeningNow[0].id;
+    } else if (ready.length === 1) {
+      autoSelectId = ready[0].id;
+    }
+  }
+
+  return Response.json({ events: mapped, autoSelectId });
+};
+
+async function getSingleEvent(eventId: string) {
+  const event = await prisma.event.findUnique({
+    where: { id: eventId },
+    select: {
+      id: true,
+      title: true,
+      sport: true,
+      dateTime: true,
+      teamOneName: true,
+      teamTwoName: true,
+      teamResults: {
+        select: { id: true, name: true, members: { select: { name: true } } },
+      },
+      history: {
+        where: { status: "played" },
+        orderBy: { dateTime: "desc" },
+        take: 1,
+        select: {
+          id: true,
+          scoreOne: true,
+          scoreTwo: true,
+          teamOneName: true,
+          teamTwoName: true,
+          editableUntil: true,
+        },
+      },
+    },
+  });
+
+  if (!event) {
+    return Response.json({ error: "Event not found" }, { status: 404 });
+  }
+
+  const now = Date.now();
+  const diff = Math.abs(event.dateTime.getTime() - now);
+
+  const hasTeams = event.teamResults.length >= 2;
+
+  return Response.json({
+    id: event.id,
+    title: event.title,
+    sport: event.sport,
+    dateTime: event.dateTime.toISOString(),
+    teamOneName: event.teamOneName,
+    teamTwoName: event.teamTwoName,
+    hasTeams,
+    isHappeningNow: diff <= HAPPENING_WINDOW_MS,
+    hasHistory: event.history.length > 0,
+    latestGame: event.history[0]
+      ? {
+          id: event.history[0].id,
+          scoreOne: event.history[0].scoreOne ?? 0,
+          scoreTwo: event.history[0].scoreTwo ?? 0,
+          teamOneName: event.history[0].teamOneName,
+          teamTwoName: event.history[0].teamTwoName,
+          editable: event.history[0].editableUntil > new Date(),
+        }
+      : null,
+  });
+}

--- a/src/pages/watch/[id].astro
+++ b/src/pages/watch/[id].astro
@@ -1,0 +1,32 @@
+---
+import WatchScoreTracker from "../../components/watch/WatchScoreTracker";
+const { id } = Astro.params;
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <title>Score — Convocados</title>
+    <link rel="icon" href="/favicon.ico" />
+    <link rel="apple-touch-icon" href="/icons/apple-touch-icon.png" />
+    <link rel="manifest" href="/watch/manifest.json" />
+    <meta name="theme-color" content="#1b6b4a" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <style>
+      * { margin: 0; padding: 0; box-sizing: border-box; }
+      body { background: #111412; overflow-x: hidden; }
+      @keyframes spin { to { transform: rotate(360deg); } }
+    </style>
+  </head>
+  <body>
+    <WatchScoreTracker client:only="react" eventId={id!} />
+    <script>
+      if ("serviceWorker" in navigator) {
+        navigator.serviceWorker.register("/watch/sw.js", { scope: "/watch/" });
+      }
+    </script>
+  </body>
+</html>

--- a/src/pages/watch/index.astro
+++ b/src/pages/watch/index.astro
@@ -1,0 +1,33 @@
+---
+export const prerender = true;
+import WatchGameList from "../../components/watch/WatchGameList";
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <title>Watch — Convocados</title>
+    <link rel="icon" href="/favicon.ico" />
+    <link rel="apple-touch-icon" href="/icons/apple-touch-icon.png" />
+    <link rel="manifest" href="/watch/manifest.json" />
+    <meta name="theme-color" content="#1b6b4a" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <style>
+      * { margin: 0; padding: 0; box-sizing: border-box; }
+      body { background: #111412; overflow-x: hidden; }
+      @keyframes spin { to { transform: rotate(360deg); } }
+      @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.3; } }
+    </style>
+  </head>
+  <body>
+    <WatchGameList client:only="react" />
+    <script>
+      if ("serviceWorker" in navigator) {
+        navigator.serviceWorker.register("/watch/sw.js", { scope: "/watch/" });
+      }
+    </script>
+  </body>
+</html>

--- a/src/pages/watch/manifest.json.ts
+++ b/src/pages/watch/manifest.json.ts
@@ -1,0 +1,25 @@
+import type { APIRoute } from "astro";
+
+export const GET: APIRoute = () => {
+  const manifest = {
+    name: "Convocados Watch",
+    short_name: "Watch",
+    description: "Track game scores from your wrist.",
+    start_url: "/watch/",
+    scope: "/watch/",
+    display: "standalone",
+    background_color: "#111412",
+    theme_color: "#1b6b4a",
+    icons: [
+      { src: "/icons/icon-192.png", sizes: "192x192", type: "image/png" },
+      { src: "/icons/icon-512.png", sizes: "512x512", type: "image/png" },
+      { src: "/icons/icon-maskable-512.png", sizes: "512x512", type: "image/png", purpose: "maskable" },
+    ],
+    categories: ["sports"],
+    orientation: "portrait-primary",
+  };
+
+  return new Response(JSON.stringify(manifest), {
+    headers: { "Content-Type": "application/manifest+json" },
+  });
+};

--- a/src/pages/watch/sw.js.ts
+++ b/src/pages/watch/sw.js.ts
@@ -1,0 +1,41 @@
+import type { APIRoute } from "astro";
+
+export const GET: APIRoute = () => {
+  const sw = `
+self.addEventListener("install", () => self.skipWaiting());
+self.addEventListener("activate", (e) => e.waitUntil(self.clients.claim()));
+
+const CACHE_NAME = "watch-v1";
+const PRECACHE = ["/watch/"];
+
+self.addEventListener("install", (e) => {
+  e.waitUntil(caches.open(CACHE_NAME).then((c) => c.addAll(PRECACHE)));
+});
+
+self.addEventListener("fetch", (e) => {
+  const url = new URL(e.request.url);
+  // Only handle requests within /watch/ scope
+  if (!url.pathname.startsWith("/watch")) return;
+
+  // Network-first for API calls
+  if (url.pathname.startsWith("/api/")) return;
+
+  e.respondWith(
+    fetch(e.request)
+      .then((res) => {
+        const clone = res.clone();
+        caches.open(CACHE_NAME).then((c) => c.put(e.request, clone));
+        return res;
+      })
+      .catch(() => caches.match(e.request))
+  );
+});
+`;
+
+  return new Response(sw.trim(), {
+    headers: {
+      "Content-Type": "application/javascript",
+      "Service-Worker-Allowed": "/watch/",
+    },
+  });
+};

--- a/src/test/watch-pwa.test.ts
+++ b/src/test/watch-pwa.test.ts
@@ -1,0 +1,272 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Watch manifest tests ─────────────────────────────────────────────────────
+
+describe("Watch PWA manifest", () => {
+  it("has correct scope and start_url for /watch subpath", async () => {
+    const mod = await import("~/pages/watch/manifest.json");
+    const response = await mod.GET({} as any);
+    const manifest = await response.json();
+
+    expect(manifest.start_url).toBe("/watch/");
+    expect(manifest.scope).toBe("/watch/");
+  });
+
+  it("has required PWA fields", async () => {
+    const mod = await import("~/pages/watch/manifest.json");
+    const response = await mod.GET({} as any);
+    const manifest = await response.json();
+
+    expect(manifest.name).toBeTruthy();
+    expect(manifest.short_name).toBeTruthy();
+    expect(manifest.display).toBe("standalone");
+    expect(manifest.icons).toBeInstanceOf(Array);
+    expect(manifest.icons.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("returns correct content-type header", async () => {
+    const mod = await import("~/pages/watch/manifest.json");
+    const response = await mod.GET({} as any);
+
+    expect(response.headers.get("Content-Type")).toBe("application/manifest+json");
+  });
+
+  it("does not conflict with main app manifest", async () => {
+    const mod = await import("~/pages/watch/manifest.json");
+    const response = await mod.GET({} as any);
+    const watchManifest = await response.json();
+
+    expect(watchManifest.start_url).not.toBe("/");
+    expect(watchManifest.scope).toBe("/watch/");
+    expect(watchManifest.short_name).toBe("Watch");
+  });
+});
+
+// ── Watch service worker tests ───────────────────────────────────────────────
+
+describe("Watch service worker endpoint", () => {
+  it("returns JavaScript content-type", async () => {
+    const mod = await import("~/pages/watch/sw.js");
+    const response = await mod.GET({} as any);
+
+    expect(response.headers.get("Content-Type")).toBe("application/javascript");
+  });
+
+  it("sets Service-Worker-Allowed header to /watch/", async () => {
+    const mod = await import("~/pages/watch/sw.js");
+    const response = await mod.GET({} as any);
+
+    expect(response.headers.get("Service-Worker-Allowed")).toBe("/watch/");
+  });
+
+  it("service worker script scopes to /watch", async () => {
+    const mod = await import("~/pages/watch/sw.js");
+    const response = await mod.GET({} as any);
+    const body = await response.text();
+
+    expect(body).toContain("/watch");
+    expect(body).toContain("fetch");
+    expect(body).toContain("caches");
+  });
+});
+
+// ── Watch types / IndexedDB helpers tests ────────────────────────────────────
+
+describe("Watch offline sync types", () => {
+  it("exports required IndexedDB helper functions", async () => {
+    const mod = await import("~/components/watch/watchTypes");
+    expect(typeof mod.savePendingSync).toBe("function");
+    expect(typeof mod.getPendingSyncs).toBe("function");
+    expect(typeof mod.removePendingSync).toBe("function");
+    expect(typeof mod.flushPendingSyncs).toBe("function");
+  });
+
+  it("WatchEventsResponse type includes autoSelectId", async () => {
+    // Verify the type is exported and usable
+    const mod = await import("~/components/watch/watchTypes");
+    // Type-level check: if this compiles, the type exists
+    const mockResponse: import("~/components/watch/watchTypes").WatchEventsResponse = {
+      events: [],
+      autoSelectId: null,
+    };
+    expect(mockResponse.autoSelectId).toBeNull();
+    expect(mockResponse.events).toEqual([]);
+  });
+
+  it("WatchEvent type includes hasTeams, isHappeningNow and dateTime", async () => {
+    const mockEvent: import("~/components/watch/watchTypes").WatchEvent = {
+      id: "test",
+      title: "Test",
+      sport: "football-5v5",
+      dateTime: new Date().toISOString(),
+      teamOneName: "A",
+      teamTwoName: "B",
+      hasTeams: true,
+      isHappeningNow: true,
+      hasHistory: false,
+      latestGame: null,
+    };
+    expect(mockEvent.isHappeningNow).toBe(true);
+    expect(mockEvent.hasTeams).toBe(true);
+    expect(mockEvent.dateTime).toBeTruthy();
+  });
+});
+
+// ── Watch Astro pages tests ──────────────────────────────────────────────────
+
+describe("Watch pages link to correct manifest", () => {
+  it("index page references /watch/manifest.json", async () => {
+    const fs = await import("fs");
+    const content = fs.readFileSync("src/pages/watch/index.astro", "utf-8");
+
+    expect(content).toContain('href="/watch/manifest.json"');
+    expect(content).not.toContain('href="/manifest.json"');
+  });
+
+  it("score page references /watch/manifest.json", async () => {
+    const fs = await import("fs");
+    const content = fs.readFileSync("src/pages/watch/[id].astro", "utf-8");
+
+    expect(content).toContain('href="/watch/manifest.json"');
+    expect(content).not.toContain('href="/manifest.json"');
+  });
+
+  it("index page registers service worker with /watch/ scope", async () => {
+    const fs = await import("fs");
+    const content = fs.readFileSync("src/pages/watch/index.astro", "utf-8");
+
+    expect(content).toContain('register("/watch/sw.js"');
+    expect(content).toContain('scope: "/watch/"');
+  });
+
+  it("score page registers service worker with /watch/ scope", async () => {
+    const fs = await import("fs");
+    const content = fs.readFileSync("src/pages/watch/[id].astro", "utf-8");
+
+    expect(content).toContain('register("/watch/sw.js"');
+    expect(content).toContain('scope: "/watch/"');
+  });
+
+  it("pages have apple-mobile-web-app-capable meta tag", async () => {
+    const fs = await import("fs");
+    const index = fs.readFileSync("src/pages/watch/index.astro", "utf-8");
+    const score = fs.readFileSync("src/pages/watch/[id].astro", "utf-8");
+
+    expect(index).toContain("apple-mobile-web-app-capable");
+    expect(score).toContain("apple-mobile-web-app-capable");
+  });
+
+  it("pages have viewport-fit=cover for watch displays", async () => {
+    const fs = await import("fs");
+    const index = fs.readFileSync("src/pages/watch/index.astro", "utf-8");
+    const score = fs.readFileSync("src/pages/watch/[id].astro", "utf-8");
+
+    expect(index).toContain("viewport-fit=cover");
+    expect(score).toContain("viewport-fit=cover");
+  });
+});
+
+// ── Main app PWA unaffected ──────────────────────────────────────────────────
+
+describe("Main app PWA is unaffected", () => {
+  it("main manifest.json still has start_url /", async () => {
+    const fs = await import("fs");
+    const content = fs.readFileSync("public/manifest.json", "utf-8");
+    const manifest = JSON.parse(content);
+
+    expect(manifest.start_url).toBe("/");
+    expect(manifest.scope).toBeUndefined();
+  });
+
+  it("main sw.js is unchanged", async () => {
+    const fs = await import("fs");
+    const content = fs.readFileSync("public/sw.js", "utf-8");
+
+    expect(content).not.toContain("watch-v1");
+    expect(content).toContain("SKIP_WAITING");
+  });
+
+  it("main pages still reference /manifest.json", async () => {
+    const fs = await import("fs");
+    const dashboard = fs.readFileSync("src/pages/dashboard.astro", "utf-8");
+
+    expect(dashboard).toContain('href="/manifest.json"');
+    expect(dashboard).not.toContain('href="/watch/manifest.json"');
+  });
+});
+
+// ── Auto-select logic tests ──────────────────────────────────────────────────
+
+describe("Watch auto-select logic", () => {
+  it("autoSelectId is set when exactly one event exists", () => {
+    const events = [
+      { id: "evt1", isHappeningNow: false },
+    ];
+    const happeningNow = events.filter((e) => e.isHappeningNow);
+    let autoSelectId: string | null = null;
+    if (happeningNow.length === 1) {
+      autoSelectId = happeningNow[0].id;
+    } else if (events.length === 1) {
+      autoSelectId = events[0].id;
+    }
+    expect(autoSelectId).toBe("evt1");
+  });
+
+  it("autoSelectId picks the happening-now event when multiple exist", () => {
+    const events = [
+      { id: "evt1", isHappeningNow: false },
+      { id: "evt2", isHappeningNow: true },
+      { id: "evt3", isHappeningNow: false },
+    ];
+    const happeningNow = events.filter((e) => e.isHappeningNow);
+    let autoSelectId: string | null = null;
+    if (happeningNow.length === 1) {
+      autoSelectId = happeningNow[0].id;
+    } else if (events.length === 1) {
+      autoSelectId = events[0].id;
+    }
+    expect(autoSelectId).toBe("evt2");
+  });
+
+  it("autoSelectId is null when multiple events are happening now", () => {
+    const events = [
+      { id: "evt1", isHappeningNow: true },
+      { id: "evt2", isHappeningNow: true },
+    ];
+    const happeningNow = events.filter((e) => e.isHappeningNow);
+    let autoSelectId: string | null = null;
+    if (happeningNow.length === 1) {
+      autoSelectId = happeningNow[0].id;
+    } else if (events.length === 1) {
+      autoSelectId = events[0].id;
+    }
+    expect(autoSelectId).toBeNull();
+  });
+
+  it("autoSelectId is null when no events exist", () => {
+    const events: { id: string; isHappeningNow: boolean }[] = [];
+    const happeningNow = events.filter((e) => e.isHappeningNow);
+    let autoSelectId: string | null = null;
+    if (happeningNow.length === 1) {
+      autoSelectId = happeningNow[0].id;
+    } else if (events.length === 1) {
+      autoSelectId = events[0].id;
+    }
+    expect(autoSelectId).toBeNull();
+  });
+
+  it("HAPPENING_WINDOW_MS is 90 minutes", () => {
+    // The API uses 90 * 60 * 1000 = 5_400_000 ms
+    const HAPPENING_WINDOW_MS = 90 * 60 * 1000;
+    expect(HAPPENING_WINDOW_MS).toBe(5_400_000);
+
+    // An event 80 minutes ago should be "happening now"
+    const now = Date.now();
+    const eightyMinAgo = now - 80 * 60 * 1000;
+    expect(Math.abs(eightyMinAgo - now)).toBeLessThanOrEqual(HAPPENING_WINDOW_MS);
+
+    // An event 100 minutes ago should NOT be "happening now"
+    const hundredMinAgo = now - 100 * 60 * 1000;
+    expect(Math.abs(hundredMinAgo - now)).toBeGreaterThan(HAPPENING_WINDOW_MS);
+  });
+});


### PR DESCRIPTION
## Changes

- **Watch PWA**: Game list, score tracker, manifest, service worker, offline sync
- **Responsive layout**: All watch UI elements use `clamp()`/`vw` units to fit screens as small as ~160px
  - Buttons: 36–48px, scores: 24–36px, gaps/fonts scale proportionally
  - Cards, badges, and all text use viewport-relative sizing
- **Back-navigation fix**: Skip auto-select when user navigates back from a game screen to the list (checks `document.referrer`)
- **i18n**: Watch link strings added to all 6 locales

## Testing

- All 1002 tests pass (67 files)
- TypeScript typecheck clean
- Watch PWA tests: 24/24 pass