### PR TITLE
fix: enable Android push notifications and update AGENTS.md

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,10 @@ PUBLIC_GOOGLE_MAPS_API_KEY=your-google-maps-api-key
 # TRUSTED_OAUTH_CLIENT_SECRET=your-trusted-client-secret
 # TRUSTED_OAUTH_REDIRECT_URIS=https://oauth.usebruno.com/callback
 
+# FCM (Firebase Cloud Messaging) — for Android/iOS push notifications
+# Download from Firebase Console → Project Settings → Service Accounts → Generate new private key
+# FCM_SERVICE_ACCOUNT_JSON='{"project_id":"...","client_email":"...","private_key":"..."}'
+
 # Litestream backup (production only — S3-compatible storage)
 # LITESTREAM_REPLICA_BUCKET=your-bucket-name
 # LITESTREAM_REPLICA_ENDPOINT=https://fly.storage.tigris.dev

--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,10 @@ challenges/.pytest_cache/
 
 # Android app
 android-app/.gradle/
+android-app/.kotlin/
+android-app/.idea/
 android-app/app/build/
 android-app/build/
 android-app/local.properties
+android-app/app/google-services.json
+android-app/gradle/gradle-daemon-jvm.properties

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,12 +2,24 @@
 
 ## Project Overview
 
-**Convocados** is a sports event management application built with:
+**Convocados** is a sports event management application with a web app and a native Android app.
+
+### Web App (root `/`)
 - **Framework**: Astro 6.x with React 19
 - **Database**: Prisma with SQLite (WAL mode, Litestream backups in production)
 - **Styling**: Material-UI (MUI)
 - **Testing**: Vitest
 - **Language**: TypeScript
+
+### Android App (`android-app/`)
+- **Language**: Kotlin
+- **UI**: Jetpack Compose with Material 3
+- **DI**: Hilt (Dagger)
+- **Networking**: Ktor client
+- **Auth**: OAuth 2.1 via Custom Tabs (redirect scheme: `convocados://auth`)
+- **Push**: Firebase Cloud Messaging (FCM) via `firebase-messaging-ktx`
+- **Build**: Gradle with KSP, minSdk 26, targetSdk 35
+- **Package**: `com.cabeda.convocados` / namespace `dev.convocados`
 
 ## Core Principles
 
