### PR TITLE
fix: use SSH deploy key for release workflow to bypass branch protection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,11 +22,16 @@ jobs:
       version: ${{ steps.bump_version.outputs.new_version }}
 
     steps:
+      - name: Setup SSH for deploy key
+        uses: webfactory/ssh-agent@v0.9.1
+        with:
+          ssh-private-key: ${{ secrets.DEPLOY_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Get latest tag
         id: get_tag
@@ -100,6 +105,7 @@ jobs:
         if: steps.version_bump.outputs.bump_type != 'none'
         run: |
           NEW_VERSION="${{ steps.bump_version.outputs.new_version }}"
+          git remote set-url origin git@github.com:${{ github.repository }}.git
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add package.json


### PR DESCRIPTION
The release workflow was failing because `GITHUB_TOKEN` cannot push directly to `main` when branch protection rules require PRs and status checks.

This switches the release workflow to use an SSH deploy key (`DEPLOY_KEY` secret) which bypasses branch protection, allowing the version bump commit and tag to be pushed to `main`.