### PR TITLE
fix: pass baseURL to betterAuth to prevent localhost redirect on OAuth

### DIFF
--- a/src/lib/auth.server.ts
+++ b/src/lib/auth.server.ts
@@ -77,6 +77,7 @@ export async function ensureTrustedClientInDB() {
 }
 
 export const auth = betterAuth({
+  baseURL: baseUrl,
   database: prismaAdapter(prisma, { provider: "sqlite" }),
   emailAndPassword: {
     enabled: true,


### PR DESCRIPTION
## Problem

The `betterAuth()` constructor in `auth.server.ts` was not receiving a `baseURL` property. Better Auth defaults to `http://localhost:3000` when no baseURL is set, causing Google OAuth to redirect to localhost instead of the production server.

## Fix

Pass `baseURL: baseUrl` (which reads from `BETTER_AUTH_URL` env var, defaulting to `http://localhost:4321` for local dev) to the `betterAuth()` config.

Also set `BETTER_AUTH_URL=https://convocados.fly.dev` as a Fly.io secret.