@@ -132,17 +144,34 @@ beforeEach(async () => {
 ## Project Structure
 
 ```
-src/
-├── components/     # React components (.tsx)
+src/                        # Web app source
+├── components/             # React components (.tsx)
 ├── pages/
-│   └── api/         # Astro API routes (.ts)
+│   └── api/               # Astro API routes (.ts)
 ├── lib/
-│   ├── i18n/        # Translations per locale
-│   ├── *.server.ts  # Server-side utilities
-│   └── *.ts         # Shared utilities
-├── test/            # Test files
+│   ├── i18n/              # Translations per locale
+│   ├── *.server.ts        # Server-side utilities
+│   └── *.ts               # Shared utilities
+├── test/                  # Test files
 └── prisma/
     └── schema.prisma
+
+android-app/               # Native Android app
+├── app/src/main/java/dev/convocados/
+│   ├── data/
+│   │   ├── api/           # ApiClient, ConvocadosApi, Models
+│   │   ├── auth/          # AuthManager, TokenStore (OAuth 2.1)
+│   │   ├── push/          # PushTokenManager, ConvocadosFcmService
+│   │   └── datastore/     # SettingsStore (preferences)
+│   ├── ui/
+│   │   ├── navigation/    # AppNavigation, Route definitions
+│   │   ├── screen/        # Feature screens (games, event, profile, etc.)
+│   │   └── theme/         # Material 3 theme & colors
+│   ├── ConvocadosApp.kt   # Hilt application class
+│   ├── MainActivity.kt    # Single activity entry point
+│   └── ConvocadosRoot.kt  # Root composable + RootViewModel
+├── app/build.gradle.kts   # App-level dependencies
+└── build.gradle.kts       # Project-level plugins
 ```
 
 ## Commands

--- a/android-app/app/build.gradle.kts
+++ b/android-app/app/build.gradle.kts
@@ -1,11 +1,10 @@
 plugins {
-    id("com.android.application")
-    id("org.jetbrains.kotlin.android")
-    id("org.jetbrains.kotlin.plugin.compose")
-    id("org.jetbrains.kotlin.plugin.serialization")
-    id("com.google.dagger.hilt.android")
-    id("com.google.devtools.ksp")
-    id("com.google.gms.google-services")
+    alias(libs.plugins.android.application)
+    alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.hilt.android)
+    alias(libs.plugins.ksp)
+    alias(libs.plugins.google.services)
 }
 
 android {
@@ -34,9 +33,6 @@ android {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
-    kotlinOptions {
-        jvmTarget = "17"
-    }
     buildFeatures {
         compose = true
     }
@@ -44,52 +40,54 @@ android {
 
 dependencies {
     // Compose BOM
-    val composeBom = platform("androidx.compose:compose-bom:2024.12.01")
-    implementation(composeBom)
-    implementation("androidx.compose.material3:material3")
-    implementation("androidx.compose.ui:ui")
-    implementation("androidx.compose.ui:ui-tooling-preview")
-    implementation("androidx.compose.material:material-icons-extended")
-    debugImplementation("androidx.compose.ui:ui-tooling")
+    implementation(platform(libs.androidx.compose.bom))
+    implementation(libs.androidx.compose.material3)
+    implementation(libs.androidx.compose.ui)
+    implementation(libs.androidx.compose.ui.tooling.preview)
+    implementation(libs.androidx.compose.material.icons.extended)
+    debugImplementation(libs.androidx.compose.ui.tooling)
 
     // Core
-    implementation("androidx.core:core-ktx:1.15.0")
-    implementation("androidx.lifecycle:lifecycle-runtime-compose:2.8.7")
-    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.7")
-    implementation("androidx.activity:activity-compose:1.9.3")
+    implementation(libs.androidx.core.ktx)
+    implementation(libs.androidx.lifecycle.runtime.compose)
+    implementation(libs.androidx.lifecycle.viewmodel.compose)
+    implementation(libs.androidx.activity.compose)
 
     // Navigation
-    implementation("androidx.navigation:navigation-compose:2.8.5")
-    implementation("androidx.hilt:hilt-navigation-compose:1.2.0")
+    implementation(libs.androidx.navigation.compose)
+    implementation(libs.androidx.hilt.navigation.compose)
 
     // Hilt DI
-    implementation("com.google.dagger:hilt-android:2.53.1")
-    ksp("com.google.dagger:hilt-compiler:2.53.1")
+    implementation(libs.hilt.android)
+    ksp(libs.hilt.compiler)
 
     // Networking
-    implementation("io.ktor:ktor-client-core:3.0.3")
-    implementation("io.ktor:ktor-client-okhttp:3.0.3")
-    implementation("io.ktor:ktor-client-content-negotiation:3.0.3")
-    implementation("io.ktor:ktor-serialization-kotlinx-json:3.0.3")
-    implementation("io.ktor:ktor-client-auth:3.0.3")
-    implementation("io.ktor:ktor-client-logging:3.0.3")
+    implementation(libs.ktor.client.core)
+    implementation(libs.ktor.client.okhttp)
+    implementation(libs.ktor.client.content.negotiation)
+    implementation(libs.ktor.serialization.kotlinx.json)
+    implementation(libs.ktor.client.auth)
+    implementation(libs.ktor.client.logging)
 
     // Serialization
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
+    implementation(libs.kotlinx.serialization.json)
 
     // DataStore (preferences)
-    implementation("androidx.datastore:datastore-preferences:1.1.1")
+    implementation(libs.androidx.datastore.preferences)
 
     // Security (encrypted shared prefs for tokens)
-    implementation("androidx.security:security-crypto:1.1.0-alpha06")
+    implementation(libs.androidx.security.crypto)
 
     // Browser (Custom Tabs for OAuth)
-    implementation("androidx.browser:browser:1.8.0")
+    implementation(libs.androidx.browser)
 
     // Splash screen
-    implementation("androidx.core:core-splashscreen:1.0.1")
+    implementation(libs.androidx.core.splashscreen)
 
     // Firebase
-    implementation(platform("com.google.firebase:firebase-bom:33.7.0"))
-    implementation("com.google.firebase:firebase-messaging-ktx")
+    implementation(platform(libs.firebase.bom))
+    implementation(libs.firebase.messaging.ktx)
+
+    // Accompanist (Permissions)
+    implementation(libs.accompanist.permissions)
 }

--- a/android-app/app/src/main/AndroidManifest.xml
+++ b/android-app/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
         android:name=".ConvocadosApp"

--- a/android-app/app/src/main/java/dev/convocados/data/auth/TokenStore.kt
+++ b/android-app/app/src/main/java/dev/convocados/data/auth/TokenStore.kt
@@ -1,11 +1,13 @@
 package dev.convocados.data.auth
 
 import android.content.Context
+import android.util.Log
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import java.security.GeneralSecurityException
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -22,7 +24,16 @@ class TokenStore @Inject constructor(@ApplicationContext context: Context) {
         .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
         .build()
 
-    private val prefs = EncryptedSharedPreferences.create(
+    private val prefs = try {
+        createEncryptedPrefs(context)
+    } catch (e: Exception) {
+        Log.e("TokenStore", "Failed to initialize EncryptedSharedPreferences, clearing and retrying", e)
+        // Delete the corrupted preferences file and retry
+        context.deleteSharedPreferences("convocados_tokens")
+        createEncryptedPrefs(context)
+    }
+
+    private fun createEncryptedPrefs(context: Context) = EncryptedSharedPreferences.create(
         context,
         "convocados_tokens",
         masterKey,

--- a/android-app/app/src/main/java/dev/convocados/ui/screen/notifications/NotificationPrefsScreen.kt
+++ b/android-app/app/src/main/java/dev/convocados/ui/screen/notifications/NotificationPrefsScreen.kt
@@ -9,12 +9,16 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.google.accompanist.permissions.ExperimentalPermissionsApi
+import com.google.accompanist.permissions.isGranted
+import com.google.accompanist.permissions.rememberPermissionState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dev.convocados.data.api.ConvocadosApi
 import dev.convocados.data.api.NotificationPrefs
@@ -23,6 +27,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import android.Manifest
+import android.os.Build
 
 data class PrefItem(val key: String, val label: String, val desc: String? = null)
 data class PrefSection(val title: String, val items: List<PrefItem>)
@@ -105,11 +111,20 @@ class NotificationPrefsViewModel @Inject constructor(private val api: Convocados
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalPermissionsApi::class)
 @Composable
 fun NotificationPrefsScreen(onBack: () -> Unit, viewModel: NotificationPrefsViewModel = hiltViewModel()) {
     val prefs by viewModel.prefs.collectAsState()
     val loading by viewModel.loading.collectAsState()
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        val permissionState = rememberPermissionState(Manifest.permission.POST_NOTIFICATIONS)
+        LaunchedEffect(permissionState.status) {
+            if (!permissionState.status.isGranted) {
+                permissionState.launchPermissionRequest()
+            }
+        }
+    }
 
     Scaffold(
         topBar = { TopAppBar(title = { Text("\uD83D\uDD14 Notifications") }, navigationIcon = { IconButton(onClick = onBack) { Icon(Icons.AutoMirrored.Filled.ArrowBack, "Back") } }, colors = TopAppBarDefaults.topAppBarColors(containerColor = Bg)) },

--- a/android-app/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/android-app/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -10,6 +10,6 @@
             android:pathData="M27,0C41.91,0 54,12.09 54,27C54,41.91 41.91,54 27,54C12.09,54 0,41.91 0,27C0,12.09 12.09,0 27,0Z"/>
         <path
             android:fillColor="#003822"
-            android:pathData="M17,18L17,36L22,36L22,29L32,29L32,36L37,36L37,18L32,18L32,24L22,24L22,18Z"/>
+            android:pathData="M37,18L17,18L17,36L37,36L37,31L22,31L22,23L37,23Z"/>
     </group>
 </vector>

--- a/android-app/build.gradle.kts
+++ b/android-app/build.gradle.kts
@@ -1,9 +1,8 @@
 plugins {
-    id("com.android.application") version "8.7.3" apply false
-    id("org.jetbrains.kotlin.android") version "2.1.0" apply false
-    id("org.jetbrains.kotlin.plugin.compose") version "2.1.0" apply false
-    id("org.jetbrains.kotlin.plugin.serialization") version "2.1.0" apply false
-    id("com.google.dagger.hilt.android") version "2.53.1" apply false
-    id("com.google.devtools.ksp") version "2.1.0-1.0.29" apply false
-    id("com.google.gms.google-services") version "4.4.2" apply false
+    alias(libs.plugins.android.application) apply false
+    alias(libs.plugins.kotlin.compose) apply false
+    alias(libs.plugins.kotlin.serialization) apply false
+    alias(libs.plugins.hilt.android) apply false
+    alias(libs.plugins.ksp) apply false
+    alias(libs.plugins.google.services) apply false
 }

--- a/android-app/gradle.properties
+++ b/android-app/gradle.properties
@@ -2,3 +2,4 @@ android.useAndroidX=true
 kotlin.code.style=official
 org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m
 org.gradle.parallel=true
+android.builtInKotlin=true

--- a/android-app/gradle/libs.versions.toml
+++ b/android-app/gradle/libs.versions.toml
@@ -1,0 +1,58 @@
+[versions]
+agp = "9.1.0"
+kotlin = "2.3.20"
+ksp = "2.3.6"
+googleServices = "4.4.4"
+hilt = "2.59.2"
+composeBom = "2024.12.01"
+androidxCore = "1.15.0"
+androidxLifecycle = "2.8.7"
+androidxActivity = "1.9.3"
+androidxNavigation = "2.8.5"
+androidxHiltNavigation = "1.2.0"
+ktor = "3.0.3"
+kotlinxSerializationJson = "1.7.3"
+androidxDataStore = "1.1.1"
+androidxSecurity = "1.1.0-alpha06"
+androidxBrowser = "1.8.0"
+androidxSplashscreen = "1.0.1"
+firebaseBom = "33.7.0"
+accompanist = "0.37.3"
+
+[libraries]
+androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "androidxCore" }
+androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "androidxLifecycle" }
+androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "androidxLifecycle" }
+androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "androidxActivity" }
+androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "androidxNavigation" }
+androidx-hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "androidxHiltNavigation" }
+androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
+androidx-compose-ui = { group = "androidx.compose.ui", name = "ui" }
+androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
+androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
+androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-compose-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
+androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "androidxDataStore" }
+androidx-security-crypto = { group = "androidx.security", name = "security-crypto", version.ref = "androidxSecurity" }
+androidx-browser = { group = "androidx.browser", name = "browser", version.ref = "androidxBrowser" }
+androidx-core-splashscreen = { group = "androidx.core", name = "core-splashscreen", version.ref = "androidxSplashscreen" }
+hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
+hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "hilt" }
+ktor-client-core = { group = "io.ktor", name = "ktor-client-core", version.ref = "ktor" }
+ktor-client-okhttp = { group = "io.ktor", name = "ktor-client-okhttp", version.ref = "ktor" }
+ktor-client-content-negotiation = { group = "io.ktor", name = "ktor-client-content-negotiation", version.ref = "ktor" }
+ktor-serialization-kotlinx-json = { group = "io.ktor", name = "ktor-serialization-kotlinx-json", version.ref = "ktor" }
+ktor-client-auth = { group = "io.ktor", name = "ktor-client-auth", version.ref = "ktor" }
+ktor-client-logging = { group = "io.ktor", name = "ktor-client-logging", version.ref = "ktor" }
+kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
+firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom" }
+firebase-messaging-ktx = { group = "com.google.firebase", name = "firebase-messaging-ktx" }
+accompanist-permissions = { group = "com.google.accompanist", name = "accompanist-permissions", version.ref = "accompanist" }
+
+[plugins]
+android-application = { id = "com.android.application", version.ref = "agp" }
+kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+google-services = { id = "com.google.gms.google-services", version.ref = "googleServices" }
+hilt-android = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }

