### PR TITLE
fix: correct Litestream v0.5.11 binary asset name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ FROM base AS production
 ENV NODE_ENV=production
 
 # Install Litestream for continuous SQLite replication to S3/R2
-ADD https://github.com/benbjohnson/litestream/releases/download/v0.5.11/litestream-v0.5.11-linux-amd64.tar.gz /tmp/litestream.tar.gz
+ADD https://github.com/benbjohnson/litestream/releases/download/v0.5.11/litestream-0.5.11-linux-x86_64.tar.gz /tmp/litestream.tar.gz
 RUN tar -C /usr/local/bin -xzf /tmp/litestream.tar.gz && rm /tmp/litestream.tar.gz
 
 COPY --from=prod-deps /app/node_modules ./node_modules


### PR DESCRIPTION
The Litestream v0.5.11 release uses a different naming convention than v0.3.x:

- `litestream-0.5.11-linux-x86_64.tar.gz` (no `v` prefix, `x86_64` instead of `amd64`)

The previous URL was returning 404 during Docker build, blocking deployment.