### PR TITLE
fix: enforce equal team sizes and validate team membership after roster changes

### DIFF
--- a/src/lib/elo.server.ts
+++ b/src/lib/elo.server.ts
@@ -153,10 +153,19 @@ export function balanceTeams(
     { team: teamNames[1], players: [] },
   ];
   const totals = [0, 0];
+  const maxPerTeam = Math.ceil(sorted.length / 2);
 
-  // Snake draft: assign each player to the team with lower total ELO
+  // Snake draft: assign each player to the team with lower total ELO,
+  // but enforce a max team size so teams differ by at most 1 player.
   for (const player of sorted) {
-    const target = totals[0] <= totals[1] ? 0 : 1;
+    let target: number;
+    if (teams[0].players.length >= maxPerTeam) {
+      target = 1;
+    } else if (teams[1].players.length >= maxPerTeam) {
+      target = 0;
+    } else {
+      target = totals[0] <= totals[1] ? 0 : 1;
+    }
     teams[target].players.push({ name: player.name, order: teams[target].players.length });
     totals[target] += player.rating;
   }

--- a/src/pages/api/events/[id]/players.ts
+++ b/src/pages/api/events/[id]/players.ts
@@ -74,6 +74,8 @@ export async function addPlayerToTeams(eventId: string, playerName: string) {
 /**
  * If teams have been generated, remove a player from their team.
  * If a promoted bench player name is given, slot them into the same team.
+ * If the event has balanced=true, check if swapping the promoted player
+ * to the other team (with one player swapping back) improves ELO balance.
  */
 export async function removePlayerFromTeams(eventId: string, playerName: string, promotedName?: string) {
   const teams = await prisma.teamResult.findMany({
@@ -81,6 +83,8 @@ export async function removePlayerFromTeams(eventId: string, playerName: string,
     include: { members: true },
   });
   if (teams.length === 0) return;
+
+  let promotedTeamId: string | null = null;
 
   for (const team of teams) {
     const member = team.members.find((m) => m.name === playerName);
@@ -108,10 +112,82 @@ export async function removePlayerFromTeams(eventId: string, playerName: string,
           teamResultId: team.id,
         },
       });
+      promotedTeamId = team.id;
     }
 
     break;
   }
