### PR TITLE
feat: wire Litestream into production and add recovery runbooks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,10 @@ RUN pnpm run build
 FROM base AS production
 ENV NODE_ENV=production
 
+# Install Litestream for continuous SQLite replication to S3/R2
+ADD https://github.com/benbjohnson/litestream/releases/download/v0.3.13/litestream-v0.3.13-linux-amd64-static.tar.gz /tmp/litestream.tar.gz
+RUN tar -C /usr/local/bin -xzf /tmp/litestream.tar.gz && rm /tmp/litestream.tar.gz
+
 COPY --from=prod-deps /app/node_modules ./node_modules
 COPY --from=build /app/dist ./dist
 COPY --from=build /app/node_modules/.prisma ./node_modules/.prisma
@@ -35,6 +39,7 @@ RUN mkdir -p node_modules/.bin && ln -sf ../prisma/build/index.js node_modules/.
 COPY package.json ./
 COPY prisma ./prisma
 COPY public ./public
+COPY litestream.yml ./litestream.yml
 COPY scripts/start.sh ./scripts/start.sh
 
 EXPOSE 3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ FROM base AS production
 ENV NODE_ENV=production
 
 # Install Litestream for continuous SQLite replication to S3/R2
-ADD https://github.com/benbjohnson/litestream/releases/download/v0.3.13/litestream-v0.3.13-linux-amd64-static.tar.gz /tmp/litestream.tar.gz
+ADD https://github.com/benbjohnson/litestream/releases/download/v0.5.11/litestream-v0.5.11-linux-amd64.tar.gz /tmp/litestream.tar.gz
 RUN tar -C /usr/local/bin -xzf /tmp/litestream.tar.gz && rm /tmp/litestream.tar.gz
 
 COPY --from=prod-deps /app/node_modules ./node_modules

--- a/docs/disaster-recovery.md
+++ b/docs/disaster-recovery.md
@@ -72,14 +72,14 @@ brew install litestream  # macOS
 ```yaml
 dbs:
   - path: ./restored.db
-    replicas:
-      - type: s3
-        bucket: convocados
-        endpoint: https://2ffa19ca2d5924a86dd7ea437f22e614.r2.cloudflarestorage.com
-        region: auto
-        force-path-style: true
-        access-key-id: <your-r2-access-key>
-        secret-access-key: <your-r2-secret-key>
+    replica:
+      type: s3
+      bucket: convocados
+      endpoint: https://2ffa19ca2d5924a86dd7ea437f22e614.r2.cloudflarestorage.com
+      region: auto
+      force-path-style: true
+      access-key-id: <your-r2-access-key>
+      secret-access-key: <your-r2-secret-key>
 ```
 
 ### 3. Restore
@@ -97,13 +97,13 @@ DATABASE_URL="file:./restored.db" npx prisma studio
 ## Listing Available Snapshots
 
 ```bash
-fly ssh console -C "litestream snapshots -config /app/litestream.yml /data/db.sqlite"
+fly ssh console -C "litestream snapshots -config /app/litestream.yml"
 ```
 
 ## Monitoring
 
 - Check replication is active: `fly logs | grep litestream`
-- Health endpoint reports WAL mode: `curl https://convocados.fly.dev/api/health`
+- Health endpoint reports WAL mode and Litestream status: `curl https://convocados.fly.dev/api/health`
 
 ## Fly.io Secrets Reference
 
@@ -134,6 +134,6 @@ fly secrets set \
 - [ ] Fly.io secrets set (see table above)
 - [ ] `fly deploy` succeeds
 - [ ] Logs show `Starting app with Litestream replication...`
-- [ ] `fly ssh console -C "litestream snapshots -config /app/litestream.yml /data/db.sqlite"` shows snapshots
+- [ ] `fly ssh console -C "litestream snapshots -config /app/litestream.yml"` shows snapshots
 - [ ] Destroy and recreate machine — DB restores automatically from R2
 - [ ] Health endpoint returns `journalMode: "wal"`

--- a/docs/disaster-recovery.md
+++ b/docs/disaster-recovery.md
@@ -4,7 +4,7 @@ This document covers how Convocados backs up and restores its SQLite database us
 
 ## Architecture
 
-- **Database**: SQLite in WAL mode at `/data/prod.db` (Fly.io persistent volume)
+- **Database**: SQLite in WAL mode at `/data/db.sqlite` (Fly.io persistent volume)
 - **Replication**: Litestream continuously streams WAL changes to Cloudflare R2
 - **Config**: `/app/litestream.yml`
 - **Startup**: `scripts/start.sh` handles restore-on-boot + replicate-on-run
@@ -13,7 +13,7 @@ This document covers how Convocados backs up and restores its SQLite database us
 
 The startup script (`scripts/start.sh`) handles recovery automatically:
 
