### PR TITLE
feat: collapse split costs accordion by default and persist state

### DIFF
--- a/android-app/app/src/main/java/dev/convocados/data/auth/TokenStore.kt
+++ b/android-app/app/src/main/java/dev/convocados/data/auth/TokenStore.kt
@@ -68,6 +68,6 @@ class TokenStore @Inject constructor(@ApplicationContext context: Context) {
     }
 
     companion object {
-        const val DEFAULT_SERVER_URL = "https://convocados.cabeda.dev"
+        const val DEFAULT_SERVER_URL = "https://convocados.fly.dev"
     }
 }

--- a/android-app/app/src/main/java/dev/convocados/ui/screen/login/LoginScreen.kt
+++ b/android-app/app/src/main/java/dev/convocados/ui/screen/login/LoginScreen.kt
@@ -70,7 +70,7 @@ fun LoginScreen(
                 OutlinedTextField(
                     value = serverUrl,
                     onValueChange = { serverUrl = it },
-                    placeholder = { Text("https://convocados.cabeda.dev") },
+                    placeholder = { Text("https://convocados.fly.dev") },
                     modifier = Modifier.fillMaxWidth(),
                     singleLine = true,
                     colors = OutlinedTextFieldDefaults.colors(

--- a/android-app/app/src/main/java/dev/convocados/ui/screen/profile/ProfileScreen.kt
+++ b/android-app/app/src/main/java/dev/convocados/ui/screen/profile/ProfileScreen.kt
@@ -110,7 +110,7 @@ fun ProfileScreen(
                 Column(Modifier.padding(12.dp)) {
                     OutlinedTextField(
                         value = serverUrl, onValueChange = { serverUrl = it },
-                        placeholder = { Text("https://convocados.cabeda.dev") },
+                        placeholder = { Text("https://convocados.fly.dev") },
                         modifier = Modifier.fillMaxWidth(), singleLine = true,
                     )
                     Row(Modifier.fillMaxWidth().padding(top = 8.dp), horizontalArrangement = Arrangement.End) {

--- a/src/components/PaymentSection.tsx
+++ b/src/components/PaymentSection.tsx
@@ -115,17 +115,20 @@ export function PaymentSection({
     return () => clearInterval(id);
   }, [fetchCost]);
 
-  const [accordionOpen, setAccordionOpen] = useState(false);
+  const storageKey = `splitCosts_expanded_${eventId}`;
+  const [accordionOpen, setAccordionOpen] = useState(() => {
+    try { return localStorage.getItem(storageKey) === "true"; } catch { return false; }
+  });
+
+  // Persist accordion state to localStorage
+  useEffect(() => {
+    try { localStorage.setItem(storageKey, String(accordionOpen)); } catch {}
+  }, [accordionOpen, storageKey]);
 
   // Sync with external control — when controlledExpanded becomes true, open
   useEffect(() => {
     if (controlledExpanded === true) setAccordionOpen(true);
   }, [controlledExpanded]);
-
-  // Auto-expand when cost data loads and there is a cost
-  useEffect(() => {
-    if (costData && costData.totalAmount > 0) setAccordionOpen(true);
-  }, [costData]);
 
   const hasCost = costData && costData.totalAmount > 0;
   const perPlayer = hasCost && activePlayerCount > 0


### PR DESCRIPTION
## Changes

- **Split costs accordion closed by default**: Removed the auto-expand behavior that opened the payment section whenever cost data loaded. The accordion now starts collapsed.
- **Persist accordion state**: The open/closed state is saved per event in localStorage, so the user's preference is remembered across page loads.
- **Android default server**: Updated the default server URL from `convocados.cabeda.dev` to `convocados.fly.dev` in TokenStore, LoginScreen, and ProfileScreen placeholders.