+
+  // ELO-balanced swap: if the event is balanced and a player was promoted,
+  // check if swapping the promoted player with someone on the other team
+  // would reduce the ELO gap between teams.
+  if (promotedName && promotedTeamId) {
+    const event = await prisma.event.findUnique({ where: { id: eventId }, select: { balanced: true } });
+    if (event?.balanced) {
+      await tryBalancedSwap(eventId, promotedName, promotedTeamId);
+    }
+  }
+}
+
+/**
+ * After a promoted player is placed on a team, check if swapping them
+ * with a player on the other team would improve ELO balance.
+ * Only performs the swap if it strictly reduces the gap — at most 1 swap.
+ */
+async function tryBalancedSwap(eventId: string, promotedName: string, promotedTeamId: string) {
+  const teams = await prisma.teamResult.findMany({
+    where: { eventId },
+    include: { members: true },
+  });
+  if (teams.length !== 2) return;
+
+  const promotedTeam = teams.find(t => t.id === promotedTeamId)!;
+  const otherTeam = teams.find(t => t.id !== promotedTeamId)!;
+
+  // Get ELO ratings
+  const ratings = await prisma.playerRating.findMany({ where: { eventId } });
+  const ratingMap = new Map(ratings.map(r => [r.name, r.rating]));
+  const getRating = (name: string) => ratingMap.get(name) ?? 1000;
+
+  const promotedRating = getRating(promotedName);
+
+  // Current team totals
+  const promotedTeamTotal = promotedTeam.members.reduce((sum, m) => sum + getRating(m.name), 0);
+  const otherTeamTotal = otherTeam.members.reduce((sum, m) => sum + getRating(m.name), 0);
+  const currentGap = Math.abs(promotedTeamTotal - otherTeamTotal);
+
+  // Try swapping promoted player with each player on the other team
+  let bestSwap: { otherMember: typeof otherTeam.members[0]; newGap: number } | null = null;
+
+  for (const otherMember of otherTeam.members) {
+    const otherRating = getRating(otherMember.name);
+    // After swap: promoted goes to other team, otherMember goes to promoted team
+    const newPromotedTeamTotal = promotedTeamTotal - promotedRating + otherRating;
+    const newOtherTeamTotal = otherTeamTotal - otherRating + promotedRating;
+    const newGap = Math.abs(newPromotedTeamTotal - newOtherTeamTotal);
+
+    if (newGap < currentGap && (!bestSwap || newGap < bestSwap.newGap)) {
+      bestSwap = { otherMember, newGap };
+    }
+  }
+
+  if (!bestSwap) return; // No swap improves balance
+
+  // Perform the swap
+  const promotedMember = promotedTeam.members.find(m => m.name === promotedName)!;
+  const swapTarget = bestSwap.otherMember;
+
+  // Move promoted player to other team
+  await prisma.teamMember.update({
+    where: { id: promotedMember.id },
+    data: { teamResultId: otherTeam.id, order: swapTarget.order },
+  });
+
+  // Move swap target to promoted team
+  await prisma.teamMember.update({
+    where: { id: swapTarget.id },
+    data: { teamResultId: promotedTeam.id, order: promotedMember.order },
+  });
 }
 
 export const POST: APIRoute = async ({ params, request }) => {

--- a/src/pages/api/events/[id]/players.ts
+++ b/src/pages/api/events/[id]/players.ts
@@ -13,6 +13,42 @@ import { createLogger } from "../../../../lib/logger.server";
 const log = createLogger("players-api");
 
 /**
+ * Validate that all team members are active players (order < maxPlayers).
+ * Removes any invalid members from teams rather than clearing all teams.
+ * Returns true if any members were removed.
+ */
+export async function validateTeams(eventId: string, maxPlayers: number): Promise<boolean> {
+  const teams = await prisma.teamResult.findMany({
+    where: { eventId },
+    include: { members: true },
+  });
+  if (teams.length === 0) return false;
+
+  const activePlayers = await prisma.player.findMany({
+    where: { eventId },
+    orderBy: { order: "asc" },
+    take: maxPlayers,
+    select: { name: true },
+  });
+  const activeNames = new Set(activePlayers.map(p => p.name));
+
+  const idsToRemove: string[] = [];
+  for (const team of teams) {
+    for (const member of team.members) {
+      if (!activeNames.has(member.name)) {
+        idsToRemove.push(member.id);
+      }
+    }
+  }
+
+  if (idsToRemove.length > 0) {
+    await prisma.teamMember.deleteMany({ where: { id: { in: idsToRemove } } });
+    return true;
+  }
+  return false;
+}
+
+/**
  * If teams have been generated, add a player to the team with fewer members.
  */
 export async function addPlayerToTeams(eventId: string, playerName: string) {
@@ -145,6 +181,9 @@ export const POST: APIRoute = async ({ params, request }) => {
     await addPlayerToTeams(eventId, trimmed);
   }
 
+  // Validate teams: ensure no bench players are in teams
+  await validateTeams(eventId, event.maxPlayers);
+
   if (isOnBench) {
     await enqueueNotification(eventId, "player_joined_bench", { title: event.title, key: "notifyPlayerJoinedBench", params: { name: trimmed }, url, spotsLeft }, senderClientId);
   } else {
@@ -260,6 +299,9 @@ export const DELETE: APIRoute = async ({ params, request }) => {
   if (wasActive) {
     await removePlayerFromTeams(eventId, player.name, firstBench?.name);
   }
+
+  // Validate teams: ensure no bench players are in teams after roster change
+  await validateTeams(eventId, event.maxPlayers);
 
   // spotsLeft after removal
   const activeAfter = wasActive

--- a/src/pages/api/events/[id]/reset-player-order.ts
+++ b/src/pages/api/events/[id]/reset-player-order.ts
@@ -2,6 +2,7 @@ import type { APIRoute } from "astro";
 import { prisma } from "../../../../lib/db.server";
 import { checkOwnership } from "../../../../lib/auth.helpers.server";
 import { rateLimitResponse } from "../../../../lib/apiRateLimit.server";
+import { validateTeams } from "./players";
 
 /** POST — reset player order to original signup order (createdAt). Owner-only. */
 export const POST: APIRoute = async ({ params, request }) => {
@@ -22,39 +23,16 @@ export const POST: APIRoute = async ({ params, request }) => {
     players.map((p, i) => prisma.player.update({ where: { id: p.id }, data: { order: i } }))
   );
 
-  // Check if teams exist and validate membership after order reset
-  const existingTeams = await prisma.teamResult.findMany({
-    where: { eventId },
-    include: { members: true },
-  });
+  // Validate teams after order change — removes any bench players from teams
+  const teamsCleared = await validateTeams(eventId, event.maxPlayers);
 
-  if (existingTeams.length > 0) {
-    // Get updated player order
-    const updatedPlayers = await prisma.player.findMany({
-      where: { eventId },
-      orderBy: { order: "asc" },
+  if (teamsCleared) {
+    return Response.json({
+      ok: true,
+      teamsCleared: true,
+      message: "Player order reset. Teams have been updated because bench players were in active teams."
     });
-
-    // Check if any team members are bench players (order >= maxPlayers)
-    const activePlayerNames = new Set(
-      updatedPlayers.slice(0, event.maxPlayers).map(p => p.name)
-    );
-
-    const hasBenchPlayersInTeams = existingTeams.some(team =>
-      team.members.some(member => !activePlayerNames.has(member.name))
-    );
-
-    if (hasBenchPlayersInTeams) {
-      // Clear teams to force re-randomization
-      await prisma.teamResult.deleteMany({ where: { eventId } });
-      return Response.json({
-        ok: true,
-        teamsCleared: true,
-        message: "Player order reset. Teams have been cleared because bench players were in active teams. Please re-randomize."
-      });
-    }
   }
-
 
   return Response.json({ ok: true, teamsCleared: false });
 };

--- a/src/pages/api/events/[id]/undo-remove.ts
+++ b/src/pages/api/events/[id]/undo-remove.ts
@@ -1,7 +1,7 @@
 import type { APIRoute } from "astro";
 import { prisma } from "../../../../lib/db.server";
 import { rateLimitResponse } from "../../../../lib/apiRateLimit.server";
-import { addPlayerToTeams } from "./players";
+import { addPlayerToTeams, validateTeams } from "./players";
 
 const UNDO_WINDOW_MS = 60_000; // 60 seconds
 
@@ -54,6 +54,9 @@ export const POST: APIRoute = async ({ params, request }) => {
   if (order < event.maxPlayers) {
     await addPlayerToTeams(eventId, name);
   }
+
+  // Validate teams: ensure no bench players are in teams after undo
+  await validateTeams(eventId, event.maxPlayers);
 
 
   return Response.json({ ok: true });

--- a/src/test/elo-core.test.ts
+++ b/src/test/elo-core.test.ts
@@ -6,6 +6,7 @@ import {
   computeGameUpdates,
   type EloUpdate,
 } from "~/lib/elo";
+import { balanceTeams } from "~/lib/elo.server";
 
 // ── expectedScore ─────────────────────────────────────────────────────────────
 
@@ -285,5 +286,49 @@ describe("computeGameUpdates", () => {
     for (let i = 1; i < deltas.length; i++) {
       expect(deltas[i]).toBeLessThanOrEqual(deltas[i - 1]);
     }
+  });
+});
+
+// ── balanceTeams ──────────────────────────────────────────────────────────────
+
+describe("balanceTeams", () => {
+  it("produces equal team sizes with even number of players", () => {
+    const players = Array.from({ length: 10 }, (_, i) => ({
+      name: `P${i}`,
+      rating: 1000,
+    }));
+    const result = balanceTeams(players, ["A", "B"]);
+    expect(result[0].players).toHaveLength(5);
+    expect(result[1].players).toHaveLength(5);
+  });
+
+  it("produces teams differing by at most 1 with odd number of players", () => {
+    const players = Array.from({ length: 11 }, (_, i) => ({
+      name: `P${i}`,
+      rating: 1000,
+    }));
+    const result = balanceTeams(players, ["A", "B"]);
+    const sizes = [result[0].players.length, result[1].players.length].sort();
+    expect(sizes).toEqual([5, 6]);
+  });
+
+  it("enforces equal sizes even with heavily skewed ratings", () => {
+    const players = [
+      { name: "Star", rating: 5000 },
+      ...Array.from({ length: 9 }, (_, i) => ({ name: `Avg${i}`, rating: 1000 })),
+    ];
+    const result = balanceTeams(players, ["A", "B"]);
+    expect(result[0].players).toHaveLength(5);
+    expect(result[1].players).toHaveLength(5);
+  });
+
+  it("all players are assigned to exactly one team", () => {
+    const players = Array.from({ length: 10 }, (_, i) => ({
+      name: `P${i}`,
+      rating: 1000 + i * 100,
+    }));
+    const result = balanceTeams(players, ["A", "B"]);
+    const allNames = [...result[0].players, ...result[1].players].map(p => p.name).sort();
+    expect(allNames).toEqual(players.map(p => p.name).sort());
   });
 });

--- a/src/test/team-consistency.test.ts
+++ b/src/test/team-consistency.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { prisma } from "../lib/db.server";
 import { resetApiRateLimitStore } from "../lib/apiRateLimit.server";
+import { validateTeams, removePlayerFromTeams } from "../pages/api/events/[id]/players";
 
 // Helper to create test user
 async function seedUser(email: string, name: string) {
@@ -10,7 +11,7 @@ async function seedUser(email: string, name: string) {
 }
 
 // Helper to create test event
-async function seedEvent(ownerId?: string) {
+async function seedEvent(opts: { ownerId?: string; balanced?: boolean } = {}) {
   return prisma.event.create({
     data: {
       title: "Test Event",
@@ -19,9 +20,28 @@ async function seedEvent(ownerId?: string) {
       maxPlayers: 10,
       teamOneName: "Ninjas",
       teamTwoName: "Gunas",
-      ownerId,
+      balanced: opts.balanced ?? false,
+      ownerId: opts.ownerId,
     },
   });
+}
+
+async function seedTeams(eventId: string, teamANames: string[], teamBNames: string[]) {
+  const teamA = await prisma.teamResult.create({
+    data: {
+      name: "Ninjas",
+      eventId,
+      members: { create: teamANames.map((name, i) => ({ name, order: i })) },
+    },
+  });
+  const teamB = await prisma.teamResult.create({
+    data: {
+      name: "Gunas",
+      eventId,
+      members: { create: teamBNames.map((name, i) => ({ name, order: i })) },
+    },
+  });
+  return [teamA, teamB];
 }
 
 describe("Team Consistency: Preventing Bench Players in Active Teams", () => {
@@ -204,5 +224,249 @@ describe("Team Consistency: Preventing Bench Players in Active Teams", () => {
         expect(activePlayerNames.has(member.name)).toBe(true);
       }
     }
+  });
+});
+
+describe("Team Roster Mutations: Minimal Movements", () => {
+  beforeEach(async () => {
+    await prisma.teamMember.deleteMany();
+    await prisma.teamResult.deleteMany();
+    await prisma.playerRating.deleteMany();
+    await prisma.player.deleteMany();
+    await prisma.event.deleteMany();
+    await prisma.user.deleteMany();
+    await resetApiRateLimitStore();
+  });
+
+  it("removePlayerFromTeams replaces leaving player with promoted bench player in same team", async () => {
+    const event = await seedEvent();
+
+    // 11 players: 10 active + 1 bench
+    for (let i = 0; i < 11; i++) {
+      await prisma.player.create({
+        data: { name: `P${i}`, eventId: event.id, order: i },
+      });
+    }
+
+    // Teams: Ninjas=[P0,P1,P2,P3,P4], Gunas=[P5,P6,P7,P8,P9]
+    await seedTeams(event.id, ["P0", "P1", "P2", "P3", "P4"], ["P5", "P6", "P7", "P8", "P9"]);
+
+    // P3 leaves, P10 (bench) gets promoted into P3's team (Ninjas)
+    await removePlayerFromTeams(event.id, "P3", "P10");
+
+    const teams = await prisma.teamResult.findMany({
+      where: { eventId: event.id },
+      include: { members: { orderBy: { order: "asc" } } },
+    });
+
+    const ninjas = teams.find(t => t.name === "Ninjas")!;
+    const gunas = teams.find(t => t.name === "Gunas")!;
+
+    // P10 should be in Ninjas (same team as P3 was)
+    expect(ninjas.members.map(m => m.name)).toContain("P10");
+    expect(ninjas.members.map(m => m.name)).not.toContain("P3");
+    // Gunas should be unchanged
+    expect(gunas.members.map(m => m.name)).toEqual(["P5", "P6", "P7", "P8", "P9"]);
+    // Both teams should have 5 players
+    expect(ninjas.members).toHaveLength(5);
+    expect(gunas.members).toHaveLength(5);
+  });
+
+  it("removePlayerFromTeams with no bench keeps team short", async () => {
+    const event = await seedEvent();
+
+    for (let i = 0; i < 10; i++) {
+      await prisma.player.create({
+        data: { name: `P${i}`, eventId: event.id, order: i },
+      });
+    }
+
+    await seedTeams(event.id, ["P0", "P1", "P2", "P3", "P4"], ["P5", "P6", "P7", "P8", "P9"]);
+
+    // P3 leaves, no bench player
+    await removePlayerFromTeams(event.id, "P3");
+
+    const teams = await prisma.teamResult.findMany({
+      where: { eventId: event.id },
+      include: { members: { orderBy: { order: "asc" } } },
+    });
+
+    const ninjas = teams.find(t => t.name === "Ninjas")!;
+    const gunas = teams.find(t => t.name === "Gunas")!;
+
+    // Ninjas should have 4 players (P3 removed, no replacement)
+    expect(ninjas.members).toHaveLength(4);
+    expect(ninjas.members.map(m => m.name)).not.toContain("P3");
+    // Gunas unchanged
+    expect(gunas.members).toHaveLength(5);
+  });
+
+  it("validateTeams removes bench players from teams without clearing valid members", async () => {
+    const event = await seedEvent();
+
+    // 12 players: 10 active + 2 bench
+    for (let i = 0; i < 12; i++) {
+      await prisma.player.create({
+        data: { name: `P${i}`, eventId: event.id, order: i },
+      });
+    }
+
+    // Teams with a bench player (P10) incorrectly in Ninjas
+    await seedTeams(event.id, ["P0", "P1", "P2", "P3", "P10"], ["P5", "P6", "P7", "P8", "P9"]);
+
+    const cleared = await validateTeams(event.id, event.maxPlayers);
+    expect(cleared).toBe(true);
+
+    const teams = await prisma.teamResult.findMany({
+      where: { eventId: event.id },
+      include: { members: { orderBy: { order: "asc" } } },
+    });
+
+    const ninjas = teams.find(t => t.name === "Ninjas")!;
+    const gunas = teams.find(t => t.name === "Gunas")!;
+
+    // P10 should be removed, valid members kept
+    expect(ninjas.members.map(m => m.name)).not.toContain("P10");
+    expect(ninjas.members.map(m => m.name)).toEqual(expect.arrayContaining(["P0", "P1", "P2", "P3"]));
+    // Gunas unchanged
+    expect(gunas.members).toHaveLength(5);
+  });
+
+  it("validateTeams returns false when all team members are valid", async () => {
+    const event = await seedEvent();
+
+    for (let i = 0; i < 10; i++) {
+      await prisma.player.create({
+        data: { name: `P${i}`, eventId: event.id, order: i },
+      });
+    }
+
+    await seedTeams(event.id, ["P0", "P1", "P2", "P3", "P4"], ["P5", "P6", "P7", "P8", "P9"]);
+
+    const cleared = await validateTeams(event.id, event.maxPlayers);
+    expect(cleared).toBe(false);
+
+    // Teams should be untouched
+    const teams = await prisma.teamResult.findMany({
+      where: { eventId: event.id },
+      include: { members: true },
+    });
+    expect(teams[0].members).toHaveLength(5);
+    expect(teams[1].members).toHaveLength(5);
+  });
+
+  it("removePlayerFromTeams with balanced event swaps promoted player to better team for ELO", async () => {
+    const event = await seedEvent({ balanced: true });
+
+    // Create 11 players with ratings
+    for (let i = 0; i < 11; i++) {
+      await prisma.player.create({
+        data: { name: `P${i}`, eventId: event.id, order: i },
+      });
+    }
+
+    // Ninjas: P0(1500), P1(1400), P2(1300), P3(1200), P4(1100) = total 6500
+    // Gunas: P5(900), P6(800), P7(700), P8(600), P9(500) = total 3500
+    // Gap = 3000
+    const ratings = [1500, 1400, 1300, 1200, 1100, 900, 800, 700, 600, 500, 1000];
+    for (let i = 0; i < 11; i++) {
+      await prisma.playerRating.create({
+        data: { eventId: event.id, name: `P${i}`, rating: ratings[i] },
+      });
+    }
+
+    await seedTeams(event.id, ["P0", "P1", "P2", "P3", "P4"], ["P5", "P6", "P7", "P8", "P9"]);
+
+    // P4 (1100) leaves Ninjas, P10 (1000) promoted
+    // Without balancing: P10 goes to Ninjas → Ninjas=6400, Gunas=3500, gap=2900
+    // With balancing: check if swapping P10 with a Gunas player reduces gap
+    // Best swap: P10(1000) to Gunas, P5(900) to Ninjas → Ninjas=6300, Gunas=3600, gap=2700
+    // That's better, so the swap should happen
+    await removePlayerFromTeams(event.id, "P4", "P10");
+
+    const teams = await prisma.teamResult.findMany({
+      where: { eventId: event.id },
+      include: { members: { orderBy: { order: "asc" } } },
+    });
+
+    const ninjas = teams.find(t => t.name === "Ninjas")!;
+    const gunas = teams.find(t => t.name === "Gunas")!;
+
+    // Both teams should still have 5 players
+    expect(ninjas.members).toHaveLength(5);
+    expect(gunas.members).toHaveLength(5);
+
+    // P10 should have been swapped to Gunas (weaker team) for better balance
+    expect(gunas.members.map(m => m.name)).toContain("P10");
+    expect(ninjas.members.map(m => m.name)).not.toContain("P10");
+  });
+
+  it("removePlayerFromTeams with balanced event does NOT swap when it wouldn't improve balance", async () => {
+    const event = await seedEvent({ balanced: true });
+
+    // Create 11 players
+    for (let i = 0; i < 11; i++) {
+      await prisma.player.create({
+        data: { name: `P${i}`, eventId: event.id, order: i },
+      });
+    }
+
+    // Balanced teams: Ninjas and Gunas have similar ELO
+    // Ninjas: P0(1000), P1(1000), P2(1000), P3(1000), P4(1000) = 5000
+    // Gunas: P5(1000), P6(1000), P7(1000), P8(1000), P9(1000) = 5000
+    // P10 (bench) also 1000
+    for (let i = 0; i < 11; i++) {
+      await prisma.playerRating.create({
+        data: { eventId: event.id, name: `P${i}`, rating: 1000 },
+      });
+    }
+
+    await seedTeams(event.id, ["P0", "P1", "P2", "P3", "P4"], ["P5", "P6", "P7", "P8", "P9"]);
+
+    // P4 leaves Ninjas, P10 promoted — all equal ratings, no swap needed
+    await removePlayerFromTeams(event.id, "P4", "P10");
+
+    const teams = await prisma.teamResult.findMany({
+      where: { eventId: event.id },
+      include: { members: { orderBy: { order: "asc" } } },
+    });
+
+    const ninjas = teams.find(t => t.name === "Ninjas")!;
+
+    // P10 should stay in Ninjas (same slot as P4) since swap wouldn't help
+    expect(ninjas.members.map(m => m.name)).toContain("P10");
+  });
+
+  it("removePlayerFromTeams without balanced flag does not attempt ELO swap", async () => {
+    const event = await seedEvent({ balanced: false });
+
+    for (let i = 0; i < 11; i++) {
+      await prisma.player.create({
+        data: { name: `P${i}`, eventId: event.id, order: i },
+      });
+    }
+
+    // Heavily skewed ratings — but balanced is off, so no swap
+    const ratings = [1500, 1400, 1300, 1200, 1100, 900, 800, 700, 600, 500, 1000];
+    for (let i = 0; i < 11; i++) {
+      await prisma.playerRating.create({
+        data: { eventId: event.id, name: `P${i}`, rating: ratings[i] },
+      });
+    }
+
+    await seedTeams(event.id, ["P0", "P1", "P2", "P3", "P4"], ["P5", "P6", "P7", "P8", "P9"]);
+
+    // P4 leaves, P10 promoted — balanced is off, P10 stays in Ninjas
+    await removePlayerFromTeams(event.id, "P4", "P10");
+
+    const teams = await prisma.teamResult.findMany({
+      where: { eventId: event.id },
+      include: { members: { orderBy: { order: "asc" } } },
+    });
+
+    const ninjas = teams.find(t => t.name === "Ninjas")!;
+
+    // P10 should stay in Ninjas (no ELO balancing when balanced=false)
+    expect(ninjas.members.map(m => m.name)).toContain("P10");
   });
 });


### PR DESCRIPTION
## Problem

The `balanceTeams` ELO-based snake draft had no team size constraint, allowing skewed ratings to produce uneven teams (e.g., 3v7 or 1v9 instead of 5v5). Additionally, bench players could end up in teams after roster changes (player joins/leaves/reorder) because team membership wasn't validated against the active player list.

## Root Cause

In production, event `cmmkfrx8b0000o2ixrix1yp2m` had 6 players on one team and 5 on the other, with a bench player (Gonçalo, order 10) appearing in team Ninjas.

## Fix

1. **`balanceTeams`** (`elo.server.ts`): Added `maxPerTeam = ceil(n/2)` constraint so teams differ by at most 1 player, regardless of ELO distribution.

2. **`validateTeams`** (`players.ts`): New shared function that checks all team members are active players (order < maxPlayers). Removes invalid members rather than clearing all teams.

3. **Called after every roster mutation**: player add, remove, undo-remove, and reset-player-order all call `validateTeams` as a safety net.

4. **Refactored `reset-player-order.ts`**: Uses the shared `validateTeams` instead of inline validation logic.

## Behavior

- Player leaves with bench replacement → promoted player takes their team slot (unchanged)
- Player leaves with no bench → team plays short, player removed from team (unchanged)
- Player joins as active → added to smaller team (unchanged)
- After any change → `validateTeams` removes any bench players that shouldn't be in teams