-1. Checks if `/data/prod.db` exists
+1. Checks if `/data/db.sqlite` exists
 2. If missing, runs `litestream restore -if-replica-exists` to pull the latest snapshot from R2
 3. Runs Prisma migrations to apply any pending schema changes
 4. Starts the app with Litestream replicating in the background
@@ -37,20 +37,20 @@ kill $(pgrep -f "node dist/server/entry.mjs")
 ### Restore latest backup
 
 ```bash
-litestream restore -config /app/litestream.yml /data/prod.db
+litestream restore -config /app/litestream.yml /data/db.sqlite
 ```
 
 ### Restore to a specific point in time
 
 ```bash
-litestream restore -config /app/litestream.yml -timestamp "2026-03-20T12:00:00Z" /data/prod.db
+litestream restore -config /app/litestream.yml -timestamp "2026-03-20T12:00:00Z" /data/db.sqlite
 ```
 
 ### Verify the restored database
 
 ```bash
-sqlite3 /data/prod.db "PRAGMA integrity_check;"
-sqlite3 /data/prod.db "SELECT count(*) FROM Event;"
+sqlite3 /data/db.sqlite "PRAGMA integrity_check;"
+sqlite3 /data/db.sqlite "SELECT count(*) FROM Event;"
 ```
 
 ### Restart the machine
@@ -97,7 +97,7 @@ DATABASE_URL="file:./restored.db" npx prisma studio
 ## Listing Available Snapshots
 
 ```bash
-fly ssh console -C "litestream snapshots -config /app/litestream.yml /data/prod.db"
+fly ssh console -C "litestream snapshots -config /app/litestream.yml /data/db.sqlite"
 ```
 
 ## Monitoring
@@ -134,6 +134,6 @@ fly secrets set \
 - [ ] Fly.io secrets set (see table above)
 - [ ] `fly deploy` succeeds
 - [ ] Logs show `Starting app with Litestream replication...`
-- [ ] `fly ssh console -C "litestream snapshots -config /app/litestream.yml /data/prod.db"` shows snapshots
+- [ ] `fly ssh console -C "litestream snapshots -config /app/litestream.yml /data/db.sqlite"` shows snapshots
 - [ ] Destroy and recreate machine — DB restores automatically from R2
 - [ ] Health endpoint returns `journalMode: "wal"`

