### PR TITLE
fix: derive public origin from forwarded headers in CSRF middleware

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -61,10 +61,17 @@ export const onRequest = defineMiddleware((context, next) => {
     return new Response("Forbidden: missing Origin header", { status: 403 });
   }
 
-  // Compare origin to the request URL's origin
-  const requestOrigin = url.origin;
+  // Compare origin to the request URL's origin.
+  // Behind a reverse proxy (e.g. Fly.dev), url.origin is the internal address
+  // (http://localhost:3000), so we also derive the public origin from forwarded headers.
+  const forwardedHost = request.headers.get("x-forwarded-host") ?? request.headers.get("host");
+  const forwardedProto = request.headers.get("x-forwarded-proto") ?? url.protocol.replace(":", "");
+  const publicOrigin = forwardedHost ? `${forwardedProto}://${forwardedHost}` : null;
+
   const allowedOrigins = new Set([
-    requestOrigin,
+    url.origin,
+    // Public origin derived from proxy headers
+    ...(publicOrigin ? [publicOrigin] : []),
     // Allow configured trusted origins
     ...(process.env.TRUSTED_ORIGINS?.split(",").map((s) => s.trim()).filter(Boolean) ?? []),
   ]);


### PR DESCRIPTION
## Problem

All POST requests on production (convocados.fly.dev) return **403 Forbidden: origin mismatch**, breaking player additions and all other mutations.

## Root Cause

The CSRF middleware in `src/middleware.ts` compares the browser's `Origin` header against `url.origin`. Behind Fly's reverse proxy:
- `url.origin` resolves to the internal address (`http://0.0.0.0:3000`)
- The browser sends `Origin: https://convocados.fly.dev`

These don't match, and `TRUSTED_ORIGINS` wasn't set as a Fly secret, so every session-authenticated mutation was blocked.

## Fix

Derive the public origin from `x-forwarded-host` and `x-forwarded-proto` headers (which Fly's proxy always sets), and include it in the allowed origins set. This matches the pattern already used in the players API route for building URLs.

No `TRUSTED_ORIGINS` Fly secret is needed for the primary production domain.