### PR TITLE
feat: replace claim player icon with 'It's me' text chip

### DIFF
--- a/src/components/event/PlayerList.tsx
+++ b/src/components/event/PlayerList.tsx
@@ -10,7 +10,7 @@ import CloseIcon from "@mui/icons-material/Close";
 import AirlineSeatReclineNormalIcon from "@mui/icons-material/AirlineSeatReclineNormal";
 import DragIndicatorIcon from "@mui/icons-material/DragIndicator";
 import ShieldIcon from "@mui/icons-material/Shield";
-import SwapHorizIcon from "@mui/icons-material/SwapHoriz";
+
 import RestartAltIcon from "@mui/icons-material/RestartAlt";
 import { useT } from "~/lib/useT";
 import { matchesWithName } from "~/lib/stringMatch";
@@ -271,9 +271,14 @@ export function PlayerList({
                       <ShieldIcon fontSize="small" sx={{ color: "primary.main", mr: 0.5, flexShrink: 0 }} />
                     </Tooltip>
                   ) : canClaimPlayer ? (
-                    <Tooltip title={t("claimPlayerDesc")}>
-                      <SwapHorizIcon fontSize="small" sx={{ cursor: "pointer", mr: 0.5, flexShrink: 0 }} onClick={() => onOpenClaimPlayerDialog(player.id, player.name)} />
-                    </Tooltip>
+                    <Chip
+                      label={t("thisIsMe")}
+                      size="small"
+                      variant="outlined"
+                      color="info"
+                      onClick={() => onOpenClaimPlayerDialog(player.id, player.name)}
+                      sx={{ mr: 0.5, flexShrink: 0, cursor: "pointer", fontSize: "0.7rem", height: 22 }}
+                    />
                   ) : null}
                   <ListItemText
                     primary={player.userId ? (
@@ -338,9 +343,14 @@ export function PlayerList({
                           <ShieldIcon fontSize="small" sx={{ color: "warning.main", mr: 0.5, flexShrink: 0 }} />
                         </Tooltip>
                       ) : canClaimPlayer ? (
-                        <Tooltip title={t("claimPlayerDesc")}>
-                          <SwapHorizIcon fontSize="small" sx={{ cursor: "pointer", mr: 0.5, flexShrink: 0 }} onClick={() => onOpenClaimPlayerDialog(player.id, player.name)} />
-                        </Tooltip>
+                        <Chip
+                          label={t("thisIsMe")}
+                          size="small"
+                          variant="outlined"
+                          color="info"
+                          onClick={() => onOpenClaimPlayerDialog(player.id, player.name)}
+                          sx={{ mr: 0.5, flexShrink: 0, cursor: "pointer", fontSize: "0.7rem", height: 22 }}
+                        />
                       ) : null}
                       <ListItemText
                         primary={player.userId ? (

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -274,6 +274,7 @@ const de: TranslationKeys = {
   saveProfile: "Speichern",
   profileUpdated: "Profil aktualisiert.",
   profileUpdateError: "Profil konnte nicht aktualisiert werden.",
+  thisIsMe: "Das bin ich",
   claimPlayer: "Als mich beanspruchen",
   claimPlayerTitle: "Spieler beanspruchen",
   claimPlayerDesc: "Verknüpfe diesen anonymen Spieler mit deinem Konto. Dein aktueller verknüpfter Spieler (falls vorhanden) wird getrennt.",

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -310,6 +310,7 @@ const en = {
   saveProfile: "Save",
   profileUpdated: "Profile updated.",
   profileUpdateError: "Could not update profile.",
+  thisIsMe: "It's me",
   claimPlayer: "Claim as me",
   claimPlayerTitle: "Claim player",
   claimPlayerDesc: "Link this anonymous player to your account. Your current linked player (if any) will be unlinked.",

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -274,6 +274,7 @@ const es: TranslationKeys = {
   saveProfile: "Guardar",
   profileUpdated: "Perfil actualizado.",
   profileUpdateError: "No se pudo actualizar el perfil.",
+  thisIsMe: "Soy yo",
   claimPlayer: "Reclamar jugador",
   claimPlayerTitle: "Reclamar jugador",
   claimPlayerDesc: "Asocia este jugador anónimo a tu cuenta. Tu jugador actual (si existe) será desvinculado.",

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -274,6 +274,7 @@ const fr: TranslationKeys = {
   saveProfile: "Enregistrer",
   profileUpdated: "Profil mis à jour.",
   profileUpdateError: "Impossible de mettre à jour le profil.",
+  thisIsMe: "C'est moi",
   claimPlayer: "Revendiquer ce joueur",
   claimPlayerTitle: "Revendiquer ce joueur",
   claimPlayerDesc: "Associe ce joueur anonyme à ton compte. Ton joueur actuel (s'il existe) sera dissocié.",

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -274,6 +274,7 @@ const it: TranslationKeys = {
   saveProfile: "Salva",
   profileUpdated: "Profilo aggiornato.",
   profileUpdateError: "Impossibile aggiornare il profilo.",
+  thisIsMe: "Sono io",
   claimPlayer: "Rivendica come me",
   claimPlayerTitle: "Rivendica giocatore",
   claimPlayerDesc: "Collega questo giocatore anonimo al tuo account. Il tuo giocatore attuale (se presente) verrà scollegato.",

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -311,6 +311,7 @@ const pt: TranslationKeys = {
   saveProfile: "Guardar",
   profileUpdated: "Perfil atualizado.",
   profileUpdateError: "Não foi possível atualizar o perfil.",
+  thisIsMe: "Sou eu",
   claimPlayer: "Assumir jogador",
   claimPlayerTitle: "Assumir jogador",
   claimPlayerDesc: "Associa este jogador anónimo à tua conta. O teu jogador atual (se existir) será desassociado.",


### PR DESCRIPTION
## Summary

Replace the ambiguous swap icon (↔) next to anonymous players with a clear **"It's me"** text chip that logged-in users can click to claim an anonymous player as their own.

## Problem

The `SwapHorizIcon` (↔) was not intuitive — users didn't understand they could associate an anonymous player with their account. The icon looked like "swap/exchange" rather than "claim this identity."

## Solution

- Replaced the icon with a small outlined MUI `Chip` labeled with a new `thisIsMe` i18n key
- Applied to both active and bench player lists
- Uses `info` color to stand out as an interactive element
- Clicking the chip triggers the same confirmation dialog as before

## i18n

Added `thisIsMe` to all 6 locales:
| Locale | Label |
|--------|-------|
| en | It's me |
| pt | Sou eu |
| es | Soy yo |
| fr | C'est moi |
| de | Das bin ich |
| it | Sono io |

## Testing

- All 1172 tests pass
- Typecheck clean
- No functional changes — only the visual trigger element changed