### PR TITLE
ci: update pnpm/action-setup to v5

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -67,7 +67,7 @@ jobs:
 
       - uses: actions/checkout@v6
         if: steps.should_run.outputs.skip != 'true'
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
         if: steps.should_run.outputs.skip != 'true'
       - uses: actions/setup-node@v6
         if: steps.should_run.outputs.skip != 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
       - uses: actions/setup-node@v6
         with:
           node-version: 22
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
       - uses: actions/setup-node@v6
         with:
           node-version: 22
@@ -80,7 +80,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
       - uses: actions/setup-node@v6
         with:
           node-version: 22


### PR DESCRIPTION
Updates `pnpm/action-setup` from v4 to v5 in test and performance workflows. v5 runs on Node.js 24.