### PR TITLE
feat: add Room database for offline caching and improve Android UI

### DIFF
--- a/android-app/app/build.gradle.kts
+++ b/android-app/app/build.gradle.kts
@@ -1,9 +1,10 @@
 plugins {
-    alias(libs.plugins.android.application)
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
     alias(libs.plugins.kotlin.compose)
-    alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.hilt.android)
     alias(libs.plugins.ksp)
+    alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.google.services)
 }
 
@@ -33,6 +34,14 @@ android {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
+    kotlinOptions {
+        jvmTarget = "17"
+        freeCompilerArgs += listOf(
+            "-P",
+            "plugin:androidx.compose.compiler.plugins.kotlin:suppressKotlinVersionCompatibilityCheck=true",
+            "-opt-in=androidx.compose.animation.ExperimentalSharedTransitionApi"
+        )
+    }
     buildFeatures {
         compose = true
     }
@@ -43,6 +52,7 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.compose.ui)
+    implementation(libs.androidx.compose.animation)
     implementation(libs.androidx.compose.ui.tooling.preview)
     implementation(libs.androidx.compose.material.icons.extended)
     debugImplementation(libs.androidx.compose.ui.tooling)
@@ -90,4 +100,15 @@ dependencies {
 
     // Accompanist (Permissions)
     implementation(libs.accompanist.permissions)
+
+    // Room
+    implementation(libs.androidx.room.runtime)
+    implementation(libs.androidx.room.ktx)
+    ksp(libs.androidx.room.compiler)
+
+    // Testing
+    testImplementation(libs.junit)
+    testImplementation(libs.mockk)
+    testImplementation(libs.turbine)
+    testImplementation(libs.kotlinx.coroutines.test)
 }

--- a/android-app/app/src/main/java/dev/convocados/data/local/AppDatabase.kt
+++ b/android-app/app/src/main/java/dev/convocados/data/local/AppDatabase.kt
@@ -1,0 +1,29 @@
+package dev.convocados.data.local
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import dev.convocados.data.local.dao.EventDao
+import dev.convocados.data.local.dao.EventDetailDao
+import dev.convocados.data.local.dao.UserDao
+import dev.convocados.data.local.entity.EventDetailEntity
+import dev.convocados.data.local.entity.EventEntity
+import dev.convocados.data.local.entity.GameHistoryEntity
+import dev.convocados.data.local.entity.PlayerEntity
+import dev.convocados.data.local.entity.UserProfileEntity
+
+@Database(
+    entities = [
+        EventEntity::class,
+        UserProfileEntity::class,
+        EventDetailEntity::class,
+        PlayerEntity::class,
+        GameHistoryEntity::class
+    ],
+    version = 2,
+    exportSchema = false
+)
+abstract class AppDatabase : RoomDatabase() {
+    abstract fun eventDao(): EventDao
+    abstract fun eventDetailDao(): EventDetailDao
+    abstract fun userDao(): UserDao
+}

--- a/android-app/app/src/main/java/dev/convocados/data/local/dao/EventDao.kt
+++ b/android-app/app/src/main/java/dev/convocados/data/local/dao/EventDao.kt
@@ -1,0 +1,27 @@
+package dev.convocados.data.local.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Transaction
+import dev.convocados.data.local.entity.EventEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface EventDao {
+    @Query("SELECT * FROM events WHERE type = :type")
+    fun getEventsByType(type: String): Flow<List<EventEntity>>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertAll(events: List<EventEntity>)
+
+    @Query("DELETE FROM events WHERE type = :type")
+    suspend fun deleteByType(type: String)
+
+    @Transaction
+    suspend fun refreshEvents(type: String, events: List<EventEntity>) {
+        deleteByType(type)
+        insertAll(events)
+    }
+}

--- a/android-app/app/src/main/java/dev/convocados/data/local/dao/EventDetailDao.kt
+++ b/android-app/app/src/main/java/dev/convocados/data/local/dao/EventDetailDao.kt
@@ -1,0 +1,47 @@
+package dev.convocados.data.local.dao
+
+import androidx.room.*
+import dev.convocados.data.local.entity.EventDetailEntity
+import dev.convocados.data.local.entity.GameHistoryEntity
+import dev.convocados.data.local.entity.PlayerEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface EventDetailDao {
+    @Query("SELECT * FROM event_details WHERE id = :id")
+    fun getEvent(id: String): Flow<EventDetailEntity?>
+
+    @Query("SELECT * FROM players WHERE eventId = :eventId ORDER BY `order` ASC")
+    fun getPlayers(eventId: String): Flow<List<PlayerEntity>>
+
+    @Query("SELECT * FROM game_history WHERE eventId = :eventId ORDER BY dateTime DESC")
+    fun getHistory(eventId: String): Flow<List<GameHistoryEntity>>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertEvent(event: EventDetailEntity)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertPlayers(players: List<PlayerEntity>)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertHistory(history: List<GameHistoryEntity>)
+
+    @Query("DELETE FROM players WHERE eventId = :eventId")
+    suspend fun deletePlayers(eventId: String)
+
+    @Query("DELETE FROM game_history WHERE eventId = :eventId")
+    suspend fun deleteHistory(eventId: String)
+
+    @Transaction
+    suspend fun refreshEvent(
+        event: EventDetailEntity,
+        players: List<PlayerEntity>,
+        history: List<GameHistoryEntity>
+    ) {
+        insertEvent(event)
+        deletePlayers(event.id)
+        insertPlayers(players)
+        deleteHistory(event.id)
+        insertHistory(history)
+    }
+}

--- a/android-app/app/src/main/java/dev/convocados/data/local/dao/UserDao.kt
+++ b/android-app/app/src/main/java/dev/convocados/data/local/dao/UserDao.kt
@@ -1,0 +1,20 @@
+package dev.convocados.data.local.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import dev.convocados.data.local.entity.UserProfileEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface UserDao {
+    @Query("SELECT * FROM user_profiles LIMIT 1")
+    fun getUserProfile(): Flow<UserProfileEntity?>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(profile: UserProfileEntity)
+
+    @Query("DELETE FROM user_profiles")
+    suspend fun clear()
+}

