### PR TITLE
fix: use APP_BASE_URL for mobile-callback redirect instead of url.origin

### DIFF
--- a/src/pages/api/auth/mobile-callback.ts
+++ b/src/pages/api/auth/mobile-callback.ts
@@ -4,6 +4,7 @@ import { prisma } from "../../../lib/db.server";
 import crypto from "node:crypto";
 
 const MOBILE_CLIENT_ID = "convocados-mobile-app";
+const APP_BASE_URL = process.env.BETTER_AUTH_URL ?? "http://localhost:4321";
 
 /** Ensure the mobile OAuth application exists in the DB */
 let _mobileClientInitialized = false;
@@ -45,7 +46,7 @@ export const GET: APIRoute = async ({ request }) => {
       // Not logged in — redirect to sign-in page with return URL
       const returnUrl = `/api/auth/mobile-callback?redirect_uri=${encodeURIComponent(redirectUri)}`;
       return Response.redirect(
-        new URL(`/auth/signin?callbackURL=${encodeURIComponent(returnUrl)}`, url.origin).toString(),
+        new URL(`/auth/signin?callbackURL=${encodeURIComponent(returnUrl)}`, APP_BASE_URL).toString(),
         302,
       );
     }


### PR DESCRIPTION
## Problem

On Fly.io behind a reverse proxy, `request.url` resolves to the internal address (`http://localhost:3000`), causing the mobile sign-in redirect to go to localhost instead of `convocados.fly.dev`.

## Fix

Use `BETTER_AUTH_URL` env var (with fallback to `localhost:4321` for local dev) as the base for the redirect URL in `mobile-callback.ts` instead of `url.origin`.