--- a/docs/runbooks/full-recovery-from-zero.md
+++ b/docs/runbooks/full-recovery-from-zero.md
@@ -1,0 +1,337 @@
+# Runbook: Full Recovery from Zero
+
+Recover the production database from total data loss using Litestream backups stored in Cloudflare R2.
+
+**When to use**: the Fly machine was destroyed, the persistent volume was wiped, or you're provisioning a completely new environment and need to restore all data from backups.
+
+## Prerequisites
+
+- `flyctl` installed and authenticated (`fly auth login`)
+- R2 access credentials (access key ID + secret key for the `convocados` bucket)
+- `litestream` installed locally for verification (`brew install litestream` on macOS)
+- `sqlite3` available (comes with macOS)
+
+## Important: 7-day retention window
+
+Litestream is configured with `retention: 168h` (7 days). If the last replication happened more than 7 days ago, the backups may have been pruned. Act quickly when you discover data loss.
+
+---
+
+## Step 1: Verify R2 has backup data
+
+Before doing anything on Fly, confirm that R2 actually contains snapshots. Run this from your local machine.
+
+Create a local config file `litestream-local.yml` (if you don't already have one):
+
+```yaml
+dbs:
+  - path: ./restored.db
+    replicas:
+      - type: s3
+        bucket: convocados
+        endpoint: https://2ffa19ca2d5924a86dd7ea437f22e614.r2.cloudflarestorage.com
+        region: auto
+        force-path-style: true
+        access-key-id: <your-r2-access-key>
+        secret-access-key: <your-r2-secret-key>
+```
+
+List available snapshots:
+
+```bash
+litestream snapshots -config litestream-local.yml
+```
+
+Expected output:
+
+```
+replica  generation        index  size     created
+s3       xxxxxxxxxxxxxxxxx 0      4194304  2026-04-05T10:00:00Z
+s3       xxxxxxxxxxxxxxxxx 1      4194304  2026-04-06T10:00:00Z
+...
+```
+
+If the list is empty, there are no backups to restore from. Stop here and assess other recovery options.
+
+## Step 2: (Optional) Restore locally to verify data
+
+Before restoring to production, pull the latest backup to your laptop and verify it:
+
+```bash
+litestream restore -config litestream-local.yml ./restored.db
+```
+
+Check integrity and row counts:
+
+```bash
+sqlite3 ./restored.db "PRAGMA integrity_check;"
+sqlite3 ./restored.db "SELECT count(*) FROM User;"
+sqlite3 ./restored.db "SELECT count(*) FROM Event;"
+sqlite3 ./restored.db "SELECT count(*) FROM Player;"
+```
+
+Optionally inspect with Prisma Studio:
+
+```bash
+DATABASE_URL="file:./restored.db" npx prisma studio
+```
+
+## Step 3: Verify Fly secrets are set
+
+The Litestream config uses environment variables for R2 credentials. Confirm they're set:
+
+```bash
+fly secrets list
+```
+
+You should see:
+
+```
+NAME                          DIGEST                  CREATED AT
+LITESTREAM_ACCESS_KEY_ID      xxxxxxxxxxxxxxxxxxxxxx  ...
+LITESTREAM_REPLICA_BUCKET     xxxxxxxxxxxxxxxxxxxxxx  ...
+LITESTREAM_REPLICA_ENDPOINT   xxxxxxxxxxxxxxxxxxxxxx  ...
+LITESTREAM_REPLICA_REGION     xxxxxxxxxxxxxxxxxxxxxx  ...
+LITESTREAM_SECRET_ACCESS_KEY  xxxxxxxxxxxxxxxxxxxxxx  ...
+```
+
+If any are missing, set them:
+
+```bash
+fly secrets set \
+  LITESTREAM_REPLICA_BUCKET=convocados \
+  LITESTREAM_REPLICA_ENDPOINT=https://2ffa19ca2d5924a86dd7ea437f22e614.r2.cloudflarestorage.com \
+  LITESTREAM_REPLICA_REGION=auto \
+  LITESTREAM_ACCESS_KEY_ID=<r2-access-key-id> \
+  LITESTREAM_SECRET_ACCESS_KEY=<r2-secret-access-key>
+```
+
+## Step 4: Ensure a persistent volume exists
+
+The database lives on a Fly persistent volume mounted at `/data`. Check if one exists:
+
+```bash
+fly volumes list
+```
+
+If the volume was destroyed, create a new one in the same region (`cdg`):
+
+```bash
+fly volumes create football_data --region cdg --size 1
+```
+
+Expected output:
+
+```
+ID: vol_xxxxxxxxxxxxxx
+Name: football_data
+Region: cdg
+Size: 1GB
+Created at: ...
+```
+
+## Step 5: Deploy
+
+Deploy the app. The startup script (`scripts/start.sh`) will automatically:
+
+1. Detect that `/data/db.sqlite` doesn't exist
+2. Run `litestream restore -if-replica-exists` to pull the latest backup from R2
+3. Run Prisma migrations
+4. Start the app with Litestream replication
+
+```bash
+fly deploy
+```
+
+Watch the logs to confirm the restore happened:
+
+```bash
+fly logs
+```
+
+You should see:
+
+```
+[startup] Database not found, attempting restore from R2...
+[startup] Database restored from R2 backup
+[startup] Database backed up to /data/db.sqlite.pre-migrate-backup
+[startup] Running database migrations...
+[startup] Starting app with Litestream replication...
+```
+
+## Step 6: Verify health
+
+```bash
+curl -s https://convocados.fly.dev/api/health | jq .
+```
+
+Expected output:
+
+```json
+{
+  "status": "ok",
+  "db": {
+    "journalMode": "wal",
+    "writable": true
+  },
+  "litestream": {
+    "running": true
+  }
+}
+```
+
+## Step 7: Verify data integrity
+
+SSH into the machine and spot-check:
+
+```bash
+fly ssh console -C "sqlite3 /data/db.sqlite 'PRAGMA integrity_check;'"
+fly ssh console -C "sqlite3 /data/db.sqlite 'SELECT count(*) FROM User;'"
+fly ssh console -C "sqlite3 /data/db.sqlite 'SELECT count(*) FROM Event;'"
+fly ssh console -C "sqlite3 /data/db.sqlite 'SELECT count(*) FROM Player;'"
+```
+
+Compare these counts against what you saw in the local preview (Step 2).
+
+## Step 8: Confirm replication is active
+
+Verify Litestream is streaming WAL changes to R2:
+
+```bash
+fly logs | grep litestream
+```
+
+You should see periodic replication messages. Also verify via the health endpoint that `litestream.running` is `true` (Step 6).
+
+---
+
+## If auto-restore fails
+
+If the deploy succeeds but the database wasn't restored (e.g., logs show "No replica found in R2"), restore manually:
+
+### SSH into the machine
+
+```bash
+fly ssh console
+```
+
+### Stop the app
+
+```bash
+kill $(pgrep -f "node dist/server/entry.mjs")
+kill $(pgrep -x litestream)
+sleep 2
+```
+
+### Manually restore
+
+```bash
+litestream restore -config /app/litestream.yml /data/db.sqlite
+```
+
+### Verify
+
+```bash
+sqlite3 /data/db.sqlite "PRAGMA integrity_check;"
+```
+
+### Restart
+
+```bash
+exit
+fly machines restart
+```
+
+---
+
+## Nuclear option: machine completely gone
+
+If the Fly app has no machines at all:
+
+```bash
+# Check current state
+fly status
+
+# If no machines exist, deploy will create one
+fly deploy
+
+# If deploy fails because there's no machine to deploy to:
+fly machine create . --region cdg
+fly deploy
+```
+
+The new machine will mount the volume (or a new one if you created it in Step 4), and the startup script will restore from R2.
+
+---
+
+## Troubleshooting
+
+### "no matching backups found" when restoring
+
+R2 bucket is empty or credentials are wrong. Verify:
+
+```bash
+# Check secrets
+fly secrets list | grep LITESTREAM
+
+# Test locally with your credentials
+litestream snapshots -config litestream-local.yml
+```
+
+If snapshots exist locally but not on the Fly machine, the secrets on Fly are likely wrong or missing. Re-set them (Step 3).
+
+### R2 credentials expired or revoked
+
+Create a new R2 API token in the Cloudflare dashboard:
+
+1. Go to Cloudflare Dashboard → R2 → Manage R2 API Tokens
+2. Create a token with read/write access to the `convocados` bucket
+3. Update Fly secrets with the new credentials
+
+### Volume not mounted
+
+If the app starts but can't write to `/data`:
+
+```bash
+fly ssh console -C "ls -la /data/"
+```
+
+If `/data` doesn't exist or is empty, the volume isn't mounted. Check:
+
+```bash
+fly volumes list
+```
+
+Ensure the volume name matches `football_data` (as configured in `fly.toml`).
+
+### Prisma migration fails on restored database
+
+The restored DB may be from before a migration was created. If `prisma migrate deploy` fails:
+
+1. Check migration status: `fly ssh console -C "./node_modules/.bin/prisma migrate status"`
+2. If a migration partially applied, you may need manual intervention
+3. See the [Point-in-Time Recovery](./point-in-time-recovery.md) runbook's troubleshooting section for migration-specific guidance
+
+### App starts but returns 503
+
+The database may not have been restored. Check:
+
+```bash
+fly ssh console -C "ls -la /data/db.sqlite"
+fly ssh console -C "sqlite3 /data/db.sqlite 'PRAGMA integrity_check;'"
+```
+
+If the file doesn't exist, the restore failed silently. Run the manual restore steps above.
+
+### Health endpoint shows litestream.running: false
+
+Litestream process isn't running. Check logs:
+
+```bash
+fly logs | grep -i "litestream\|replicate\|error"
+```
+
+Common causes:
+- Missing `LITESTREAM_REPLICA_BUCKET` secret (Litestream is skipped entirely)
+- R2 credentials invalid (Litestream crashes on startup)
+- Litestream binary not found (Docker image issue — redeploy)

--- a/docs/runbooks/full-recovery-from-zero.md
+++ b/docs/runbooks/full-recovery-from-zero.md
@@ -26,14 +26,14 @@ Create a local config file `litestream-local.yml` (if you don't already have one
 ```yaml
 dbs:
   - path: ./restored.db
-    replicas:
-      - type: s3
-        bucket: convocados
-        endpoint: https://2ffa19ca2d5924a86dd7ea437f22e614.r2.cloudflarestorage.com
-        region: auto
-        force-path-style: true
-        access-key-id: <your-r2-access-key>
-        secret-access-key: <your-r2-secret-key>
+    replica:
+      type: s3
+      bucket: convocados
+      endpoint: https://2ffa19ca2d5924a86dd7ea437f22e614.r2.cloudflarestorage.com
+      region: auto
+      force-path-style: true
+      access-key-id: <your-r2-access-key>
+      secret-access-key: <your-r2-secret-key>
 ```
 
 List available snapshots:
@@ -42,12 +42,12 @@ List available snapshots:
 litestream snapshots -config litestream-local.yml
 ```
 
-Expected output:
+Expected output (v0.5+ uses LTX format, no generations):
 
 ```
-replica  generation        index  size     created
-s3       xxxxxxxxxxxxxxxxx 0      4194304  2026-04-05T10:00:00Z
-s3       xxxxxxxxxxxxxxxxx 1      4194304  2026-04-06T10:00:00Z
+db        replica  type  snapshot  size      created
+/data/db  s3       ltx   xxxxxxxx  4194304   2026-04-05T10:00:00Z
+/data/db  s3       ltx   xxxxxxxx  4194304   2026-04-06T10:00:00Z
 ...
 ```
 

--- a/docs/runbooks/point-in-time-recovery.md
+++ b/docs/runbooks/point-in-time-recovery.md
@@ -1,0 +1,280 @@
+# Runbook: Point-in-Time Recovery
+
+Recover the production database to a specific moment in time using Litestream backups stored in Cloudflare R2.
+
+**When to use**: accidental data deletion, bad migration, corrupted data, or any situation where you need to roll back to a known-good state.
+
+## Prerequisites
+
+- `flyctl` installed and authenticated (`fly auth login`)
+- R2 access credentials (see `fly secrets list` for current values)
+- `litestream` installed locally for optional preview (`brew install litestream` on macOS)
+- `sqlite3` available (comes with macOS, `apk add sqlite` on Alpine)
+
+## Important: 7-day retention window
+
+Litestream is configured with `retention: 168h` (7 days). You can only restore to timestamps within the last 7 days. Anything older has been pruned from R2.
+
+---
+
+## Step 1: Identify the target timestamp
+
+Determine the exact moment you want to restore to. Sources:
+
+- Application logs: `fly logs`
+- Event logs in the database (if still accessible)
+- User reports with approximate times
+
+The timestamp must be in RFC 3339 / ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ` (UTC).
+
+Example: `2026-04-10T14:30:00Z`
+
+## Step 2: List available snapshots
+
+SSH into the Fly machine and check what's available:
+
+```bash
+fly ssh console -C "litestream snapshots -config /app/litestream.yml"
+```
+
+Expected output:
+
+```
+replica  generation        index  size     created
+s3       xxxxxxxxxxxxxxxxx 0      4194304  2026-04-05T10:00:00Z
+s3       xxxxxxxxxxxxxxxxx 1      4194304  2026-04-06T10:00:00Z
+...
+```
+
+Verify your target timestamp falls within the range of available snapshots.
+
+## Step 3 (Optional): Preview locally first
+
+Before touching production, restore to your laptop and verify the data looks right.
+
+Create a local config file `litestream-local.yml`:
+
+```yaml
+dbs:
+  - path: ./restored.db
+    replicas:
+      - type: s3
+        bucket: convocados
+        endpoint: https://2ffa19ca2d5924a86dd7ea437f22e614.r2.cloudflarestorage.com
+        region: auto
+        force-path-style: true
+        access-key-id: <your-r2-access-key>
+        secret-access-key: <your-r2-secret-key>
+```
+
+Restore locally:
+
+```bash
+litestream restore -config litestream-local.yml -timestamp "2026-04-10T14:30:00Z" ./restored.db
+```
+
+Inspect with Prisma Studio:
+
+```bash
+DATABASE_URL="file:./restored.db" npx prisma studio
+```
+
+Or with sqlite3:
+
+```bash
+sqlite3 ./restored.db "SELECT count(*) FROM User;"
+sqlite3 ./restored.db "SELECT count(*) FROM Event;"
+sqlite3 ./restored.db "SELECT count(*) FROM Player;"
+```
+
+If the data looks correct, proceed to restore in production.
+
+## Step 4: SSH into the Fly machine
+
+```bash
+fly ssh console
+```
+
+## Step 5: Stop the running app
+
+Litestream is the parent process running the app via `-exec`. Killing the Node process will cause Litestream to exit too, but we want a clean stop:
+
+```bash
+# Kill the Node app process
+kill $(pgrep -f "node dist/server/entry.mjs")
+# Kill Litestream (stops replication)
+kill $(pgrep -x litestream)
+```
+
+Wait a moment for processes to exit:
+
+```bash
+sleep 2
+pgrep -x litestream || echo "Litestream stopped"
+pgrep -f "node dist" || echo "App stopped"
+```
+
+## Step 6: Back up the current database
+
+Always keep a copy of the current state before overwriting:
+
+```bash
+cp /data/db.sqlite /data/db.sqlite.pre-restore-backup
+echo "Current DB backed up to /data/db.sqlite.pre-restore-backup"
+```
+
+## Step 7: Remove current database files
+
+You must remove the WAL and SHM files too, otherwise SQLite may replay them on top of the restored data:
+
+```bash
+rm -f /data/db.sqlite /data/db.sqlite-wal /data/db.sqlite-shm
+```
+
+## Step 8: Restore to the target timestamp
+
+```bash
+litestream restore -config /app/litestream.yml -timestamp "2026-04-10T14:30:00Z" /data/db.sqlite
+```
+
+Expected output:
+
+```
+/data/db.sqlite: restoring snapshot XXXXXXXXXXXXXXXX/XXXXXXXXXXXXXXXX to /data/db.sqlite
+```
+
+## Step 9: Verify database integrity
+
+```bash
+sqlite3 /data/db.sqlite "PRAGMA integrity_check;"
+```
+
+Expected output: `ok`
+
+Spot-check key tables:
+
+```bash
+sqlite3 /data/db.sqlite "SELECT count(*) FROM User;"
+sqlite3 /data/db.sqlite "SELECT count(*) FROM Event;"
+sqlite3 /data/db.sqlite "SELECT count(*) FROM Player;"
+sqlite3 /data/db.sqlite "SELECT count(*) FROM GameHistory;"
+```
+
+Compare these counts against what you expect for the target timestamp.
+
+## Step 10: Restart the machine
+
+Exit the SSH session and restart:
+
+```bash
+exit
+fly machines restart
+```
+
+The startup script (`scripts/start.sh`) will:
+1. Skip the restore step (DB file now exists)
+2. Run Prisma migrations (applies any schema changes newer than the restored snapshot)
+3. Start the app with Litestream replication
+
+## Step 11: Verify health
+
+```bash
+curl -s https://convocados.fly.dev/api/health | jq .
+```
+
+Expected output:
+
+```json
+{
+  "status": "ok",
+  "db": {
+    "journalMode": "wal",
+    "writable": true
+  },
+  "litestream": {
+    "running": true
+  }
+}
+```
+
+Check logs to confirm replication resumed:
+
+```bash
+fly logs | grep litestream
+```
+
+---
+
+## Troubleshooting
+
+### "no matching backups found" or empty snapshot list
+
+Your target timestamp is outside the 7-day retention window, or no backups exist yet. Check:
+
+```bash
+fly ssh console -C "litestream snapshots -config /app/litestream.yml"
+```
+
+If the list is empty, Litestream was never replicating. Check that `LITESTREAM_REPLICA_BUCKET` and other secrets are set:
+
+```bash
+fly secrets list
+```
+
+### PRAGMA integrity_check fails
+
+The restored database is corrupted. Try restoring to a slightly earlier timestamp:
+
+```bash
+rm -f /data/db.sqlite /data/db.sqlite-wal /data/db.sqlite-shm
+litestream restore -config /app/litestream.yml -timestamp "2026-04-10T14:00:00Z" /data/db.sqlite
+sqlite3 /data/db.sqlite "PRAGMA integrity_check;"
+```
+
+If all snapshots are corrupted, see the [Full Recovery from Zero](./full-recovery-from-zero.md) runbook.
+
+### Prisma migration fails after restore
+
+The restored DB may be behind on schema. If `prisma migrate deploy` fails:
+
+1. Check which migrations are pending: `./node_modules/.bin/prisma migrate status`
+2. If the failure is due to a column/table already existing (from a partial migration), you may need to manually resolve — see the Prisma docs on [failed migrations](https://www.prisma.io/docs/guides/database/production-troubleshooting)
+3. Do NOT use `prisma migrate resolve --applied` unless you're certain the migration was fully applied
+
+### App won't start after restore
+
+Check logs:
+
+```bash
+fly logs
+```
+
+Common causes:
+- Migration failure (see above)
+- Database file permissions: `chmod 644 /data/db.sqlite`
+- Volume not mounted: `fly ssh console -C "ls -la /data/"`
+
+### litestream.running is false after restart
+
+Litestream may have failed to start. Check:
+
+```bash
+fly logs | grep -i "litestream\|replicate\|error"
+```
+
+Verify secrets are set:
+
+```bash
+fly secrets list | grep LITESTREAM
+```
+
+If secrets are missing, set them and redeploy:
+
+```bash
+fly secrets set \
+  LITESTREAM_REPLICA_BUCKET=convocados \
+  LITESTREAM_REPLICA_ENDPOINT=https://2ffa19ca2d5924a86dd7ea437f22e614.r2.cloudflarestorage.com \
+  LITESTREAM_REPLICA_REGION=auto \
+  LITESTREAM_ACCESS_KEY_ID=<r2-access-key-id> \
+  LITESTREAM_SECRET_ACCESS_KEY=<r2-secret-access-key>
+```

--- a/docs/runbooks/point-in-time-recovery.md
+++ b/docs/runbooks/point-in-time-recovery.md
@@ -37,12 +37,12 @@ SSH into the Fly machine and check what's available:
 fly ssh console -C "litestream snapshots -config /app/litestream.yml"
 ```
 
-Expected output:
+Expected output (v0.5+ uses LTX format, no generations):
 
 ```
-replica  generation        index  size     created
-s3       xxxxxxxxxxxxxxxxx 0      4194304  2026-04-05T10:00:00Z
-s3       xxxxxxxxxxxxxxxxx 1      4194304  2026-04-06T10:00:00Z
+db        replica  type  snapshot  size      created
+/data/db  s3       ltx   xxxxxxxx  4194304   2026-04-05T10:00:00Z
+/data/db  s3       ltx   xxxxxxxx  4194304   2026-04-06T10:00:00Z
 ...
 ```
 
@@ -57,14 +57,14 @@ Create a local config file `litestream-local.yml`:
 ```yaml
 dbs:
   - path: ./restored.db
-    replicas:
-      - type: s3
-        bucket: convocados
-        endpoint: https://2ffa19ca2d5924a86dd7ea437f22e614.r2.cloudflarestorage.com
-        region: auto
-        force-path-style: true
-        access-key-id: <your-r2-access-key>
-        secret-access-key: <your-r2-secret-key>
+    replica:
+      type: s3
+      bucket: convocados
+      endpoint: https://2ffa19ca2d5924a86dd7ea437f22e614.r2.cloudflarestorage.com
+      region: auto
+      force-path-style: true
+      access-key-id: <your-r2-access-key>
+      secret-access-key: <your-r2-secret-key>
 ```
 
 Restore locally:

--- a/litestream.yml
+++ b/litestream.yml
@@ -1,17 +1,16 @@
 # Litestream configuration for continuous SQLite replication.
-# Replicates the production database to an S3-compatible bucket.
+# Replicates the production database to an S3-compatible bucket (Cloudflare R2).
 # See: https://litestream.io/reference/config/
 
 dbs:
   - path: /data/db.sqlite
-    replicas:
-      - type: s3
-        bucket: ${LITESTREAM_REPLICA_BUCKET}
-        path: db
-        endpoint: ${LITESTREAM_REPLICA_ENDPOINT}
-        region: ${LITESTREAM_REPLICA_REGION}
-        force-path-style: true
-        access-key-id: ${LITESTREAM_ACCESS_KEY_ID}
-        secret-access-key: ${LITESTREAM_SECRET_ACCESS_KEY}
-        retention: 168h  # 7 days
-        sync-interval: 1s
+    replica:
+      type: s3
+      bucket: ${LITESTREAM_REPLICA_BUCKET}
+      path: db
+      endpoint: ${LITESTREAM_REPLICA_ENDPOINT}
+      region: ${LITESTREAM_REPLICA_REGION}
+      force-path-style: true
+      access-key-id: ${LITESTREAM_ACCESS_KEY_ID}
+      secret-access-key: ${LITESTREAM_SECRET_ACCESS_KEY}
+      retention: 168h  # 7 days

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -4,13 +4,24 @@ set -e
 DATABASE_URL="${DATABASE_URL:-file:/data/db.sqlite}"
 export DATABASE_URL
 
-echo "[startup] Running database migrations..."
+# ── Restore from R2 if DB is missing ─────────────────────────────────────────
+if [ ! -f /data/db.sqlite ] && [ -n "$LITESTREAM_REPLICA_BUCKET" ]; then
+  echo "[startup] Database not found, attempting restore from R2..."
+  litestream restore -config /app/litestream.yml -if-replica-exists /data/db.sqlite
+  if [ -f /data/db.sqlite ]; then
+    echo "[startup] Database restored from R2 backup"
+  else
+    echo "[startup] No replica found in R2 — starting with fresh database"
+  fi
+fi
 
-# Back up the database before migrating so we have a recovery path
+# ── Pre-migration backup ─────────────────────────────────────────────────────
 if [ -f /data/db.sqlite ]; then
   cp /data/db.sqlite /data/db.sqlite.pre-migrate-backup
   echo "[startup] Database backed up to /data/db.sqlite.pre-migrate-backup"
 fi
+
+echo "[startup] Running database migrations..."
 
 # Run migrations — if this fails, the deploy fails and Fly keeps the old machine.
 # Do NOT auto-resolve failed migrations. They require manual intervention to
@@ -19,5 +30,11 @@ fi
 # unexecuted migrations as "applied".
 ./node_modules/.bin/prisma migrate deploy
 
-echo "[startup] Starting app..."
-exec node dist/server/entry.mjs
+# ── Start app ─────────────────────────────────────────────────────────────────
+if [ -n "$LITESTREAM_REPLICA_BUCKET" ]; then
+  echo "[startup] Starting app with Litestream replication..."
+  exec litestream replicate -exec "node dist/server/entry.mjs" -config /app/litestream.yml
+else
+  echo "[startup] Starting app (no Litestream — LITESTREAM_REPLICA_BUCKET not set)..."
+  exec node dist/server/entry.mjs
+fi

--- a/src/pages/api/health.ts
+++ b/src/pages/api/health.ts
@@ -11,13 +11,28 @@ export const GET: APIRoute = async () => {
     ) as { journal_mode: string }[];
     const journalMode = pragmaResult[0]?.journal_mode ?? "unknown";
 
-    return Response.json({
+    const response: Record<string, unknown> = {
       status: "ok",
       db: {
         journalMode,
         writable: true,
       },
-    });
+    };
+
+    // In production, check if Litestream replication process is running
+    if (process.env.NODE_ENV === "production") {
+      let running = false;
+      try {
+        const { execSync } = await import("node:child_process");
+        execSync("pgrep -x litestream", { timeout: 1000 });
+        running = true;
+      } catch {
+        // pgrep exits non-zero when no process matches
+      }
+      response.litestream = { running };
+    }
+
+    return Response.json(response);
   } catch (err: any) {
     return Response.json(
       { status: "error", message: err?.message ?? "db unreachable" },

--- a/src/test/coverage-zero.test.ts
+++ b/src/test/coverage-zero.test.ts
@@ -59,6 +59,12 @@ describe("GET /api/health", () => {
     expect(body.db.writable).toBe(true);
     expect(body.db.journalMode).toBeTruthy();
   });
+
+  it("omits litestream field in non-production", async () => {
+    const res = await getHealth({ request: new Request("http://localhost/api/health"), params: {} } as any);
+    const body = await res.json();
+    expect(body.litestream).toBeUndefined();
+  });
 });
 
 // ─── GET /api/events/[id]/calendar.ics ───────────────────────────────────────


### PR DESCRIPTION
## Summary

Wires Litestream v0.5.11 into the production Docker image and startup script so that SQLite backups to Cloudflare R2 actually happen. Previously, `litestream.yml` existed but Litestream was never installed or started.

Also adds two operational runbooks for disaster recovery and enhances the health endpoint to report Litestream replication status.

## Changes

### Litestream wiring
- **Dockerfile**: Install Litestream v0.5.11 static binary in the production stage, copy `litestream.yml` into the image
- **scripts/start.sh**: Restore from R2 on boot if DB is missing, start app under `litestream replicate -exec` for continuous replication. Skips Litestream entirely when `LITESTREAM_REPLICA_BUCKET` is not set (local dev)
- **litestream.yml**: Updated to v0.5 config format — singular `replica` field instead of deprecated `replicas` array, removed `sync-interval` (1s is the default)

### Health endpoint
- **src/pages/api/health.ts**: Add `litestream.running` field (production only) that checks if the Litestream process is alive via `pgrep`. Informational — does not affect HTTP status code
- **src/test/coverage-zero.test.ts**: Test that the field is absent in non-production

### Runbooks
- **docs/runbooks/point-in-time-recovery.md**: Step-by-step for restoring to a specific timestamp (bad mutation, accidental deletion)
- **docs/runbooks/full-recovery-from-zero.md**: Step-by-step for total data loss recovery (machine destroyed, volume wiped)

Both include local preview steps, expected output examples (v0.5 LTX format), troubleshooting sections, and a warning about the 7-day retention window.

### Bug fixes
- **docs/disaster-recovery.md**: Fix incorrect DB path `/data/prod.db` → `/data/db.sqlite` throughout, update local config to v0.5 `replica` format, update `litestream snapshots` commands (no DB path arg in v0.5), update monitoring section to mention Litestream health field

## Litestream v0.3 → v0.5 migration notes

Key changes applied in this PR:
- **Version**: v0.3.13 → v0.5.11 (latest stable, released 2026-04-08)
- **Config format**: `replicas` (array) → `replica` (singular object)
- **Replication format**: LTX (Litestream Transaction Log) replaces old WAL segments
- **Generations removed**: v0.5 uses monotonically incrementing transaction IDs instead
- **Binary naming**: `litestream-v0.5.11-linux-amd64.tar.gz` (no more `-static` suffix)
- **CA certs**: v0.5 embeds a fallback root CA bundle — no need to install `ca-certificates` in Alpine

## How it works

```
Boot sequence (production):
1. DB missing? → litestream restore -if-replica-exists (pulls latest from R2)
2. Pre-migration backup
3. prisma migrate deploy
4. litestream replicate -exec "node dist/server/entry.mjs"
   └── Litestream wraps the app, replicates WAL changes to R2 every 1s

Boot sequence (local dev, no LITESTREAM_REPLICA_BUCKET):
1. Pre-migration backup
2. prisma migrate deploy
3. node dist/server/entry.mjs (no Litestream)
```

## Health endpoint response (production)

```json
{
  "status": "ok",
  "db": { "journalMode": "wal", "writable": true },
  "litestream": { "running": true }
}
```

## Testing

- All 1360 tests pass
- Typecheck clean
- New test verifies `litestream` field is absent in non-production