--- a/android-app/app/src/main/java/dev/convocados/data/local/entity/EventDetailEntities.kt
+++ b/android-app/app/src/main/java/dev/convocados/data/local/entity/EventDetailEntities.kt
@@ -1,0 +1,98 @@
+package dev.convocados.data.local.entity
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+import dev.convocados.data.api.EventDetail
+import dev.convocados.data.api.GameHistory
+import dev.convocados.data.api.Player
+
+@Entity(tableName = "event_details")
+data class EventDetailEntity(
+    @PrimaryKey val id: String,
+    val title: String,
+    val location: String,
+    val dateTime: String,
+    val maxPlayers: Int,
+    val sport: String,
+    val ownerId: String?,
+    val isAdmin: Boolean,
+    val locked: Boolean,
+    val teamOneName: String,
+    val teamTwoName: String,
+)
+
+@Entity(
+    tableName = "players",
+    foreignKeys = [
+        ForeignKey(
+            entity = EventDetailEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["eventId"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [Index("eventId")]
+)
+data class PlayerEntity(
+    @PrimaryKey val id: String,
+    val eventId: String,
+    val name: String,
+    val order: Int,
+    val userId: String?
+)
+
+@Entity(
+    tableName = "game_history",
+    foreignKeys = [
+        ForeignKey(
+            entity = EventDetailEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["eventId"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [Index("eventId")]
+)
+data class GameHistoryEntity(
+    @PrimaryKey val id: String,
+    val eventId: String,
+    val dateTime: String,
+    val scoreOne: Int?,
+    val scoreTwo: Int?,
+    val teamOneName: String,
+    val teamTwoName: String,
+)
+
+fun EventDetail.toEntity() = EventDetailEntity(
+    id = id,
+    title = title,
+    location = location,
+    dateTime = dateTime,
+    maxPlayers = maxPlayers,
+    sport = sport,
+    ownerId = ownerId,
+    isAdmin = isAdmin,
+    locked = locked,
+    teamOneName = teamOneName,
+    teamTwoName = teamTwoName
+)
+
+fun Player.toEntity(eventId: String) = PlayerEntity(
+    id = id,
+    eventId = eventId,
+    name = name,
+    order = order,
+    userId = userId
+)
+
+fun GameHistory.toEntity(eventId: String) = GameHistoryEntity(
+    id = id,
+    eventId = eventId,
+    dateTime = dateTime,
+    scoreOne = scoreOne,
+    scoreTwo = scoreTwo,
+    teamOneName = teamOneName,
+    teamTwoName = teamTwoName
+)

--- a/android-app/app/src/main/java/dev/convocados/data/local/entity/EventEntity.kt
+++ b/android-app/app/src/main/java/dev/convocados/data/local/entity/EventEntity.kt
@@ -1,0 +1,44 @@
+package dev.convocados.data.local.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import dev.convocados.data.api.EventSummary
+
+@Entity(tableName = "events")
+data class EventEntity(
+    @PrimaryKey val id: String,
+    val title: String,
+    val location: String,
+    val dateTime: String,
+    val sport: String,
+    val maxPlayers: Int,
+    val playerCount: Int,
+    val archivedAt: String?,
+    val isRecurring: Boolean,
+    val type: String // "owned", "joined", "archivedOwned", "archivedJoined"
+)
+
+fun EventEntity.toSummary() = EventSummary(
+    id = id,
+    title = title,
+    location = location,
+    dateTime = dateTime,
+    sport = sport,
+    maxPlayers = maxPlayers,
+    playerCount = playerCount,
+    archivedAt = archivedAt,
+    isRecurring = isRecurring
+)
+
+fun EventSummary.toEntity(type: String) = EventEntity(
+    id = id,
+    title = title,
+    location = location,
+    dateTime = dateTime,
+    sport = sport,
+    maxPlayers = maxPlayers,
+    playerCount = playerCount,
+    archivedAt = archivedAt,
+    isRecurring = isRecurring,
+    type = type
+)

--- a/android-app/app/src/main/java/dev/convocados/data/local/entity/UserProfileEntity.kt
+++ b/android-app/app/src/main/java/dev/convocados/data/local/entity/UserProfileEntity.kt
@@ -1,0 +1,27 @@
+package dev.convocados.data.local.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import dev.convocados.data.api.UserProfile
+
+@Entity(tableName = "user_profiles")
+data class UserProfileEntity(
+    @PrimaryKey val id: String,
+    val name: String,
+    val email: String,
+    val image: String?
+)
+
+fun UserProfileEntity.toDomain() = UserProfile(
+    id = id,
+    name = name,
+    email = email,
+    image = image
+)
+
+fun UserProfile.toEntity() = UserProfileEntity(
+    id = id,
+    name = name,
+    email = email,
+    image = image
+)

--- a/android-app/app/src/main/java/dev/convocados/data/repository/EventRepository.kt
+++ b/android-app/app/src/main/java/dev/convocados/data/repository/EventRepository.kt
@@ -1,0 +1,119 @@
+package dev.convocados.data.repository
+
+import dev.convocados.data.api.ConvocadosApi
+import dev.convocados.data.api.EventSummary
+import dev.convocados.data.api.EventDetail
+import dev.convocados.data.api.GameHistory
+import dev.convocados.data.api.OkResponse
+import dev.convocados.data.api.PaginatedHistory
+import dev.convocados.data.api.Player
+import dev.convocados.data.api.RemovePlayerResponse
+import dev.convocados.data.api.UndoData
+import dev.convocados.data.local.dao.EventDao
+import dev.convocados.data.local.dao.EventDetailDao
+import dev.convocados.data.local.entity.EventDetailEntity
+import dev.convocados.data.local.entity.GameHistoryEntity
+import dev.convocados.data.local.entity.PlayerEntity
+import dev.convocados.data.local.entity.toEntity
+import dev.convocados.data.local.entity.toSummary
+import dev.convocados.data.api.MyGamesResponse
+import dev.convocados.ui.UiEventManager
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class EventRepository @Inject constructor(
+    private val api: ConvocadosApi,
+    private val eventDao: EventDao,
+    private val eventDetailDao: EventDetailDao,
+    private val uiEventManager: UiEventManager
+) {
+    fun getEventsByType(type: String): Flow<List<EventSummary>> =
+        eventDao.getEventsByType(type).map { entities ->
+            entities.map { it.toSummary() }
+        }
+
+    fun getEventDetail(eventId: String): Flow<EventDetail?> =
+        combine(
+            eventDetailDao.getEvent(eventId),
+            eventDetailDao.getPlayers(eventId),
+            eventDetailDao.getHistory(eventId)
+        ) { entity, players, history ->
+            entity?.toDomain(players, history)
+        }
+
+    fun getPlayers(eventId: String): Flow<List<Player>> =
+        eventDetailDao.getPlayers(eventId).map { entities -> entities.map { it.toDomain() } }
+
+    fun getHistory(eventId: String): Flow<List<GameHistory>> =
+        eventDetailDao.getHistory(eventId).map { entities -> entities.map { it.toDomain() } }
+
+    suspend fun refreshEventDetail(eventId: String) {
+        try {
+            val event = api.fetchEvent(eventId)
+            val history = runCatching { api.fetchHistory(eventId) }.getOrElse { PaginatedHistory() }
+            
+            eventDetailDao.refreshEvent(
+                event.toEntity(),
+                event.players.map { it.toEntity(eventId) },
+                history.data.map { it.toEntity(eventId) }
+            )
+        } catch (e: Exception) {
+            uiEventManager.showSnackbar("Offline: showing cached data")
+        }
+    }
+
+    suspend fun refreshMyGames() {
+        try {
+            val response = api.fetchMyGames()
+            eventDao.refreshEvents("owned", response.owned.map { it.toEntity("owned") })
+            eventDao.refreshEvents("joined", response.joined.map { it.toEntity("joined") })
+        } catch (e: Exception) {
+            uiEventManager.showSnackbar("Failed to refresh games: ${e.message}")
+        }
+    }
+
+    suspend fun addPlayer(eventId: String, name: String, link: Boolean): Result<Unit> = try {
+        api.addPlayer(eventId, name, link)
+        refreshEventDetail(eventId)
+        Result.success(Unit)
+    } catch (e: Exception) {
+        Result.failure(e)
+    }
+
+    suspend fun removePlayer(eventId: String, playerId: String): Result<UndoData?> = try {
+        val res = api.removePlayer(eventId, playerId)
+        refreshEventDetail(eventId)
+        Result.success(res.undo)
+    } catch (e: Exception) {
+        Result.failure(e)
+    }
+
+    suspend fun verifyPassword(eventId: String, password: String): Result<Unit> = try {
+        api.verifyEventPassword(eventId, password)
+        refreshEventDetail(eventId)
+        Result.success(Unit)
+    } catch (e: Exception) {
+        Result.failure(e)
+    }
+
+    // Helper mappers for the Flow
+    private fun EventDetailEntity.toDomain(players: List<PlayerEntity>, history: List<GameHistoryEntity>) = EventDetail(
+        id = id, title = title, location = location, dateTime = dateTime,
+        maxPlayers = maxPlayers, sport = sport, ownerId = ownerId,
+        isAdmin = isAdmin, locked = locked, teamOneName = teamOneName, teamTwoName = teamTwoName,
+        players = players.map { it.toDomain() }
+    )
+
+    private fun PlayerEntity.toDomain() = Player(
+        id = id, name = name, order = order, userId = userId
+    )
+
+    private fun GameHistoryEntity.toDomain() = GameHistory(
+        id = id, dateTime = dateTime, scoreOne = scoreOne, scoreTwo = scoreTwo,
+        teamOneName = teamOneName, teamTwoName = teamTwoName
+    )
+}

--- a/android-app/app/src/main/java/dev/convocados/data/repository/UserRepository.kt
+++ b/android-app/app/src/main/java/dev/convocados/data/repository/UserRepository.kt
@@ -1,0 +1,34 @@
+package dev.convocados.data.repository
+
+import dev.convocados.data.api.ConvocadosApi
+import dev.convocados.data.api.UserProfile
+import dev.convocados.data.local.dao.UserDao
+import dev.convocados.data.local.entity.toDomain
+import dev.convocados.data.local.entity.toEntity
+import dev.convocados.ui.UiEventManager
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class UserRepository @Inject constructor(
+    private val api: ConvocadosApi,
+    private val userDao: UserDao,
+    private val uiEventManager: UiEventManager
+) {
+    val userProfile: Flow<UserProfile?> = userDao.getUserProfile().map { it?.toDomain() }
+
+    suspend fun refreshUserProfile() {
+        try {
+            val profile = api.fetchUserInfo()
+            userDao.insert(profile.toEntity())
+        } catch (e: Exception) {
+            uiEventManager.showSnackbar("Failed to refresh profile: ${e.message}")
+        }
+    }
+
+    suspend fun clearUser() {
+        userDao.clear()
+    }
+}

--- a/android-app/app/src/main/java/dev/convocados/di/DatabaseModule.kt
+++ b/android-app/app/src/main/java/dev/convocados/di/DatabaseModule.kt
@@ -1,0 +1,38 @@
+package dev.convocados.di
+
+import android.content.Context
+import androidx.room.Room
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import dev.convocados.data.local.AppDatabase
+import dev.convocados.data.local.dao.EventDao
+import dev.convocados.data.local.dao.EventDetailDao
+import dev.convocados.data.local.dao.UserDao
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object DatabaseModule {
+
+    @Provides
+    @Singleton
+    fun provideAppDatabase(@ApplicationContext context: Context): AppDatabase {
+        return Room.databaseBuilder(
+            context,
+            AppDatabase::class.java,
+            "convocados.db"
+        ).build()
+    }
+
+    @Provides
+    fun provideEventDao(db: AppDatabase): EventDao = db.eventDao()
+
+    @Provides
+    fun provideEventDetailDao(db: AppDatabase): EventDetailDao = db.eventDetailDao()
+
+    @Provides
+    fun provideUserDao(db: AppDatabase): UserDao = db.userDao()
+}

--- a/android-app/app/src/main/java/dev/convocados/ui/UiEventManager.kt
+++ b/android-app/app/src/main/java/dev/convocados/ui/UiEventManager.kt
@@ -1,0 +1,20 @@
+package dev.convocados.ui
+
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class UiEventManager @Inject constructor() {
+    private val _events = MutableSharedFlow<UiEvent>()
+    val events = _events.asSharedFlow()
+
+    suspend fun showSnackbar(message: String) {
+        _events.emit(UiEvent.ShowSnackbar(message))
+    }
+}
+
+sealed class UiEvent {
+    data class ShowSnackbar(val message: String) : UiEvent()
+}

--- a/android-app/app/src/main/java/dev/convocados/ui/components/Shimmer.kt
+++ b/android-app/app/src/main/java/dev/convocados/ui/components/Shimmer.kt
@@ -1,0 +1,78 @@
+package dev.convocados.ui.components
+
+import androidx.compose.animation.core.*
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import dev.convocados.ui.theme.Border
+import dev.convocados.ui.theme.Surface
+
+@Composable
+fun ShimmerItem(
+    modifier: Modifier = Modifier,
+    shimmerColor: Color = Border.copy(alpha = 0.5f),
+    baseColor: Color = Border.copy(alpha = 0.2f)
+) {
+    val transition = rememberInfiniteTransition(label = "shimmer")
+    val translateAnim = transition.animateFloat(
+        initialValue = -200f,
+        targetValue = 1000f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 1200, easing = LinearEasing),
+            repeatMode = RepeatMode.Restart
+        ),
+        label = "shimmer"
+    )
+
+    val brush = Brush.linearGradient(
+        colors = listOf(baseColor, shimmerColor, baseColor),
+        start = Offset(x = translateAnim.value - 200f, y = translateAnim.value - 200f),
+        end = Offset(x = translateAnim.value, y = translateAnim.value)
+    )
+
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = Surface),
+        shape = RoundedCornerShape(12.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth(0.6f)
+                    .height(20.dp)
+                    .clip(RoundedCornerShape(4.dp))
+                    .background(brush)
+            )
+            Spacer(Modifier.height(8.dp))
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth(0.4f)
+                    .height(14.dp)
+                    .clip(RoundedCornerShape(4.dp))
+                    .background(brush)
+            )
+            Spacer(Modifier.height(8.dp))
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth(0.3f)
+                    .height(12.dp)
+                    .clip(RoundedCornerShape(4.dp))
+                    .background(brush)
+            )
+        }
+    }
+}

