### PR TITLE
fix: await notification drain to prevent burst delivery

### DIFF
--- a/src/lib/notificationQueue.server.ts
+++ b/src/lib/notificationQueue.server.ts
@@ -61,7 +61,44 @@ export function enqueueNotification(
 }
 
 /**
- * Drain pending notification jobs — called by the cron endpoint.
+ * Singleton guard: if a drain is already in progress, new callers piggyback
+ * on the running drain instead of starting a concurrent one. This avoids
+ * SQLite BUSY errors and the race where concurrent drains both see 0 pending
+ * jobs because the first one already claimed them.
+ *
+ * After the running drain finishes, we do one more pass to pick up any jobs
+ * that were enqueued while the drain was in progress.
+ */
+let _drainInFlight: Promise<number> | null = null;
+let _drainAgain = false;
+
+export function drainNotificationQueue(): Promise<number> {
+  if (_drainInFlight) {
+    // A drain is already running — flag that we need another pass when it finishes
+    _drainAgain = true;
+    return _drainInFlight;
+  }
+
+  _drainInFlight = _doDrain()
+    .then(async (count) => {
+      // If new jobs were enqueued while we were draining, do one more pass
+      if (_drainAgain) {
+        _drainAgain = false;
+        const extra = await _doDrain();
+        return count + extra;
+      }
+      return count;
+    })
+    .finally(() => {
+      _drainInFlight = null;
+      _drainAgain = false;
+    });
+
+  return _drainInFlight;
+}
+
+/**
+ * Internal drain implementation.
  *
  * Claims each batch atomically via a transaction (SQLite-safe).
  * NOTE(postgres #236): Replace the $transaction claim with
@@ -72,7 +109,7 @@ export function enqueueNotification(
  * moved to dead-letter state (failedAt set). Dead-letter jobs older than
  * DEAD_LETTER_TTL_DAYS are pruned on each run.
  */
-export async function drainNotificationQueue(): Promise<number> {
+async function _doDrain(): Promise<number> {
   // Lazy import to avoid circular dependency
   const { sendPushToEvent } = await import("./push.server");
 

--- a/src/pages/api/events/[id]/datetime.ts
+++ b/src/pages/api/events/[id]/datetime.ts
@@ -3,6 +3,9 @@ import { prisma } from "../../../../lib/db.server";
 import { checkOwnership } from "../../../../lib/auth.helpers.server";
 import { rateLimitResponse } from "../../../../lib/apiRateLimit.server";
 import { enqueueNotification, drainNotificationQueue } from "../../../../lib/notificationQueue.server";
+import { createLogger } from "../../../../lib/logger.server";
+
+const log = createLogger("datetime-api");
 
 export const PUT: APIRoute = async ({ params, request }) => {
   const limited = await rateLimitResponse(request, "write");
@@ -76,8 +79,12 @@ export const PUT: APIRoute = async ({ params, request }) => {
       spotsLeft,
     });
 
-    // Drain notification queue immediately so push is sent in near-real-time
-    if (!process.env.VITEST) drainNotificationQueue().catch(() => {});
+    // Drain notification queue before responding so push is sent immediately.
+    if (!process.env.VITEST) {
+      await drainNotificationQueue().catch((err) => {
+        log.error({ eventId, err }, "Failed to drain notification queue");
+      });
+    }
   }
 
   return Response.json({

--- a/src/pages/api/events/[id]/players.ts
+++ b/src/pages/api/events/[id]/players.ts
@@ -8,6 +8,9 @@ import { getSession, checkOwnership } from "../../../../lib/auth.helpers.server"
 import { rateLimitResponse } from "../../../../lib/apiRateLimit.server";
 import { syncPaymentsForEvent } from "../../../../lib/payments.server";
 import { logEvent } from "../../../../lib/eventLog.server";
+import { createLogger } from "../../../../lib/logger.server";
+
+const log = createLogger("players-api");
 
 /**
  * If teams have been generated, add a player to the team with fewer members.
@@ -148,8 +151,13 @@ export const POST: APIRoute = async ({ params, request }) => {
     await enqueueNotification(eventId, "player_joined", { title: event.title, key: "notifyPlayerJoined", params: { name: trimmed }, url, spotsLeft }, senderClientId);
   }
 
-  // Drain notification queue immediately so push is sent in near-real-time
-  if (!process.env.VITEST) drainNotificationQueue().catch(() => {});
+  // Drain notification queue before responding so push is sent immediately.
+  // Must be awaited — fire-and-forget gets killed when the response completes.
+  if (!process.env.VITEST) {
+    await drainNotificationQueue().catch((err) => {
+      log.error({ eventId, err }, "Failed to drain notification queue");
+    });
+  }
 
   // Send game invite email to the joining player if they have a linked account
   if (shouldLink && session?.user?.email) {
@@ -268,8 +276,12 @@ export const DELETE: APIRoute = async ({ params, request }) => {
     await enqueueNotification(eventId, "player_left", { title: event.title, key: "notifyPlayerLeft", params: { name: player.name }, url, spotsLeft }, senderClientId);
   }
 
-  // Drain notification queue immediately so push is sent in near-real-time
-  if (!process.env.VITEST) drainNotificationQueue().catch(() => {});
+  // Drain notification queue before responding so push is sent immediately.
+  if (!process.env.VITEST) {
+    await drainNotificationQueue().catch((err) => {
+      log.error({ eventId, err }, "Failed to drain notification queue");
+    });
+  }
 
   // Fire webhooks (non-blocking)
   fireWebhooks(eventId, "player_left", { playerName: player.name, spotsLeft }).catch(() => {});


### PR DESCRIPTION
## Problem

Push notifications were delivered in bursts instead of immediately when a player joined/left an event. Testing with `/events/cmnu9tcm60006pihy1goaoyba` showed:

- Job created at 13:11:14 → processed at 13:11:55 (41 seconds late)
- Job created at 13:11:36 → processed at 13:11:55 (19 seconds late)
- 2 jobs created at 13:13:37 and 13:13:46 → **never processed** (stuck pending)

## Root Cause

Two issues:

1. **Fire-and-forget drain** — `drainNotificationQueue().catch(() => {})` was called without `await`. On Fly.io, once the HTTP response is sent, async work can be killed. Jobs would pile up and only get processed when the next request or cron triggered another drain.

2. **Concurrent drain races** — When multiple player actions happened in quick succession, multiple drain calls would race against each other on SQLite. The first drain claims the batch via `$transaction`, but jobs enqueued *during* the drain are missed because the `while(true)` loop already saw 0 pending jobs.

## Fix

### 1. Singleton drain guard (`notificationQueue.server.ts`)
- Only one drain runs at a time — concurrent callers piggyback on the running drain
- After a drain completes, does one more pass to pick up jobs enqueued during the drain
- Eliminates SQLite BUSY errors from concurrent transactions

### 2. Await drain before responding (`players.ts`, `datetime.ts`)
- Changed from `drainNotificationQueue().catch(() => {})` to `await drainNotificationQueue()`
- Push notifications are now sent before the HTTP response returns
- Errors are logged instead of silently swallowed

### 3. Cleared stuck production jobs
- Manually marked 2 stuck pending jobs as processed on production

## Impact

Notifications should now arrive within 1-2 seconds of a player action instead of being batched up and delivered minutes later.