### PR TITLE
chore: upgrade Astro 6.0.5→6.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "k6:sse": "k6 run k6/scripts/sse.js"
   },
   "dependencies": {
-    "@astrojs/node": "^10.0.2",
-    "@astrojs/react": "^5.0.0",
+    "@astrojs/node": "^10.0.4",
+    "@astrojs/react": "^5.0.2",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
     "@fontsource/roboto": "^5.2.5",
@@ -34,7 +34,7 @@
     "@mui/material": "^6.4.6",
     "@prisma/client": "^6.5.0",
     "@types/web-push": "^3.6.4",
-    "astro": "^6.0.5",
+    "astro": "^6.1.1",
     "better-auth": "^1.5.5",
     "pino": "^10.3.1",
     "react": "^19.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,11 +9,11 @@ importers:
   .:
     dependencies:
       '@astrojs/node':
-        specifier: ^10.0.2
-        version: 10.0.3(astro@6.0.8(@types/node@25.5.0)(jiti@2.6.1)(rollup@4.60.0)(typescript@5.9.3))
+        specifier: ^10.0.4
+        version: 10.0.4(astro@6.1.1(@types/node@25.5.0)(jiti@2.6.1)(rollup@4.60.0)(typescript@5.9.3))
       '@astrojs/react':
-        specifier: ^5.0.0
-        version: 5.0.1(@types/node@25.5.0)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(jiti@2.6.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: ^5.0.2
+        version: 5.0.2(@types/node@25.5.0)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(jiti@2.6.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@emotion/react':
         specifier: ^11.14.0
         version: 11.14.0(@types/react@19.2.14)(react@19.2.4)
@@ -36,8 +36,8 @@ importers:
         specifier: ^3.6.4
         version: 3.6.4
       astro:
-        specifier: ^6.0.5
-        version: 6.0.8(@types/node@25.5.0)(jiti@2.6.1)(rollup@4.60.0)(typescript@5.9.3)
+        specifier: ^6.1.1
+        version: 6.1.1(@types/node@25.5.0)(jiti@2.6.1)(rollup@4.60.0)(typescript@5.9.3)
       better-auth:
         specifier: ^1.5.5
         version: 1.5.6(@opentelemetry/api@1.9.0)(@prisma/client@6.19.2(prisma@6.19.2(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3))(prisma@6.19.2(magicast@0.3.5)(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.5.0)(jiti@2.6.1)(jsdom@29.0.1(@noble/hashes@2.0.1)))
@@ -147,11 +147,11 @@ packages:
   '@astrojs/internal-helpers@0.8.0':
     resolution: {integrity: sha512-J56GrhEiV+4dmrGLPNOl2pZjpHXAndWVyiVDYGDuw6MWKpBSEMLdFxHzeM/6sqaknw9M+HFfHZAcvi3OfT3D/w==}
 
-  '@astrojs/markdown-remark@7.0.1':
-    resolution: {integrity: sha512-zAfLJmn07u9SlDNNHTpjv0RT4F8D4k54NR7ReRas8CO4OeGoqSvOuKwqCFg2/cqN3wHwdWlK/7Yv/lMXlhVIaw==}
+  '@astrojs/markdown-remark@7.1.0':
+    resolution: {integrity: sha512-P+HnCsu2js3BoTc8kFmu+E9gOcFeMdPris75g+Zl4sY8+bBRbSQV6xzcBDbZ27eE7yBGEGQoqjpChx+KJYIPYQ==}
 
-  '@astrojs/node@10.0.3':
-    resolution: {integrity: sha512-yWDPaXTOw34h9qNpxDBz1Xj5HudnyuWW2E8ZSegW6o8n+mKI3Yq/iLAUQfxA3h8wfaIRY/PCh3T2jLAys2SXeQ==}
+  '@astrojs/node@10.0.4':
+    resolution: {integrity: sha512-7pVgiVSscQHRC2WqjlXcnbbcKMYp2GXrYpmuvdGg5zgA8J1lFm2vmwVhHZFuZK3Ik5PzoxiDROaEgoDGLbfhLw==}
     peerDependencies:
       astro: ^6.0.0
 
@@ -159,8 +159,8 @@ packages:
     resolution: {integrity: sha512-nksZQVjlferuWzhPsBpQ1JE5XuKAf1id1/9Hj4a9KG4+ofrlzxUUwX4YGQF/SuDiuiGKEnzopGOt38F3AnVWsQ==}
     engines: {node: '>=22.12.0'}
 
-  '@astrojs/react@5.0.1':
-    resolution: {integrity: sha512-gJgQfDUxyePk+UIzwCEtAq04SGbziwRNwOMYvkxLHEtZScSMvRnvQhDWAEMCjLwwEomoT92Tfm34xpD7XAAzOg==}
+  '@astrojs/react@5.0.2':
+    resolution: {integrity: sha512-BDpPrapV3Wgp9sD7aTMvP+ORH0jFEue9OmkBu98KcBbTlsQCnvisDW3m7PQrMptXwEDlX5HGfP/CHmkEVY2tZA==}
     engines: {node: '>=22.12.0'}
     peerDependencies:
       '@types/react': ^17.0.50 || ^18.0.21 || ^19.0.0
@@ -1654,8 +1654,8 @@ packages:
   ast-v8-to-istanbul@0.3.12:
     resolution: {integrity: sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==}
 
-  astro@6.0.8:
-    resolution: {integrity: sha512-DCPeb8GKOoFWh+8whB7Qi/kKWD/6NcQ9nd1QVNzJFxgHkea3WYrNroQRq4whmBdjhkYPTLS/1gmUAl2iA2Es2g==}
+  astro@6.1.1:
+    resolution: {integrity: sha512-vq8sHpu1JsY1fWAunn+tdKNbVDmLQNiVdyuGsVT2csgITdFGXXVAyEXFWc1DzkMN0ehElPeiHnqItyQOJK+GqA==}
     engines: {node: '>=22.12.0', npm: '>=9.6.5', pnpm: '>=7.1.0'}
     hasBin: true
 
@@ -4742,7 +4742,7 @@ snapshots:
     dependencies:
       picomatch: 4.0.4
 
-  '@astrojs/markdown-remark@7.0.1':
+  '@astrojs/markdown-remark@7.1.0':
     dependencies:
       '@astrojs/internal-helpers': 0.8.0
       '@astrojs/prism': 4.0.1
@@ -4757,6 +4757,7 @@ snapshots:
       remark-parse: 11.0.0
       remark-rehype: 11.1.2
       remark-smartypants: 3.0.2
+      retext-smartypants: 6.2.0
       shiki: 4.0.2
       smol-toml: 1.6.1
       unified: 11.0.5
@@ -4767,10 +4768,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/node@10.0.3(astro@6.0.8(@types/node@25.5.0)(jiti@2.6.1)(rollup@4.60.0)(typescript@5.9.3))':
+  '@astrojs/node@10.0.4(astro@6.1.1(@types/node@25.5.0)(jiti@2.6.1)(rollup@4.60.0)(typescript@5.9.3))':
     dependencies:
       '@astrojs/internal-helpers': 0.8.0
-      astro: 6.0.8(@types/node@25.5.0)(jiti@2.6.1)(rollup@4.60.0)(typescript@5.9.3)
+      astro: 6.1.1(@types/node@25.5.0)(jiti@2.6.1)(rollup@4.60.0)(typescript@5.9.3)
       send: 1.2.1
       server-destroy: 1.0.1
     transitivePeerDependencies:
@@ -4780,7 +4781,7 @@ snapshots:
     dependencies:
       prismjs: 1.30.0
 
-  '@astrojs/react@5.0.1(@types/node@25.5.0)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(jiti@2.6.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@astrojs/react@5.0.2(@types/node@25.5.0)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(jiti@2.6.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@astrojs/internal-helpers': 0.8.0
       '@types/react': 19.2.14
@@ -6262,11 +6263,11 @@ snapshots:
       estree-walker: 3.0.3
       js-tokens: 10.0.0
 
-  astro@6.0.8(@types/node@25.5.0)(jiti@2.6.1)(rollup@4.60.0)(typescript@5.9.3):
+  astro@6.1.1(@types/node@25.5.0)(jiti@2.6.1)(rollup@4.60.0)(typescript@5.9.3):
     dependencies:
       '@astrojs/compiler': 3.0.1
       '@astrojs/internal-helpers': 0.8.0
-      '@astrojs/markdown-remark': 7.0.1
+      '@astrojs/markdown-remark': 7.1.0
       '@astrojs/telemetry': 3.3.0
       '@capsizecss/unpack': 4.0.0
       '@clack/prompts': 1.1.0


### PR DESCRIPTION
## Astro 6.1 upgrade

Upgrades Astro and related integrations using `@astrojs/upgrade`.

### Packages updated
- `astro`: 6.0.5 → 6.1.1
- `@astrojs/node`: 10.0.2 → 10.0.4
- `@astrojs/react`: 5.0.0 → 5.0.2

### Astro 6.1 highlights
- React hydration fixes — multiple fixes for conditional slot rendering and `experimentalReactChildren` mismatches (directly relevant to this project)
- CSRF protection behind reverse proxies — `checkOrigin` now correctly reads `X-Forwarded-Proto` (relevant for deployments behind a proxy)
- Sharp codec-specific image defaults via `image.service.config`
- Smoother view transitions on mobile

See https://astro.build/blog/astro-610/ for full details.