--- a/android-app/app/src/main/java/dev/convocados/ui/navigation/AppNavigation.kt
+++ b/android-app/app/src/main/java/dev/convocados/ui/navigation/AppNavigation.kt
@@ -1,5 +1,9 @@
 package dev.convocados.ui.navigation
 
+import androidx.compose.animation.AnimatedVisibilityScope
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.SharedTransitionLayout
+import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Person
@@ -34,6 +38,7 @@ import dev.convocados.ui.screen.user.UserProfileScreen
 
 data class BottomNavItem(val route: String, val label: String, val icon: @Composable () -> Unit)
 
+@OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
 fun AppNavigation(isAuthenticated: Boolean) {
     val navController = rememberNavController()
@@ -74,126 +79,134 @@ fun AppNavigation(isAuthenticated: Boolean) {
             }
         }
     ) { padding ->
-        NavHost(
-            navController = navController,
-            startDestination = startDestination,
-            modifier = Modifier.padding(padding),
-        ) {
-            composable(Route.Login.route) {
-                LoginScreen(onLoginSuccess = {
-                    navController.navigate(Route.Games.route) {
-                        popUpTo(Route.Login.route) { inclusive = true }
-                    }
-                })
-            }
-            composable(Route.Games.route) {
-                GamesScreen(
-                    onEventClick = { navController.navigate(Route.EventDetail.create(it)) },
-                    onCreateClick = { navController.navigate(Route.CreateEvent.route) },
-                    onPublicClick = { navController.navigate(Route.PublicGames.route) },
-                )
-            }
-            composable(Route.Stats.route) {
-                StatsScreen(onEventClick = { navController.navigate(Route.EventDetail.create(it)) })
-            }
-            composable(Route.Profile.route) {
-                ProfileScreen(
-                    onLogout = {
-                        navController.navigate(Route.Login.route) {
-                            popUpTo(0) { inclusive = true }
+        SharedTransitionLayout {
+            NavHost(
+                navController = navController,
+                startDestination = startDestination,
+                modifier = Modifier.padding(padding),
+            ) {
+                composable(Route.Login.route) {
+                    LoginScreen(onLoginSuccess = {
+                        navController.navigate(Route.Games.route) {
+                            popUpTo(Route.Login.route) { inclusive = true }
                         }
-                    },
-                    onNotificationPrefs = { navController.navigate(Route.NotificationPrefs.route) },
-                )
-            }
-            composable(Route.CreateEvent.route) {
-                CreateEventScreen(
-                    onCreated = { id ->
-                        navController.navigate(Route.EventDetail.create(id)) {
-                            popUpTo(Route.CreateEvent.route) { inclusive = true }
-                        }
-                    },
-                    onBack = { navController.popBackStack() },
-                )
-            }
-            composable(
-                Route.EventDetail().route,
-                arguments = listOf(navArgument("eventId") { type = NavType.StringType }),
-            ) { entry ->
-                val eventId = entry.arguments?.getString("eventId") ?: return@composable
-                EventDetailScreen(
-                    eventId = eventId,
-                    onBack = { navController.popBackStack() },
-                    onSettings = { navController.navigate(Route.EventSettings.create(eventId)) },
-                    onRankings = { navController.navigate(Route.EventRankings.create(eventId)) },
-                    onPayments = { navController.navigate(Route.EventPayments.create(eventId)) },
-                    onLog = { navController.navigate(Route.EventLog.create(eventId)) },
-                    onAttendance = { navController.navigate(Route.EventAttendance.create(eventId)) },
-                    onNotificationPrefs = { navController.navigate(Route.NotificationPrefs.route) },
-                    onUserClick = { navController.navigate(Route.UserProfile.create(it)) },
-                )
-            }
-            composable(
-                Route.EventSettings().route,
-                arguments = listOf(navArgument("eventId") { type = NavType.StringType }),
-            ) { entry ->
-                val eventId = entry.arguments?.getString("eventId") ?: return@composable
-                EventSettingsScreen(
-                    eventId = eventId,
-                    onBack = { navController.popBackStack() },
-                    onRankings = { navController.navigate(Route.EventRankings.create(eventId)) },
-                    onPayments = { navController.navigate(Route.EventPayments.create(eventId)) },
-                    onLog = { navController.navigate(Route.EventLog.create(eventId)) },
-                    onAttendance = { navController.navigate(Route.EventAttendance.create(eventId)) },
-                )
-            }
-            composable(
-                Route.EventRankings().route,
-                arguments = listOf(navArgument("eventId") { type = NavType.StringType }),
-            ) { entry ->
-                val eventId = entry.arguments?.getString("eventId") ?: return@composable
-                RankingsScreen(eventId = eventId, onBack = { navController.popBackStack() })
-            }
-            composable(
-                Route.EventPayments().route,
-                arguments = listOf(navArgument("eventId") { type = NavType.StringType }),
-            ) { entry ->
-                val eventId = entry.arguments?.getString("eventId") ?: return@composable
-                PaymentsScreen(eventId = eventId, onBack = { navController.popBackStack() })
-            }
-            composable(
-                Route.EventAttendance().route,
-                arguments = listOf(navArgument("eventId") { type = NavType.StringType }),
-            ) { entry ->
-                val eventId = entry.arguments?.getString("eventId") ?: return@composable
-                AttendanceScreen(eventId = eventId, onBack = { navController.popBackStack() })
-            }
-            composable(
-                Route.EventLog().route,
-                arguments = listOf(navArgument("eventId") { type = NavType.StringType }),
-            ) { entry ->
-                val eventId = entry.arguments?.getString("eventId") ?: return@composable
-                EventLogScreen(eventId = eventId, onBack = { navController.popBackStack() })
-            }
-            composable(Route.PublicGames.route) {
-                PublicGamesScreen(
-                    onEventClick = { navController.navigate(Route.EventDetail.create(it)) },
-                    onBack = { navController.popBackStack() },
-                )
-            }
-            composable(Route.NotificationPrefs.route) {
-                NotificationPrefsScreen(onBack = { navController.popBackStack() })
-            }
-            composable(
-                Route.UserProfile().route,
-                arguments = listOf(navArgument("userId") { type = NavType.StringType }),
-            ) { entry ->
-                val userId = entry.arguments?.getString("userId") ?: return@composable
-                UserProfileScreen(
-                    userId = userId,
-                    onBack = { navController.popBackStack() },
-                    onEventClick = { navController.navigate(Route.EventDetail.create(it)) },
-                )
+                    })
+                }
+                composable(Route.Games.route) {
+                    GamesScreen(
+                        onEventClick = { navController.navigate(Route.EventDetail.create(it)) },
+                        onCreateClick = { navController.navigate(Route.CreateEvent.route) },
+                        onPublicClick = { navController.navigate(Route.PublicGames.route) },
+                        sharedTransitionScope = this@SharedTransitionLayout,
+                        animatedVisibilityScope = this@composable,
+                    )
+                }
+                composable(Route.Stats.route) {
+                    StatsScreen(onEventClick = { navController.navigate(Route.EventDetail.create(it)) })
+                }
+                composable(Route.Profile.route) {
+                    ProfileScreen(
+                        onLogout = {
+                            navController.navigate(Route.Login.route) {
+                                popUpTo(0) { inclusive = true }
+                            }
+                        },
+                        onNotificationPrefs = { navController.navigate(Route.NotificationPrefs.route) },
+                    )
+                }
+                composable(Route.CreateEvent.route) {
+                    CreateEventScreen(
+                        onCreated = { id ->
+                            navController.navigate(Route.EventDetail.create(id)) {
+                                popUpTo(Route.CreateEvent.route) { inclusive = true }
+                            }
+                        },
+                        onBack = { navController.popBackStack() },
+                    )
+                }
+                composable(
+                    Route.EventDetail().route,
+                    arguments = listOf(navArgument("eventId") { type = NavType.StringType }),
+                ) { entry ->
+                    val eventId = entry.arguments?.getString("eventId") ?: return@composable
+                    EventDetailScreen(
+                        eventId = eventId,
+                        onBack = { navController.popBackStack() },
+                        onSettings = { navController.navigate(Route.EventSettings.create(eventId)) },
+                        onRankings = { navController.navigate(Route.EventRankings.create(eventId)) },
+                        onPayments = { navController.navigate(Route.EventPayments.create(eventId)) },
+                        onLog = { navController.navigate(Route.EventLog.create(eventId)) },
+                        onAttendance = { navController.navigate(Route.EventAttendance.create(eventId)) },
+                        onNotificationPrefs = { navController.navigate(Route.NotificationPrefs.route) },
+                        onUserClick = { navController.navigate(Route.UserProfile.create(it)) },
+                        sharedTransitionScope = this@SharedTransitionLayout,
+                        animatedVisibilityScope = this@composable,
+                    )
+                }
+                composable(
+                    Route.EventSettings().route,
+                    arguments = listOf(navArgument("eventId") { type = NavType.StringType }),
+                ) { entry ->
+                    val eventId = entry.arguments?.getString("eventId") ?: return@composable
+                    EventSettingsScreen(
+                        eventId = eventId,
+                        onBack = { navController.popBackStack() },
+                        onRankings = { navController.navigate(Route.EventRankings.create(eventId)) },
+                        onPayments = { navController.navigate(Route.EventPayments.create(eventId)) },
+                        onLog = { navController.navigate(Route.EventLog.create(eventId)) },
+                        onAttendance = { navController.navigate(Route.EventAttendance.create(eventId)) },
+                    )
+                }
+                composable(
+                    Route.EventRankings().route,
+                    arguments = listOf(navArgument("eventId") { type = NavType.StringType }),
+                ) { entry ->
+                    val eventId = entry.arguments?.getString("eventId") ?: return@composable
+                    RankingsScreen(eventId = eventId, onBack = { navController.popBackStack() })
+                }
+                composable(
+                    Route.EventPayments().route,
+                    arguments = listOf(navArgument("eventId") { type = NavType.StringType }),
+                ) { entry ->
+                    val eventId = entry.arguments?.getString("eventId") ?: return@composable
+                    PaymentsScreen(eventId = eventId, onBack = { navController.popBackStack() })
+                }
+                composable(
+                    Route.EventAttendance().route,
+                    arguments = listOf(navArgument("eventId") { type = NavType.StringType }),
+                ) { entry ->
+                    val eventId = entry.arguments?.getString("eventId") ?: return@composable
+                    AttendanceScreen(eventId = eventId, onBack = { navController.popBackStack() })
+                }
+                composable(
+                    Route.EventLog().route,
+                    arguments = listOf(navArgument("eventId") { type = NavType.StringType }),
+                ) { entry ->
+                    val eventId = entry.arguments?.getString("eventId") ?: return@composable
+                    EventLogScreen(eventId = eventId, onBack = { navController.popBackStack() })
+                }
+                composable(Route.PublicGames.route) {
+                    PublicGamesScreen(
+                        onEventClick = { navController.navigate(Route.EventDetail.create(it)) },
+                        onBack = { navController.popBackStack() },
+                        sharedTransitionScope = this@SharedTransitionLayout,
+                        animatedVisibilityScope = this@composable,
+                    )
+                }
+                composable(Route.NotificationPrefs.route) {
+                    NotificationPrefsScreen(onBack = { navController.popBackStack() })
+                }
+                composable(
+                    Route.UserProfile().route,
+                    arguments = listOf(navArgument("userId") { type = NavType.StringType }),
+                ) { entry ->
+                    val userId = entry.arguments?.getString("userId") ?: return@composable
+                    UserProfileScreen(
+                        userId = userId,
+                        onBack = { navController.popBackStack() },
+                        onEventClick = { navController.navigate(Route.EventDetail.create(it)) },
+                    )
+                }
             }
         }
     }

--- a/android-app/app/src/main/java/dev/convocados/ui/screen/event/EventDetailScreen.kt
+++ b/android-app/app/src/main/java/dev/convocados/ui/screen/event/EventDetailScreen.kt
@@ -1,6 +1,9 @@
 package dev.convocados.ui.screen.event
 
 import android.content.Intent
+import androidx.compose.animation.AnimatedVisibilityScope
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.*
@@ -14,6 +17,7 @@ import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -21,15 +25,25 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dev.convocados.data.api.*
 import dev.convocados.data.auth.TokenStore
+import dev.convocados.data.repository.EventRepository
 import dev.convocados.ui.screen.games.formatRelativeDate
 import dev.convocados.ui.theme.*
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -47,13 +61,36 @@ data class EventScreenState(
     val undoData: UndoData? = null,
 )
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel
 class EventDetailViewModel @Inject constructor(
+    private val repository: EventRepository,
     private val api: ConvocadosApi,
     private val tokenStore: TokenStore,
 ) : ViewModel() {
-    private val _state = MutableStateFlow(EventScreenState())
-    val state: StateFlow<EventScreenState> = _state
+    private val _eventId = MutableStateFlow<String?>(null)
+
+    val event = _eventId.flatMapLatest { id ->
+        if (id == null) flowOf(null) else repository.getEventDetail(id)
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
+
+    val players = _eventId.flatMapLatest { id ->
+        if (id == null) flowOf(emptyList()) else repository.getPlayers(id)
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    val history = _eventId.flatMapLatest { id ->
+        if (id == null) flowOf(emptyList()) else repository.getHistory(id)
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    private val _state = MutableStateFlow(EventScreenState(locked = true))
+    val state: StateFlow<EventScreenState> = combine(_state, event, history) { s, e, h ->
+        s.copy(
+            event = e,
+            history = h,
+            loading = s.loading && e == null,
+            locked = if (e?.locked == true) s.locked else false
+        )
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), EventScreenState(locked = true))
 
     private val _user = MutableStateFlow<UserProfile?>(null)
     val user: StateFlow<UserProfile?> = _user
@@ -63,25 +100,11 @@ class EventDetailViewModel @Inject constructor(
     }
 
     fun load(eventId: String) {
+        _eventId.value = eventId
         viewModelScope.launch {
-            _state.value = _state.value.copy(loading = _state.value.event == null)
-            runCatching {
-                val ev = api.fetchEvent(eventId)
-                if (ev.locked) {
-                    _state.value = EventScreenState(loading = false, locked = true)
-                    return@launch
-                }
-                val hist = runCatching { api.fetchHistory(eventId) }.getOrElse { PaginatedHistory() }
-                val kp = runCatching { api.fetchKnownPlayers(eventId) }.getOrElse { KnownPlayersResponse() }
-                val pg = runCatching { api.fetchPostGameStatus(eventId) }.getOrNull()
-                _state.value = _state.value.copy(
-                    loading = false, refreshing = false, event = ev,
-                    history = hist.data, historyHasMore = hist.hasMore, historyCursor = hist.nextCursor,
-                    knownPlayers = kp.players, postGame = pg, error = null,
-                )
-            }.onFailure {
-                _state.value = _state.value.copy(loading = false, refreshing = false, error = it.message)
-            }
+            _state.value = _state.value.copy(loading = event.value == null)
+            repository.refreshEventDetail(eventId)
+            _state.value = _state.value.copy(loading = false, refreshing = false)
         }
     }
 
@@ -92,22 +115,20 @@ class EventDetailViewModel @Inject constructor(
 
     fun addPlayer(eventId: String, name: String, link: Boolean = true) {
         viewModelScope.launch {
-            runCatching { api.addPlayer(eventId, name, link) }
-                .onSuccess { load(eventId) }
+            repository.addPlayer(eventId, name, link)
                 .onFailure { _state.value = _state.value.copy(error = it.message) }
         }
     }
 
     fun removePlayer(eventId: String, playerId: String) {
         viewModelScope.launch {
-            runCatching { api.removePlayer(eventId, playerId) }
-                .onSuccess { res ->
-                    _state.value = _state.value.copy(undoData = res.undo)
-                    load(eventId)
-                    // Clear undo after 60s
+            repository.removePlayer(eventId, playerId)
+                .onSuccess { undo ->
+                    _state.value = _state.value.copy(undoData = undo)
                     delay(60_000)
                     _state.value = _state.value.copy(undoData = null)
                 }
+                .onFailure { _state.value = _state.value.copy(error = it.message) }
         }
     }
 
@@ -115,32 +136,38 @@ class EventDetailViewModel @Inject constructor(
         val undo = _state.value.undoData ?: return
         viewModelScope.launch {
             runCatching { api.undoRemovePlayer(eventId, undo) }
-                .onSuccess { _state.value = _state.value.copy(undoData = null); load(eventId) }
+                .onSuccess {
+                    _state.value = _state.value.copy(undoData = null)
+                    repository.refreshEventDetail(eventId)
+                }
         }
     }
 
     fun randomize(eventId: String, balanced: Boolean) {
         viewModelScope.launch {
-            runCatching { api.randomizeTeams(eventId, balanced) }.onSuccess { load(eventId) }
+            runCatching { api.randomizeTeams(eventId, balanced) }
+                .onSuccess { repository.refreshEventDetail(eventId) }
         }
     }
 
     fun claimPlayer(eventId: String, playerId: String) {
         viewModelScope.launch {
-            runCatching { api.claimPlayer(eventId, playerId) }.onSuccess { load(eventId) }
+            runCatching { api.claimPlayer(eventId, playerId) }
+                .onSuccess { repository.refreshEventDetail(eventId) }
         }
     }
 
     fun saveScore(eventId: String, historyId: String, s1: Int, s2: Int) {
         viewModelScope.launch {
-            runCatching { api.updateScore(eventId, historyId, s1, s2) }.onSuccess { load(eventId) }
+            runCatching { api.updateScore(eventId, historyId, s1, s2) }
+                .onSuccess { repository.refreshEventDetail(eventId) }
         }
     }
 
     fun verifyPassword(eventId: String, password: String) {
         viewModelScope.launch {
-            runCatching { api.verifyEventPassword(eventId, password) }
-                .onSuccess { _state.value = _state.value.copy(locked = false); load(eventId) }
+            repository.verifyPassword(eventId, password)
+                .onSuccess { _state.value = _state.value.copy(locked = false) }
                 .onFailure { _state.value = _state.value.copy(error = "Incorrect password") }
         }
     }
@@ -148,7 +175,7 @@ class EventDetailViewModel @Inject constructor(
     fun getShareUrl(eventId: String): String = "${tokenStore.getServerUrl()}/events/$eventId"
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalSharedTransitionApi::class)
 @Composable
 fun EventDetailScreen(
     eventId: String,
@@ -161,9 +188,14 @@ fun EventDetailScreen(
     onNotificationPrefs: () -> Unit,
     onUserClick: (String) -> Unit,
     viewModel: EventDetailViewModel = hiltViewModel(),
+    sharedTransitionScope: SharedTransitionScope,
+    animatedVisibilityScope: AnimatedVisibilityScope,
 ) {
-    val state by viewModel.state.collectAsState()
-    val user by viewModel.user.collectAsState()
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    val event by viewModel.event.collectAsStateWithLifecycle()
+    val players by viewModel.players.collectAsStateWithLifecycle()
+    val history by viewModel.history.collectAsStateWithLifecycle()
+    val user by viewModel.user.collectAsStateWithLifecycle()
     val context = LocalContext.current
     var newPlayer by remember { mutableStateOf("") }
     var editingScoreId by remember { mutableStateOf<String?>(null) }
@@ -176,15 +208,21 @@ fun EventDetailScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text(state.event?.title ?: "Event", maxLines = 1) },
+                title = { Text(event?.title ?: "Event", maxLines = 1) },
                 navigationIcon = { IconButton(onClick = onBack) { Icon(Icons.AutoMirrored.Filled.ArrowBack, "Back") } },
                 colors = TopAppBarDefaults.topAppBarColors(containerColor = Bg),
             )
         },
         containerColor = Bg,
+        modifier = with(sharedTransitionScope) {
+            Modifier.sharedElement(
+                rememberSharedContentState(key = "item-container-$eventId"),
+                animatedVisibilityScope = animatedVisibilityScope
+            )
+        }
     ) { padding ->
         when {
-            state.loading -> Box(Modifier.fillMaxSize().padding(padding), Alignment.Center) {
+            state.loading && event == null -> Box(Modifier.fillMaxSize().padding(padding), Alignment.Center) {
                 CircularProgressIndicator(color = Primary)
             }
             state.locked -> {

--- a/android-app/app/src/main/java/dev/convocados/ui/screen/games/GamesScreen.kt
+++ b/android-app/app/src/main/java/dev/convocados/ui/screen/games/GamesScreen.kt
@@ -1,5 +1,8 @@
 package dev.convocados.ui.screen.games
 
+import androidx.compose.animation.AnimatedVisibilityScope
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
@@ -23,9 +26,12 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import dev.convocados.data.api.ConvocadosApi
 import dev.convocados.data.api.EventSummary
 import dev.convocados.data.api.MyGamesResponse
+import dev.convocados.data.repository.EventRepository
 import dev.convocados.ui.theme.*
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import java.time.Instant
 import java.time.ZoneId
@@ -34,46 +40,52 @@ import java.time.format.FormatStyle
 import javax.inject.Inject
 
 @HiltViewModel
-class GamesViewModel @Inject constructor(private val api: ConvocadosApi) : ViewModel() {
-    private val _state = MutableStateFlow<GamesState>(GamesState.Loading)
-    val state: StateFlow<GamesState> = _state
+class GamesViewModel @Inject constructor(
+    private val repository: EventRepository,
+    private val api: ConvocadosApi
+) : ViewModel() {
+    private val _refreshing = MutableStateFlow(false)
+    val refreshing: StateFlow<Boolean> = _refreshing
 
-    init { load() }
+    val ownedGames = repository.getEventsByType("owned")
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
-    fun load() {
-        viewModelScope.launch {
-            _state.value = GamesState.Loading
-            runCatching { api.fetchMyGames() }
-                .onSuccess { _state.value = GamesState.Success(it) }
-                .onFailure { _state.value = GamesState.Error(it.message ?: "Failed to load") }
-        }
-    }
+    val joinedGames = repository.getEventsByType("joined")
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    val archivedOwned = repository.getEventsByType("archivedOwned")
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    val archivedJoined = repository.getEventsByType("archivedJoined")
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    init { refresh() }
 
     fun refresh() {
         viewModelScope.launch {
-            runCatching { api.fetchMyGames() }
-                .onSuccess { _state.value = GamesState.Success(it) }
+            _refreshing.value = true
+            repository.refreshMyGames()
+            _refreshing.value = false
         }
     }
 }
 
-sealed class GamesState {
-    data object Loading : GamesState()
-    data class Success(val data: MyGamesResponse) : GamesState()
-    data class Error(val message: String) : GamesState()
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalSharedTransitionApi::class)
 @Composable
 fun GamesScreen(
     onEventClick: (String) -> Unit,
     onCreateClick: () -> Unit,
     onPublicClick: () -> Unit,
     viewModel: GamesViewModel = hiltViewModel(),
+    sharedTransitionScope: SharedTransitionScope,
+    animatedVisibilityScope: AnimatedVisibilityScope,
 ) {
-    val state by viewModel.state.collectAsState()
+    val owned by viewModel.ownedGames.collectAsState()
+    val joined by viewModel.joinedGames.collectAsState()
+    val archivedOwned by viewModel.archivedOwned.collectAsState()
+    val archivedJoined by viewModel.archivedJoined.collectAsState()
+    val isRefreshing by viewModel.refreshing.collectAsState()
     var showArchived by remember { mutableStateOf(false) }
-    var isRefreshing by remember { mutableStateOf(false) }
 
     Scaffold(
         floatingActionButton = {
@@ -83,100 +95,103 @@ fun GamesScreen(
         },
         containerColor = Bg,
     ) { padding ->
-        when (val s = state) {
-            is GamesState.Loading -> Box(Modifier.fillMaxSize().padding(padding), Alignment.Center) {
-                CircularProgressIndicator(color = Primary)
-            }
-            is GamesState.Error -> Box(Modifier.fillMaxSize().padding(padding), Alignment.Center) {
-                Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                    Text(s.message, color = Error, fontSize = 14.sp)
-                    Spacer(Modifier.height(12.dp))
-                    TextButton(onClick = { viewModel.load() }) { Text("Retry", color = Primary) }
+        val active = owned + joined
+        val archived = archivedOwned + archivedJoined
+        val games = if (showArchived) archived else active
+
+        PullToRefreshBox(
+            isRefreshing = isRefreshing,
+            onRefresh = { viewModel.refresh() },
+            modifier = Modifier.fillMaxSize().padding(padding),
+        ) {
+            LazyColumn(
+                contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                // Tab bar
+                item {
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.padding(bottom = 8.dp)) {
+                        FilterChip(
+                            selected = !showArchived,
+                            onClick = { showArchived = false },
+                            label = { Text("My Games (${active.size})") },
+                            colors = FilterChipDefaults.filterChipColors(
+                                selectedContainerColor = PrimaryDark,
+                                selectedLabelColor = PrimaryContainer,
+                            ),
+                        )
+                        if (archived.isNotEmpty()) {
+                            FilterChip(
+                                selected = showArchived,
+                                onClick = { showArchived = true },
+                                label = { Text("Archived (${archived.size})") },
+                                colors = FilterChipDefaults.filterChipColors(
+                                    selectedContainerColor = PrimaryDark,
+                                    selectedLabelColor = PrimaryContainer,
+                                ),
+                            )
+                        }
+                        FilterChip(
+                            selected = false,
+                            onClick = onPublicClick,
+                            label = { Text("\uD83C\uDF0D") },
+                        )
+                    }
                 }
-            }
-            is GamesState.Success -> {
-                val active = s.data.owned + s.data.joined
-                val archived = s.data.archivedOwned + s.data.archivedJoined
-                val games = if (showArchived) archived else active
 
-                PullToRefreshBox(
-                    isRefreshing = isRefreshing,
-                    onRefresh = {
-                        isRefreshing = true
-                        viewModel.refresh()
-                        isRefreshing = false
-                    },
-                    modifier = Modifier.fillMaxSize().padding(padding),
-                ) {
-                    LazyColumn(
-                        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
-                        verticalArrangement = Arrangement.spacedBy(8.dp),
-                    ) {
-                        // Tab bar
-                        item {
-                            Row(horizontalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.padding(bottom = 8.dp)) {
-                                FilterChip(
-                                    selected = !showArchived,
-                                    onClick = { showArchived = false },
-                                    label = { Text("My Games (${active.size})") },
-                                    colors = FilterChipDefaults.filterChipColors(
-                                        selectedContainerColor = PrimaryDark,
-                                        selectedLabelColor = PrimaryContainer,
-                                    ),
-                                )
-                                if (archived.isNotEmpty()) {
-                                    FilterChip(
-                                        selected = showArchived,
-                                        onClick = { showArchived = true },
-                                        label = { Text("Archived (${archived.size})") },
-                                        colors = FilterChipDefaults.filterChipColors(
-                                            selectedContainerColor = PrimaryDark,
-                                            selectedLabelColor = PrimaryContainer,
-                                        ),
-                                    )
-                                }
-                                FilterChip(
-                                    selected = false,
-                                    onClick = onPublicClick,
-                                    label = { Text("\uD83C\uDF0D") },
-                                )
+                if (games.isEmpty() && !showArchived) {
+                    item {
+                        Column(
+                            modifier = Modifier.fillMaxWidth().padding(vertical = 48.dp),
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                        ) {
+                            Text("No games yet", color = TextPrimary, fontWeight = FontWeight.Bold, fontSize = 18.sp)
+                            Spacer(Modifier.height(8.dp))
+                            Text("Create a game or join one to get started.", color = TextMuted, fontSize = 14.sp)
+                            Spacer(Modifier.height(20.dp))
+                            Button(
+                                onClick = onCreateClick,
+                                colors = ButtonDefaults.buttonColors(containerColor = Primary),
+                            ) {
+                                Text("+ Create a Game", color = OnPrimary, fontWeight = FontWeight.Bold)
                             }
-                        }
-
-                        if (games.isEmpty() && !showArchived) {
-                            item {
-                                Column(
-                                    modifier = Modifier.fillMaxWidth().padding(vertical = 48.dp),
-                                    horizontalAlignment = Alignment.CenterHorizontally,
-                                ) {
-                                    Text("No games yet", color = TextPrimary, fontWeight = FontWeight.Bold, fontSize = 18.sp)
-                                    Spacer(Modifier.height(8.dp))
-                                    Text("Create a game or join one to get started.", color = TextMuted, fontSize = 14.sp)
-                                    Spacer(Modifier.height(20.dp))
-                                    Button(
-                                        onClick = onCreateClick,
-                                        colors = ButtonDefaults.buttonColors(containerColor = Primary),
-                                    ) {
-                                        Text("+ Create a Game", color = OnPrimary, fontWeight = FontWeight.Bold)
-                                    }
-                                }
-                            }
-                        }
-
-                        items(games, key = { it.id }) { game ->
-                            GameCard(game = game, onClick = { onEventClick(game.id) })
                         }
                     }
+                }
+
+                items(games, key = { it.id }) { game ->
+                    GameCard(
+                        game = game,
+                        onClick = { onEventClick(game.id) },
+                        sharedTransitionScope = sharedTransitionScope,
+                        animatedVisibilityScope = animatedVisibilityScope,
+                    )
                 }
             }
         }
     }
 }
 
+@OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
-fun GameCard(game: EventSummary, onClick: () -> Unit) {
+fun GameCard(
+    game: EventSummary,
+    onClick: () -> Unit,
+    sharedTransitionScope: SharedTransitionScope,
+    animatedVisibilityScope: AnimatedVisibilityScope,
+) {
     Card(
-        modifier = Modifier.fillMaxWidth().clickable(onClick = onClick),
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .then(
+                with(sharedTransitionScope) {
+                    Modifier.sharedElement(
+                        rememberSharedContentState(key = "item-container-${game.id}"),
+                        animatedVisibilityScope = animatedVisibilityScope
+                    )
+                }
+            ),
         colors = CardDefaults.cardColors(containerColor = Surface),
     ) {
         Column(modifier = Modifier.padding(16.dp)) {

--- a/android-app/app/src/main/java/dev/convocados/ui/screen/profile/ProfileScreen.kt
+++ b/android-app/app/src/main/java/dev/convocados/ui/screen/profile/ProfileScreen.kt
@@ -20,9 +20,12 @@ import dev.convocados.data.auth.AuthManager
 import dev.convocados.data.auth.TokenStore
 import dev.convocados.data.datastore.SettingsStore
 import dev.convocados.data.push.PushTokenManager
+import dev.convocados.data.repository.UserRepository
 import dev.convocados.ui.theme.*
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -35,19 +38,26 @@ val LOCALE_OPTIONS = listOf(
 
 @HiltViewModel
 class ProfileViewModel @Inject constructor(
+    private val repository: UserRepository,
     private val api: ConvocadosApi,
     private val authManager: AuthManager,
     private val tokenStore: TokenStore,
     private val settingsStore: SettingsStore,
     private val pushTokenManager: PushTokenManager,
 ) : ViewModel() {
-    private val _user = MutableStateFlow<UserProfile?>(null)
-    val user: StateFlow<UserProfile?> = _user
+    val user: StateFlow<UserProfile?> = repository.userProfile
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
     val locale = settingsStore.locale
 
-    init { viewModelScope.launch { runCatching { _user.value = api.fetchUserInfo() } } }
+    init { viewModelScope.launch { repository.refreshUserProfile() } }
 
-    fun logout() { pushTokenManager.unregisterCurrentToken(); authManager.logout() }
+    fun logout() { 
+        viewModelScope.launch {
+            pushTokenManager.unregisterCurrentToken()
+            authManager.logout()
+            repository.clearUser()
+        }
+    }
     fun getServerUrl() = tokenStore.getServerUrl()
     fun setServerUrl(url: String) = tokenStore.setServerUrl(url)
     fun setLocale(code: String) { viewModelScope.launch { settingsStore.setLocale(code) } }

--- a/android-app/app/src/main/java/dev/convocados/ui/screen/publicgames/PublicGamesScreen.kt
+++ b/android-app/app/src/main/java/dev/convocados/ui/screen/publicgames/PublicGamesScreen.kt
@@ -1,5 +1,8 @@
 package dev.convocados.ui.screen.publicgames
 
+import androidx.compose.animation.AnimatedVisibilityScope
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
@@ -58,9 +61,15 @@ class PublicGamesViewModel @Inject constructor(private val api: ConvocadosApi) :
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalSharedTransitionApi::class)
 @Composable
-fun PublicGamesScreen(onEventClick: (String) -> Unit, onBack: () -> Unit, viewModel: PublicGamesViewModel = hiltViewModel()) {
+fun PublicGamesScreen(
+    onEventClick: (String) -> Unit,
+    onBack: () -> Unit,
+    viewModel: PublicGamesViewModel = hiltViewModel(),
+    sharedTransitionScope: SharedTransitionScope,
+    animatedVisibilityScope: AnimatedVisibilityScope,
+) {
     val events by viewModel.events.collectAsState()
     val loading by viewModel.loading.collectAsState()
     val hasMore by viewModel.hasMore.collectAsState()
@@ -81,7 +90,20 @@ fun PublicGamesScreen(onEventClick: (String) -> Unit, onBack: () -> Unit, viewMo
                 }
             }
             items(events, key = { it.id }) { event ->
-                Card(colors = CardDefaults.cardColors(containerColor = Surface), modifier = Modifier.fillMaxWidth().clickable { onEventClick(event.id) }) {
+                Card(
+                    colors = CardDefaults.cardColors(containerColor = Surface),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable { onEventClick(event.id) }
+                        .then(
+                            with(sharedTransitionScope) {
+                                Modifier.sharedElement(
+                                    rememberSharedContentState(key = "item-container-${event.id}"),
+                                    animatedVisibilityScope = animatedVisibilityScope
+                                )
+                            }
+                        )
+                ) {
                     Column(Modifier.padding(16.dp)) {
                         Row(horizontalArrangement = Arrangement.SpaceBetween, modifier = Modifier.fillMaxWidth()) {
                             Text(event.title, color = TextPrimary, fontWeight = FontWeight.Bold, fontSize = 16.sp, modifier = Modifier.weight(1f))

--- a/android-app/app/src/test/java/dev/convocados/data/repository/EventRepositoryTest.kt
+++ b/android-app/app/src/test/java/dev/convocados/data/repository/EventRepositoryTest.kt
@@ -1,0 +1,68 @@
+package dev.convocados.data.repository
+
+import app.cash.turbine.test
+import dev.convocados.data.api.ConvocadosApi
+import dev.convocados.data.api.EventSummary
+import dev.convocados.data.api.MyGamesResponse
+import dev.convocados.data.local.dao.EventDao
+import dev.convocados.data.local.dao.EventDetailDao
+import dev.convocados.data.local.entity.EventEntity
+import dev.convocados.ui.UiEventManager
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class EventRepositoryTest {
+    private val api = mockk<ConvocadosApi>()
+    private val dao = mockk<EventDao>()
+    private val detailDao = mockk<EventDetailDao>()
+    private val uiEventManager = mockk<UiEventManager>(relaxed = true)
+    private val repository = EventRepository(api, dao, detailDao, uiEventManager)
+
+    @Test
+    fun `getEventsByType returns mapped summaries from dao`() = runTest {
+        val entities = listOf(
+            EventEntity("1", "Title", "Loc", "2024-01-01", "Soccer", 10, 5, null, false, "owned")
+        )
+        coEvery { dao.getEventsByType("owned") } returns flowOf(entities)
+
+        repository.getEventsByType("owned").test {
+            val item = awaitItem()
+            assertEquals(1, item.size)
+            assertEquals("1", item[0].id)
+            assertEquals("Title", item[0].title)
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun `refreshMyGames fetches from api and updates dao`() = runTest {
+        val response = MyGamesResponse(
+            owned = listOf(EventSummary("1", "T1", "L1", "D1", "S1", 10, 5, null, false)),
+            joined = emptyList(),
+            archivedOwned = emptyList(),
+            archivedJoined = emptyList()
+        )
+        coEvery { api.fetchMyGames() } returns response
+        coEvery { dao.refreshEvents(any(), any()) } returns Unit
+
+        repository.refreshMyGames()
+
+        coVerify { api.fetchMyGames() }
+        coVerify { dao.refreshEvents("owned", any()) }
+        coVerify { dao.refreshEvents("joined", any()) }
+    }
+
+    @Test
+    fun `refreshMyGames shows snackbar on failure`() = runTest {
+        coEvery { api.fetchMyGames() } throws Exception("Network error")
+
+        repository.refreshMyGames()
+
+        coVerify { uiEventManager.showSnackbar("Failed to refresh games: Network error") }
+    }
+}

--- a/android-app/app/src/test/java/dev/convocados/data/repository/UserRepositoryTest.kt
+++ b/android-app/app/src/test/java/dev/convocados/data/repository/UserRepositoryTest.kt
@@ -1,0 +1,74 @@
+package dev.convocados.data.repository
+
+import app.cash.turbine.test
+import dev.convocados.data.api.ConvocadosApi
+import dev.convocados.data.api.UserProfile
+import dev.convocados.data.local.dao.UserDao
+import dev.convocados.data.local.entity.UserProfileEntity
+import dev.convocados.ui.UiEventManager
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class UserRepositoryTest {
+    private val api = mockk<ConvocadosApi>()
+    private val dao = mockk<UserDao>()
+    private val uiEventManager = mockk<UiEventManager>(relaxed = true)
+    private lateinit var repository: UserRepository
+
+    @Before
+    fun setup() {
+        every { dao.getUserProfile() } returns flowOf(null)
+        repository = UserRepository(api, dao, uiEventManager)
+    }
+
+    @Test
+    fun `userProfile returns mapped domain from dao`() = runTest {
+        val entity = UserProfileEntity("1", "User", "user@test.com", null)
+        every { dao.getUserProfile() } returns flowOf(entity)
+        val repository = UserRepository(api, dao, uiEventManager)
+
+        repository.userProfile.test {
+            val item = awaitItem()
+            assertEquals("1", item?.id)
+            assertEquals("User", item?.name)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `refreshUserProfile fetches from api and updates dao`() = runTest {
+        val profile = UserProfile("1", "User", "user@test.com", null)
+        coEvery { api.fetchUserInfo() } returns profile
+        coEvery { dao.insert(any()) } returns Unit
+
+        repository.refreshUserProfile()
+
+        coVerify { api.fetchUserInfo() }
+        coVerify { dao.insert(match { it.id == "1" && it.name == "User" }) }
+    }
+
+    @Test
+    fun `refreshUserProfile shows snackbar on failure`() = runTest {
+        coEvery { api.fetchUserInfo() } throws Exception("API error")
+
+        repository.refreshUserProfile()
+
+        coVerify { uiEventManager.showSnackbar("Failed to refresh profile: API error") }
+    }
+
+    @Test
+    fun `clearUser calls dao clear`() = runTest {
+        coEvery { dao.clear() } returns Unit
+
+        repository.clearUser()
+
+        coVerify { dao.clear() }
+    }
+}

--- a/android-app/app/src/test/java/dev/convocados/ui/screen/event/EventDetailViewModelTest.kt
+++ b/android-app/app/src/test/java/dev/convocados/ui/screen/event/EventDetailViewModelTest.kt
@@ -1,0 +1,137 @@
+package dev.convocados.ui.screen.event
+
+import app.cash.turbine.test
+import dev.convocados.data.api.*
+import dev.convocados.data.auth.TokenStore
+import dev.convocados.data.repository.EventRepository
+import io.mockk.coEvery
+import kotlinx.coroutines.flow.flowOf
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.*
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class EventDetailViewModelTest {
+    private val repository = mockk<EventRepository>(relaxed = true)
+    private val api = mockk<ConvocadosApi>(relaxed = true)
+    private val tokenStore = mockk<TokenStore>(relaxed = true)
+    private val testDispatcher = StandardTestDispatcher()
+
+    private val eventId = "event-123"
+    private val mockEvent = EventDetail(
+        id = eventId,
+        title = "Test Event",
+        location = "Test Location",
+        dateTime = "2024-01-01T10:00:00Z",
+        maxPlayers = 10,
+        players = emptyList(),
+        ownerId = "user-1",
+        isAdmin = true
+    )
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `load fetches event details and history`() = runTest {
+        coEvery { repository.getEventDetail(eventId) } returns flowOf(mockEvent)
+        coEvery { repository.getPlayers(eventId) } returns flowOf(emptyList())
+        coEvery { repository.getHistory(eventId) } returns flowOf(emptyList())
+
+        val viewModel = EventDetailViewModel(repository, api, tokenStore)
+        viewModel.load(eventId)
+        
+        viewModel.event.test {
+            assertEquals(mockEvent, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `load sets locked state when event is password protected`() = runTest {
+        val lockedEvent = mockEvent.copy(locked = true)
+        coEvery { repository.getEventDetail(eventId) } returns flowOf(lockedEvent)
+        coEvery { repository.getPlayers(eventId) } returns flowOf(emptyList())
+        coEvery { repository.getHistory(eventId) } returns flowOf(emptyList())
+
+        val viewModel = EventDetailViewModel(repository, api, tokenStore)
+        viewModel.load(eventId)
+        
+        viewModel.state.test {
+            val state = awaitItem()
+            assertEquals(true, state.locked)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `addPlayer calls api and reloads event`() = runTest {
+        coEvery { repository.getEventDetail(eventId) } returns flowOf(mockEvent)
+        coEvery { repository.getPlayers(eventId) } returns flowOf(emptyList())
+        coEvery { repository.getHistory(eventId) } returns flowOf(emptyList())
+        coEvery { repository.addPlayer(eventId, "New Player", true) } returns Result.success(Unit)
+
+        val viewModel = EventDetailViewModel(repository, api, tokenStore)
+        viewModel.addPlayer(eventId, "New Player")
+        advanceUntilIdle()
+
+        coVerify { repository.addPlayer(eventId, "New Player", true) }
+    }
+
+    @Test
+    fun `removePlayer sets undo data and reloads`() = runTest {
+        coEvery { repository.getEventDetail(eventId) } returns flowOf(mockEvent)
+        coEvery { repository.getPlayers(eventId) } returns flowOf(emptyList())
+        coEvery { repository.getHistory(eventId) } returns flowOf(emptyList())
+        val undo = UndoData(name = "Player One", order = 1, userId = "p-1", removedAt = 123456789L)
+        coEvery { repository.removePlayer(eventId, "p-1") } returns Result.success(undo)
+
+        val viewModel = EventDetailViewModel(repository, api, tokenStore)
+        viewModel.load(eventId)
+        viewModel.removePlayer(eventId, "p-1")
+        
+        viewModel.state.test {
+            val item = awaitItem()
+            assertEquals(undo, item.undoData)
+            cancelAndIgnoreRemainingEvents()
+        }
+        coVerify { repository.removePlayer(eventId, "p-1") }
+    }
+
+    @Test
+    fun `verifyPassword unlocks event on success`() = runTest {
+        coEvery { repository.getEventDetail(eventId) } returns flowOf(mockEvent.copy(locked = true))
+        coEvery { repository.getPlayers(eventId) } returns flowOf(emptyList())
+        coEvery { repository.getHistory(eventId) } returns flowOf(emptyList())
+        coEvery { repository.verifyPassword(eventId, "secret") } returns Result.success(Unit)
+
+        val viewModel = EventDetailViewModel(repository, api, tokenStore)
+        viewModel.load(eventId)
+        
+        viewModel.state.test {
+            val initialState = awaitItem()
+            assertEquals(true, initialState.locked)
+            
+            viewModel.verifyPassword(eventId, "secret")
+            
+            assertEquals(false, awaitItem().locked)
+            cancelAndIgnoreRemainingEvents()
+        }
+        coVerify { repository.verifyPassword(eventId, "secret") }
+    }
+}

--- a/android-app/app/src/test/java/dev/convocados/ui/screen/games/GamesViewModelTest.kt
+++ b/android-app/app/src/test/java/dev/convocados/ui/screen/games/GamesViewModelTest.kt
@@ -1,0 +1,75 @@
+package dev.convocados.ui.screen.games
+
+import app.cash.turbine.test
+import dev.convocados.data.api.ConvocadosApi
+import dev.convocados.data.api.EventSummary
+import dev.convocados.data.repository.EventRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.*
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class GamesViewModelTest {
+    private val repository = mockk<EventRepository>(relaxed = true)
+    private val api = mockk<ConvocadosApi>(relaxed = true)
+    private val testDispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `viewModel observes repository flows`() = runTest {
+        val owned = listOf(EventSummary("1", "T1", "L1", "D1", "S1", 10, 5, null, false))
+        val joined = listOf(EventSummary("2", "T2", "L2", "D2", "S2", 12, 6, null, false))
+        
+        coEvery { repository.getEventsByType("owned") } returns flowOf(owned)
+        coEvery { repository.getEventsByType("joined") } returns flowOf(joined)
+        coEvery { repository.getEventsByType("archivedOwned") } returns flowOf(emptyList())
+        coEvery { repository.getEventsByType("archivedJoined") } returns flowOf(emptyList())
+
+        val viewModel = GamesViewModel(repository, api)
+        
+        viewModel.ownedGames.test {
+            assertEquals(owned, awaitItem())
+        }
+        viewModel.joinedGames.test {
+            assertEquals(joined, awaitItem())
+        }
+    }
+
+    @Test
+    fun `refresh calls repository refresh`() = runTest {
+        coEvery { repository.getEventsByType(any()) } returns flowOf(emptyList())
+        val viewModel = GamesViewModel(repository, api)
+        
+        viewModel.refreshing.test {
+            // The init block calls refresh(), so we might see true/false or just false depending on timing.
+            // But since we are using StandardTestDispatcher, it won't run until we trigger it.
+            
+            // Initial state from StateFlow (it starts with false)
+            assertEquals(false, awaitItem())
+            
+            viewModel.refresh()
+            
+            assertEquals(true, awaitItem())
+            assertEquals(false, awaitItem())
+        }
+
+        coVerify { repository.refreshMyGames() }
+    }
+}

--- a/android-app/app/src/test/java/dev/convocados/ui/screen/profile/ProfileViewModelTest.kt
+++ b/android-app/app/src/test/java/dev/convocados/ui/screen/profile/ProfileViewModelTest.kt
@@ -1,0 +1,77 @@
+package dev.convocados.ui.screen.profile
+
+import app.cash.turbine.test
+import dev.convocados.data.api.ConvocadosApi
+import dev.convocados.data.api.UserProfile
+import dev.convocados.data.auth.AuthManager
+import dev.convocados.data.auth.TokenStore
+import dev.convocados.data.datastore.SettingsStore
+import dev.convocados.data.push.PushTokenManager
+import dev.convocados.data.repository.UserRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.*
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ProfileViewModelTest {
+    private val userRepository = mockk<UserRepository>(relaxed = true)
+    private val api = mockk<ConvocadosApi>(relaxed = true)
+    private val authManager = mockk<AuthManager>(relaxed = true)
+    private val tokenStore = mockk<TokenStore>(relaxed = true)
+    private val settingsStore = mockk<SettingsStore>(relaxed = true)
+    private val pushTokenManager = mockk<PushTokenManager>(relaxed = true)
+    private val testDispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `viewModel observes user profile from repository`() = runTest {
+        val profile = UserProfile("1", "User", "user@test.com", null)
+        every { userRepository.userProfile } returns flowOf(profile)
+
+        val viewModel = ProfileViewModel(userRepository, api, authManager, tokenStore, settingsStore, pushTokenManager)
+
+        viewModel.user.test {
+            assertEquals(profile, awaitItem())
+        }
+    }
+
+    @Test
+    fun `logout calls clear user and auth logout`() = runTest {
+        val viewModel = ProfileViewModel(userRepository, api, authManager, tokenStore, settingsStore, pushTokenManager)
+
+        viewModel.logout()
+        advanceUntilIdle()
+
+        coVerify { pushTokenManager.unregisterCurrentToken() }
+        coVerify { authManager.logout() }
+        coVerify { userRepository.clearUser() }
+    }
+
+    @Test
+    fun `setLocale updates settings store`() = runTest {
+        val viewModel = ProfileViewModel(userRepository, api, authManager, tokenStore, settingsStore, pushTokenManager)
+
+        viewModel.setLocale("pt")
+        advanceUntilIdle()
+
+        coVerify { settingsStore.setLocale("pt") }
+    }
+}

--- a/android-app/app/src/test/java/dev/convocados/ui/screen/publicgames/PublicGamesViewModelTest.kt
+++ b/android-app/app/src/test/java/dev/convocados/ui/screen/publicgames/PublicGamesViewModelTest.kt
@@ -1,0 +1,86 @@
+package dev.convocados.ui.screen.publicgames
+
+import app.cash.turbine.test
+import dev.convocados.data.api.ConvocadosApi
+import dev.convocados.data.api.PaginatedPublicEvents
+import dev.convocados.data.api.PublicEvent
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.*
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PublicGamesViewModelTest {
+    private val api = mockk<ConvocadosApi>()
+    private val testDispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `initial load fetches events from api`() = runTest {
+        val events = listOf(
+            PublicEvent("1", "Title 1", "Loc 1", null, null, "Soccer", "2024-01-01T10:00:00Z", 10, 5, 5)
+        )
+        val response = PaginatedPublicEvents(data = events, nextCursor = "c1", hasMore = true)
+        
+        coEvery { api.fetchPublicEvents(null) } returns response
+
+        val viewModel = PublicGamesViewModel(api)
+        
+        // Advance until idle to let the init { load() } finish
+        advanceUntilIdle()
+
+        assertEquals(events, viewModel.events.value)
+        assertEquals(true, viewModel.hasMore.value)
+        assertEquals(false, viewModel.loading.value)
+    }
+
+    @Test
+    fun `loadMore appends events to current list`() = runTest {
+        val initialEvents = listOf(PublicEvent("1", "T1", "L1", null, null, "S1", "D1", 10, 5, 5))
+        val initialResponse = PaginatedPublicEvents(data = initialEvents, nextCursor = "c1", hasMore = true)
+        
+        val moreEvents = listOf(PublicEvent("2", "T2", "L2", null, null, "S2", "D2", 12, 6, 6))
+        val moreResponse = PaginatedPublicEvents(data = moreEvents, nextCursor = "c2", hasMore = false)
+
+        coEvery { api.fetchPublicEvents(null) } returns initialResponse
+        coEvery { api.fetchPublicEvents("c1") } returns moreResponse
+
+        val viewModel = PublicGamesViewModel(api)
+        advanceUntilIdle()
+
+        viewModel.loadMore()
+        advanceUntilIdle()
+
+        assertEquals(initialEvents + moreEvents, viewModel.events.value)
+        assertEquals(false, viewModel.hasMore.value)
+    }
+
+    @Test
+    fun `loading state is updated correctly`() = runTest {
+        val response = PaginatedPublicEvents(data = emptyList(), nextCursor = null, hasMore = false)
+        coEvery { api.fetchPublicEvents(any()) } returns response
+
+        val viewModel = PublicGamesViewModel(api)
+
+        viewModel.loading.test {
+            // Initial state from init load() might be true or false depending on how fast it runs
+            // But with StandardTestDispatcher it should be predictable
+            assertEquals(true, awaitItem())
+            assertEquals(false, awaitItem())
+        }
+    }
+}

--- a/android-app/build.gradle.kts
+++ b/android-app/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     alias(libs.plugins.android.application) apply false
+    alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.hilt.android) apply false

--- a/android-app/gradle.properties
+++ b/android-app/gradle.properties
@@ -2,4 +2,4 @@ android.useAndroidX=true
 kotlin.code.style=official
 org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m
 org.gradle.parallel=true
-android.builtInKotlin=true
+android.builtInKotlin=false

--- a/android-app/gradle/libs.versions.toml
+++ b/android-app/gradle/libs.versions.toml
@@ -1,9 +1,9 @@
 [versions]
-agp = "9.1.0"
-kotlin = "2.3.20"
-ksp = "2.3.6"
-googleServices = "4.4.4"
-hilt = "2.59.2"
+agp = "8.7.2"
+kotlin = "2.1.0"
+ksp = "2.1.0-1.0.29"
+googleServices = "4.4.2"
+hilt = "2.53"
 composeBom = "2024.12.01"
 androidxCore = "1.15.0"
 androidxLifecycle = "2.8.7"
@@ -17,7 +17,11 @@ androidxSecurity = "1.1.0-alpha06"
 androidxBrowser = "1.8.0"
 androidxSplashscreen = "1.0.1"
 firebaseBom = "33.7.0"
-accompanist = "0.37.3"
+accompanist = "0.37.0"
+room = "2.6.1"
+turbine = "1.1.0"
+mockk = "1.13.13"
+kotlinxCoroutinesTest = "1.9.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "androidxCore" }
@@ -28,6 +32,7 @@ androidx-navigation-compose = { group = "androidx.navigation", name = "navigatio
 androidx-hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "androidxHiltNavigation" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
 androidx-compose-ui = { group = "androidx.compose.ui", name = "ui" }
+androidx-compose-animation = { group = "androidx.compose.animation", name = "animation" }
 androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
@@ -48,9 +53,19 @@ kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-
 firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom" }
 firebase-messaging-ktx = { group = "com.google.firebase", name = "firebase-messaging-ktx" }
 accompanist-permissions = { group = "com.google.accompanist", name = "accompanist-permissions", version.ref = "accompanist" }
+androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
+androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
+androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
+
+# Testing
+junit = { group = "junit", name = "junit", version = "4.13.2" }
+mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
+turbine = { group = "app.cash.turbine", name = "turbine", version.ref = "turbine" }
+kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesTest" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 google-services = { id = "com.google.gms.google-services", version.ref = "googleServices" }


### PR DESCRIPTION
## Summary

Add Room database integration to the Android app for offline-first caching, along with UI improvements and comprehensive test coverage.

## Changes

### Room Database & Data Layer
- Add `AppDatabase` with Room setup (events, event details, user profiles)
- Add DAOs: `EventDao`, `EventDetailDao`, `UserDao`
- Add entities: `EventEntity`, `EventDetailEntities`, `UserProfileEntity`
- Add `EventRepository` and `UserRepository` with offline-first caching pattern
- Add Hilt `DatabaseModule` for dependency injection

### UI Improvements
- Add shimmer loading components for better loading UX
- Add shared element transitions in navigation
- Add `UiEventManager` for centralized UI event handling
- Update `GamesScreen`, `EventDetailScreen`, `ProfileScreen`, `PublicGamesScreen`

### Build & Dependencies
- Add Room, MockK, Turbine, kotlinx-coroutines-test dependencies
- Add Compose animation library for shared transitions
- Adjust Gradle plugin configuration and compiler options
- Downgrade AGP/Kotlin/KSP/Hilt versions for build compatibility

### Tests
- `EventRepositoryTest` and `UserRepositoryTest`
- `EventDetailViewModelTest`, `GamesViewModelTest`, `ProfileViewModelTest`
- `PublicGamesViewModelTest`