--- a/android-app/gradle/wrapper/gradle-wrapper.properties
+++ b/android-app/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/android-app/settings.gradle.kts
+++ b/android-app/settings.gradle.kts
@@ -5,6 +5,9 @@ pluginManagement {
         gradlePluginPortal()
     }
 }
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.10.0"
+}
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {


### PR DESCRIPTION
## Summary

Android push notifications were not working due to two issues:

1. **Missing `FCM_SERVICE_ACCOUNT_JSON` on Fly.io** — the server-side FCM code in `push.server.ts` silently bailed out because no service account credentials were configured. Fixed by deploying the secret.

2. **Missing `google-services.json` in the Android app** — Firebase SDK couldn't initialize without it, causing `PushTokenManager.registerCurrentToken()` to fail with `IllegalArgumentException: Please set a valid API key`. Fixed by adding the file (gitignored since it contains API keys).

## Changes

### Server-side
- Added `FCM_SERVICE_ACCOUNT_JSON` to `.env.example` documentation
- Deployed the secret to Fly.io (already done)

### Android app
- Added `google-services.json` to `.gitignore` (contains API keys)
- Migrated Gradle to version catalog (`libs.versions.toml`)
- Added `POST_NOTIFICATIONS` permission for Android 13+
- Added notification permission request in `NotificationPrefsScreen`
- Added `accompanist-permissions` dependency
- Improved `TokenStore` resilience with `EncryptedSharedPreferences` recovery
- Updated Gradle wrapper to 9.3.1, AGP to 9.1.0, Hilt to 2.59.2
- Updated app launcher icon

### Documentation
- Updated `AGENTS.md` with Android app tech stack and project structure

## Testing
- All 1371 web tests pass
- TypeScript typecheck passes
- Coverage: 95.09% statements, 85.68% branches