### PR TITLE
feat: Wear OS app with offline score tracking and Google Sign-In

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,11 +203,11 @@ jobs:
           VERSION="${{ needs.release.outputs.version }}"
           sed -i "s/versionName = \".*\"/versionName = \"$VERSION\"/" app/build.gradle.kts
 
-      - name: Build release APK
+      - name: Build phone release APK
         working-directory: android-app
-        run: ./gradlew assembleRelease --no-daemon
+        run: ./gradlew :app:assembleRelease --no-daemon
 
-      - name: Sign APK
+      - name: Sign phone APK
         if: ${{ env.HAS_KEYSTORE == 'true' }}
         working-directory: android-app
         run: |
@@ -231,7 +231,7 @@ jobs:
           fi
           rm -f /tmp/release.keystore
 
-      - name: Upload APK to GitHub Release
+      - name: Upload phone APK to GitHub Release
         uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -254,6 +254,95 @@ jobs:
 
             const apkPath = path.join(apkDir, apk);
             const apkName = `convocados-${version}.apk`;
+
+            await github.rest.repos.uploadReleaseAsset({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: release.id,
+              name: apkName,
+              data: fs.readFileSync(apkPath)
+            });
+
+            console.log(`Uploaded ${apkName} to release ${tag}`);
+
+  build-wear:
+    name: Build Wear OS APK
+    needs: release
+    if: needs.release.outputs.released == 'true'
+    runs-on: ubuntu-latest
+    env:
+      HAS_KEYSTORE: ${{ secrets.ANDROID_KEYSTORE != '' }}
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: v${{ needs.release.outputs.version }}
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Update wear version
+        working-directory: android-app
+        run: |
+          VERSION="${{ needs.release.outputs.version }}"
+          sed -i "s/versionName = \".*\"/versionName = \"$VERSION\"/" wear/build.gradle.kts
+
+      - name: Build Wear OS release APK
+        working-directory: android-app
+        run: ./gradlew :wear:assembleRelease --no-daemon
+
+      - name: Sign Wear OS APK
+        if: ${{ env.HAS_KEYSTORE == 'true' }}
+        working-directory: android-app
+        run: |
+          echo "${{ secrets.ANDROID_KEYSTORE }}" | base64 -d > /tmp/release.keystore
+          APK=$(find wear/build/outputs/apk/release -name "*.apk" | head -1)
+          if [ -z "$APK" ]; then echo "No Wear APK found"; exit 1; fi
+          APKSIGNER=$(find $ANDROID_HOME/build-tools -name apksigner -type f 2>/dev/null | sort -V | tail -1)
+          if [ -n "$APKSIGNER" ]; then
+            $APKSIGNER sign \
+              --ks /tmp/release.keystore \
+              --ks-key-alias "${{ secrets.KEY_ALIAS }}" \
+              --ks-pass "pass:${{ secrets.KEYSTORE_PASSWORD }}" \
+              --key-pass "pass:${{ secrets.KEY_PASSWORD }}" \
+              "$APK"
+          else
+            jarsigner -verbose -sigalg SHA256withRSA -digestalg SHA-256 \
+              -keystore /tmp/release.keystore \
+              -storepass "${{ secrets.KEYSTORE_PASSWORD }}" \
+              -keypass "${{ secrets.KEY_PASSWORD }}" \
+              "$APK" "${{ secrets.KEY_ALIAS }}"
+          fi
+          rm -f /tmp/release.keystore
+
+      - name: Upload Wear OS APK to GitHub Release
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const version = '${{ needs.release.outputs.version }}';
+            const tag = `v${version}`;
+
+            const { data: release } = await github.rest.repos.getReleaseByTag({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag
+            });
+
+            const apkDir = 'android-app/wear/build/outputs/apk/release';
+            const files = fs.readdirSync(apkDir);
+            const apk = files.find(f => f.endsWith('.apk'));
+            if (!apk) throw new Error('No Wear APK found in ' + apkDir);
+
+            const apkPath = path.join(apkDir, apk);
+            const apkName = `convocados-wear-${version}.apk`;
 
             await github.rest.repos.uploadReleaseAsset({
               owner: context.repo.owner,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,6 +110,29 @@ jobs:
           }
           EOF
 
-      - name: Build debug APK
+      - name: Build phone debug APK
         working-directory: android-app
-        run: ./gradlew assembleDebug --no-daemon
+        run: ./gradlew :app:assembleDebug --no-daemon
+
+  android-wear:
+    name: Wear OS Build
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+       contains(join(github.event.pull_request.*.filename, ' '), 'android-app/'))
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build Wear OS debug APK
+        working-directory: android-app
+        run: ./gradlew :wear:assembleDebug --no-daemon

--- a/android-app/app/src/main/java/dev/convocados/data/auth/AuthManager.kt
+++ b/android-app/app/src/main/java/dev/convocados/data/auth/AuthManager.kt
@@ -5,6 +5,9 @@ import android.net.Uri
 import androidx.browser.customtabs.CustomTabsIntent
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dev.convocados.data.api.ApiClient
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -13,7 +16,10 @@ class AuthManager @Inject constructor(
     @ApplicationContext private val context: Context,
     private val apiClient: ApiClient,
     private val tokenStore: TokenStore,
+    private val wearAuthSync: WearAuthSync,
 ) {
+    private val scope = CoroutineScope(Dispatchers.IO)
+
     fun startLogin(context: android.app.Activity) {
         val redirectUri = "convocados://auth"
         val url = apiClient.getLoginUrl(redirectUri)
@@ -31,10 +37,13 @@ class AuthManager @Inject constructor(
                 expiresAt = System.currentTimeMillis() + tokenResponse.expiresIn * 1000,
             )
         )
+        // Sync tokens to paired Wear OS device
+        scope.launch { wearAuthSync.syncTokens() }
         return true
     }
 
     fun logout() {
         tokenStore.clearTokens()
+        scope.launch { wearAuthSync.clearTokens() }
     }
 }

--- a/android-app/app/src/main/java/dev/convocados/data/auth/WearAuthSync.kt
+++ b/android-app/app/src/main/java/dev/convocados/data/auth/WearAuthSync.kt
@@ -1,0 +1,53 @@
+package dev.convocados.data.auth
+
+import android.content.Context
+import android.util.Log
+import com.google.android.gms.wearable.PutDataMapRequest
+import com.google.android.gms.wearable.Wearable
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.tasks.await
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Syncs auth tokens to connected Wear OS devices via the Wearable Data Layer API.
+ * Called after login/token refresh on the phone app.
+ */
+@Singleton
+class WearAuthSync @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val tokenStore: TokenStore,
+) {
+    suspend fun syncTokens() {
+        val tokens = tokenStore.getTokens() ?: return
+        try {
+            val request = PutDataMapRequest.create("/auth").apply {
+                dataMap.putString("access_token", tokens.accessToken)
+                dataMap.putString("refresh_token", tokens.refreshToken)
+                dataMap.putLong("expires_at", tokens.expiresAt)
+                dataMap.putString("server_url", tokenStore.getServerUrl())
+                // Force update even if data hasn't changed
+                dataMap.putLong("timestamp", System.currentTimeMillis())
+            }.asPutDataRequest().setUrgent()
+
+            Wearable.getDataClient(context).putDataItem(request).await()
+            Log.d("WearAuthSync", "Tokens synced to watch")
+        } catch (e: Exception) {
+            // Wearable API not available (no watch paired) — ignore silently
+            Log.d("WearAuthSync", "No watch connected or Wearable API unavailable", e)
+        }
+    }
+
+    suspend fun clearTokens() {
+        try {
+            val request = PutDataMapRequest.create("/auth").apply {
+                // Empty data signals logout
+            }.asPutDataRequest().setUrgent()
+
+            Wearable.getDataClient(context).deleteDataItems(request.uri).await()
+            Log.d("WearAuthSync", "Tokens cleared on watch")
+        } catch (e: Exception) {
+            Log.d("WearAuthSync", "No watch connected or Wearable API unavailable", e)
+        }
+    }
+}

--- a/android-app/gradle/libs.versions.toml
+++ b/android-app/gradle/libs.versions.toml
@@ -19,6 +19,13 @@ androidxSplashscreen = "1.0.1"
 firebaseBom = "33.7.0"
 accompanist = "0.37.0"
 room = "2.6.1"
+wearCompose = "1.4.0"
+horologistComposeLayout = "0.6.20"
+playServicesWearable = "18.2.0"
+playServicesAuth = "21.3.0"
+googleIdIdentity = "1.1.1"
+workRuntime = "2.10.0"
+hiltWork = "1.2.0"
 turbine = "1.1.0"
 mockk = "1.13.13"
 kotlinxCoroutinesTest = "1.9.0"
@@ -56,6 +63,21 @@ accompanist-permissions = { group = "com.google.accompanist", name = "accompanis
 androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
 androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
 androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
+
+# Wear OS
+wear-compose-foundation = { group = "androidx.wear.compose", name = "compose-foundation", version.ref = "wearCompose" }
+wear-compose-material = { group = "androidx.wear.compose", name = "compose-material", version.ref = "wearCompose" }
+wear-compose-navigation = { group = "androidx.wear.compose", name = "compose-navigation", version.ref = "wearCompose" }
+horologist-compose-layout = { group = "com.google.android.horologist", name = "horologist-compose-layout", version.ref = "horologistComposeLayout" }
+play-services-wearable = { group = "com.google.android.gms", name = "play-services-wearable", version.ref = "playServicesWearable" }
+play-services-auth = { group = "com.google.android.gms", name = "play-services-auth", version.ref = "playServicesAuth" }
+google-id-identity = { group = "com.google.android.libraries.identity.googleid", name = "googleid", version.ref = "googleIdIdentity" }
+androidx-credentials = { group = "androidx.credentials", name = "credentials", version = "1.3.0" }
+androidx-credentials-play = { group = "androidx.credentials", name = "credentials-play-services-auth", version = "1.3.0" }
+androidx-work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "workRuntime" }
+androidx-hilt-work = { group = "androidx.hilt", name = "hilt-work", version.ref = "hiltWork" }
+androidx-hilt-compiler = { group = "androidx.hilt", name = "hilt-compiler", version.ref = "hiltWork" }
+androidx-wear = { group = "androidx.wear", name = "wear", version = "1.3.0" }
 
 # Testing
 junit = { group = "junit", name = "junit", version = "4.13.2" }

--- a/android-app/settings.gradle.kts
+++ b/android-app/settings.gradle.kts
@@ -17,3 +17,4 @@ dependencyResolutionManagement {
 }
 rootProject.name = "Convocados"
 include(":app")
+include(":wear")

--- a/android-app/wear/build.gradle.kts
+++ b/android-app/wear/build.gradle.kts
@@ -5,20 +5,18 @@ plugins {
     alias(libs.plugins.hilt.android)
     alias(libs.plugins.ksp)
     alias(libs.plugins.kotlin.serialization)
-    alias(libs.plugins.google.services)
 }
 
 android {
-    namespace = "dev.convocados"
+    namespace = "dev.convocados.wear"
     compileSdk = 35
 
     defaultConfig {
-        applicationId = "com.cabeda.convocados"
-        minSdk = 26
+        applicationId = "com.cabeda.convocados.wear"
+        minSdk = 30
         targetSdk = 35
         versionCode = 1
         versionName = "1.0.0"
-        manifestPlaceholders["appAuthRedirectScheme"] = "convocados"
     }
 
     buildTypes {
@@ -36,11 +34,6 @@ android {
     }
     kotlinOptions {
         jvmTarget = "17"
-        freeCompilerArgs += listOf(
-            "-P",
-            "plugin:androidx.compose.compiler.plugins.kotlin:suppressKotlinVersionCompatibilityCheck=true",
-            "-opt-in=androidx.compose.animation.ExperimentalSharedTransitionApi"
-        )
     }
     buildFeatures {
         compose = true
@@ -48,13 +41,14 @@ android {
 }
 
 dependencies {
-    // Compose BOM
+    // Wear Compose
     implementation(platform(libs.androidx.compose.bom))
-    implementation(libs.androidx.compose.material3)
+    implementation(libs.wear.compose.foundation)
+    implementation(libs.wear.compose.material)
+    implementation(libs.wear.compose.navigation)
+    implementation(libs.horologist.compose.layout)
     implementation(libs.androidx.compose.ui)
-    implementation(libs.androidx.compose.animation)
     implementation(libs.androidx.compose.ui.tooling.preview)
-    implementation(libs.androidx.compose.material.icons.extended)
     debugImplementation(libs.androidx.compose.ui.tooling)
 
     // Core
@@ -62,56 +56,45 @@ dependencies {
     implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.androidx.activity.compose)
-
-    // Navigation
-    implementation(libs.androidx.navigation.compose)
-    implementation(libs.androidx.hilt.navigation.compose)
+    implementation(libs.androidx.wear)
 
     // Hilt DI
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)
+    implementation(libs.androidx.hilt.navigation.compose)
+    implementation(libs.androidx.hilt.work)
+    ksp(libs.androidx.hilt.compiler)
 
-    // Networking
+    // Networking (Ktor)
     implementation(libs.ktor.client.core)
     implementation(libs.ktor.client.okhttp)
     implementation(libs.ktor.client.content.negotiation)
     implementation(libs.ktor.serialization.kotlinx.json)
     implementation(libs.ktor.client.auth)
-    implementation(libs.ktor.client.logging)
 
     // Serialization
     implementation(libs.kotlinx.serialization.json)
 
-    // DataStore (preferences)
-    implementation(libs.androidx.datastore.preferences)
-
-    // Security (encrypted shared prefs for tokens)
-    implementation(libs.androidx.security.crypto)
-
-    // Browser (Custom Tabs for OAuth)
-    implementation(libs.androidx.browser)
-
-    // Splash screen
-    implementation(libs.androidx.core.splashscreen)
-
-    // Firebase
-    implementation(platform(libs.firebase.bom))
-    implementation(libs.firebase.messaging.ktx)
-
-    // Accompanist (Permissions)
-    implementation(libs.accompanist.permissions)
-
-    // Wearable Data Layer (sync auth tokens to watch)
-    implementation(libs.play.services.wearable)
-
-    // Room
+    // Room (offline DB)
     implementation(libs.androidx.room.runtime)
     implementation(libs.androidx.room.ktx)
     ksp(libs.androidx.room.compiler)
 
-    // Testing
-    testImplementation(libs.junit)
-    testImplementation(libs.mockk)
-    testImplementation(libs.turbine)
-    testImplementation(libs.kotlinx.coroutines.test)
+    // WorkManager (sync queue)
+    implementation(libs.androidx.work.runtime.ktx)
+
+    // Wearable Data Layer (auth sync from phone)
+    implementation(libs.play.services.wearable)
+
+    // Google Sign-In (direct login on watch)
+    implementation(libs.play.services.auth)
+    implementation(libs.google.id.identity)
+    implementation(libs.androidx.credentials)
+    implementation(libs.androidx.credentials.play)
+
+    // Security (encrypted prefs for tokens)
+    implementation(libs.androidx.security.crypto)
+
+    // DataStore
+    implementation(libs.androidx.datastore.preferences)
 }

--- a/android-app/wear/proguard-rules.pro
+++ b/android-app/wear/proguard-rules.pro
@@ -1,0 +1,12 @@
+# Ktor
+-keep class io.ktor.** { *; }
+-dontwarn io.ktor.**
+
+# Kotlinx Serialization
+-keepattributes *Annotation*, InnerClasses
+-dontnote kotlinx.serialization.AnnotationsKt
+-keepclassmembers class kotlinx.serialization.json.** { *** Companion; }
+-keepclasseswithmembers class kotlinx.serialization.json.** { kotlinx.serialization.KSerializer serializer(...); }
+-keep,includedescriptorclasses class dev.convocados.wear.**$$serializer { *; }
+-keepclassmembers class dev.convocados.wear.** { *** Companion; }
+-keepclasseswithmembers class dev.convocados.wear.** { kotlinx.serialization.KSerializer serializer(...); }

--- a/android-app/wear/src/main/AndroidManifest.xml
+++ b/android-app/wear/src/main/AndroidManifest.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
+
+    <uses-feature android:name="android.hardware.type.watch" />
+
+    <application
+        android:name=".WearApp"
+        android:allowBackup="true"
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/app_name"
+        android:supportsRtl="true"
+        android:theme="@android:style/Theme.DeviceDefault">
+
+        <uses-library
+            android:name="com.google.android.wearable"
+            android:required="true" />
+
+        <activity
+            android:name=".ui.WearActivity"
+            android:exported="true"
+            android:taskAffinity=""
+            android:theme="@android:style/Theme.DeviceDefault">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+
+        <service
+            android:name=".data.auth.AuthDataListenerService"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="com.google.android.gms.wearable.DATA_CHANGED" />
+                <data
+                    android:host="*"
+                    android:pathPrefix="/auth"
+                    android:scheme="wear" />
+            </intent-filter>
+        </service>
+    </application>
+</manifest>

--- a/android-app/wear/src/main/java/dev/convocados/wear/WearApp.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/WearApp.kt
@@ -1,0 +1,19 @@
+package dev.convocados.wear
+
+import android.app.Application
+import androidx.hilt.work.HiltWorkerFactory
+import androidx.work.Configuration
+import dagger.hilt.android.HiltAndroidApp
+import javax.inject.Inject
+
+@HiltAndroidApp
+class WearApp : Application(), Configuration.Provider {
+
+    @Inject
+    lateinit var workerFactory: HiltWorkerFactory
+
+    override val workManagerConfiguration: Configuration
+        get() = Configuration.Builder()
+            .setWorkerFactory(workerFactory)
+            .build()
+}

--- a/android-app/wear/src/main/java/dev/convocados/wear/data/api/Models.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/data/api/Models.kt
@@ -1,0 +1,99 @@
+package dev.convocados.wear.data.api
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class EventSummary(
+    val id: String,
+    val title: String,
+    val location: String = "",
+    val dateTime: String,
+    val sport: String = "",
+    val maxPlayers: Int,
+    val playerCount: Int,
+    val isRecurring: Boolean = false,
+)
+
+@Serializable
+data class MyGamesResponse(
+    val owned: List<EventSummary> = emptyList(),
+    val joined: List<EventSummary> = emptyList(),
+)
+
+@Serializable
+data class EventDetail(
+    val id: String,
+    val title: String,
+    val location: String = "",
+    val dateTime: String,
+    val maxPlayers: Int,
+    val teamOneName: String = "Team 1",
+    val teamTwoName: String = "Team 2",
+    val sport: String = "",
+    val durationMinutes: Int = 60,
+    val players: List<Player> = emptyList(),
+    val teamResults: List<TeamResult>? = null,
+)
+
+@Serializable
+data class Player(
+    val id: String,
+    val name: String,
+    val order: Int,
+    val userId: String? = null,
+)
+
+@Serializable
+data class TeamResult(
+    val id: String,
+    val name: String,
+    val members: List<TeamMember> = emptyList(),
+)
+
+@Serializable
+data class TeamMember(
+    val id: String,
+    val name: String,
+    val order: Int,
+)
+
+@Serializable
+data class GameHistory(
+    val id: String,
+    val dateTime: String,
+    val status: String = "played",
+    val scoreOne: Int? = null,
+    val scoreTwo: Int? = null,
+    val teamOneName: String = "",
+    val teamTwoName: String = "",
+    val editable: Boolean = false,
+)
+
+@Serializable
+data class PaginatedHistory(
+    val data: List<GameHistory> = emptyList(),
+    val nextCursor: String? = null,
+    val hasMore: Boolean = false,
+)
+
+@Serializable
+data class PostGameStatus(
+    val gameEnded: Boolean = false,
+    val hasScore: Boolean = false,
+    val isParticipant: Boolean = false,
+    val latestHistoryId: String? = null,
+)
+
+@Serializable
+data class OkResponse(val ok: Boolean = true)
+
+@Serializable
+data class ScoreRequest(val scoreOne: Int, val scoreTwo: Int)
+
+@Serializable
+data class OAuthTokenResponse(
+    @SerialName("access_token") val accessToken: String,
+    @SerialName("refresh_token") val refreshToken: String? = null,
+    @SerialName("expires_in") val expiresIn: Long,
+)

--- a/android-app/wear/src/main/java/dev/convocados/wear/data/api/WearApi.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/data/api/WearApi.kt
@@ -1,0 +1,21 @@
+package dev.convocados.wear.data.api
+
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class WearApi @Inject constructor(private val client: WearApiClient) {
+
+    suspend fun fetchMyGames(): MyGamesResponse = client.get("/api/me/games")
+
+    suspend fun fetchEvent(id: String): EventDetail = client.get("/api/events/$id")
+
+    suspend fun fetchHistory(id: String): PaginatedHistory =
+        client.get("/api/events/$id/history")
+
+    suspend fun fetchPostGameStatus(id: String): PostGameStatus =
+        client.get("/api/events/$id/post-game-status")
+
+    suspend fun updateScore(eventId: String, historyId: String, scoreOne: Int, scoreTwo: Int): GameHistory =
+        client.patch("/api/events/$eventId/history/$historyId", ScoreRequest(scoreOne, scoreTwo))
+}

--- a/android-app/wear/src/main/java/dev/convocados/wear/data/api/WearApiClient.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/data/api/WearApiClient.kt
@@ -96,11 +96,15 @@ class WearApiClient @Inject constructor(private val tokenStore: WearTokenStore) 
     suspend inline fun <reified T> patch(path: String, body: Any? = null): T =
         authenticatedRequest(HttpMethod.Patch, path, body).body()
 
-    /** Exchange a Google ID token for Convocados OAuth tokens (unauthenticated). */
+    /**
+     * Exchange a Google ID token for Convocados OAuth tokens (unauthenticated).
+     * Uses better-auth's built-in social sign-in callback endpoint, which is
+     * already configured with GOOGLE_CLIENT_ID / GOOGLE_CLIENT_SECRET on the backend.
+     */
     suspend fun exchangeGoogleToken(idToken: String): OAuthTokenResponse {
-        val response = client.post("$baseUrl/api/auth/google/callback") {
+        val response = client.post("$baseUrl/api/auth/callback/google") {
             contentType(ContentType.Application.Json)
-            setBody(mapOf("idToken" to idToken, "clientId" to "mobile-app"))
+            setBody(mapOf("idToken" to idToken, "callbackURL" to "/"))
         }
         if (!response.status.isSuccess()) {
             val errorBody = runCatching { response.bodyAsText() }.getOrDefault("")

--- a/android-app/wear/src/main/java/dev/convocados/wear/data/api/WearApiClient.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/data/api/WearApiClient.kt
@@ -1,0 +1,113 @@
+package dev.convocados.wear.data.api
+
+import dev.convocados.wear.data.auth.OAuthTokens
+import dev.convocados.wear.data.auth.WearTokenStore
+import io.ktor.client.*
+import io.ktor.client.call.*
+import io.ktor.client.engine.okhttp.*
+import io.ktor.client.plugins.*
+import io.ktor.client.plugins.contentnegotiation.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import io.ktor.serialization.kotlinx.json.*
+import kotlinx.serialization.json.Json
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class WearApiClient @Inject constructor(private val tokenStore: WearTokenStore) {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+        coerceInputValues = true
+    }
+
+    private val client = HttpClient(OkHttp) {
+        install(ContentNegotiation) { json(this@WearApiClient.json) }
+        install(HttpTimeout) {
+            requestTimeoutMillis = 10_000
+            connectTimeoutMillis = 8_000
+        }
+        defaultRequest {
+            contentType(ContentType.Application.Json)
+        }
+    }
+
+    private val baseUrl: String get() = tokenStore.getServerUrl()
+
+    @PublishedApi
+    internal suspend fun authenticatedRequest(
+        method: HttpMethod,
+        path: String,
+        body: Any? = null,
+        retry: Boolean = true,
+    ): HttpResponse {
+        val tokens = tokenStore.getTokens() ?: throw ApiException(401, "Not authenticated")
+
+        var response = client.request("$baseUrl$path") {
+            this.method = method
+            header("Authorization", "Bearer ${tokens.accessToken}")
+            if (body != null) setBody(body)
+        }
+
+        if (response.status == HttpStatusCode.Unauthorized && retry) {
+            refreshToken()
+            val newTokens = tokenStore.getTokens() ?: throw ApiException(401, "Session expired")
+            response = client.request("$baseUrl$path") {
+                this.method = method
+                header("Authorization", "Bearer ${newTokens.accessToken}")
+                if (body != null) setBody(body)
+            }
+        }
+
+        if (!response.status.isSuccess()) {
+            val errorBody = runCatching { response.bodyAsText() }.getOrDefault("")
+            throw ApiException(response.status.value, errorBody)
+        }
+        return response
+    }
+
+    @PublishedApi
+    internal suspend fun refreshToken() {
+        val tokens = tokenStore.getTokens() ?: throw ApiException(401, "No refresh token")
+        val response = client.post("$baseUrl/api/auth/oauth2/token") {
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody("grant_type=refresh_token&refresh_token=${tokens.refreshToken}&client_id=mobile-app")
+        }
+        if (!response.status.isSuccess()) {
+            tokenStore.clearTokens()
+            throw ApiException(401, "Session expired")
+        }
+        val data: OAuthTokenResponse = response.body()
+        tokenStore.setTokens(
+            OAuthTokens(
+                accessToken = data.accessToken,
+                refreshToken = data.refreshToken ?: tokens.refreshToken,
+                expiresAt = System.currentTimeMillis() + data.expiresIn * 1000,
+            )
+        )
+    }
+
+    suspend inline fun <reified T> get(path: String): T =
+        authenticatedRequest(HttpMethod.Get, path).body()
+
+    suspend inline fun <reified T> patch(path: String, body: Any? = null): T =
+        authenticatedRequest(HttpMethod.Patch, path, body).body()
+
+    /** Exchange a Google ID token for Convocados OAuth tokens (unauthenticated). */
+    suspend fun exchangeGoogleToken(idToken: String): OAuthTokenResponse {
+        val response = client.post("$baseUrl/api/auth/google/callback") {
+            contentType(ContentType.Application.Json)
+            setBody(mapOf("idToken" to idToken, "clientId" to "mobile-app"))
+        }
+        if (!response.status.isSuccess()) {
+            val errorBody = runCatching { response.bodyAsText() }.getOrDefault("")
+            throw ApiException(response.status.value, "Google token exchange failed: $errorBody")
+        }
+        return response.body()
+    }
+}
+
+class ApiException(val code: Int, message: String) : Exception(message)

--- a/android-app/wear/src/main/java/dev/convocados/wear/data/auth/AuthDataListenerService.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/data/auth/AuthDataListenerService.kt
@@ -1,0 +1,44 @@
+package dev.convocados.wear.data.auth
+
+import android.util.Log
+import com.google.android.gms.wearable.DataEvent
+import com.google.android.gms.wearable.DataEventBuffer
+import com.google.android.gms.wearable.DataMapItem
+import com.google.android.gms.wearable.WearableListenerService
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+
+/**
+ * Listens for auth token updates pushed from the phone app via the
+ * Wearable Data Layer API. The phone app writes tokens to /auth path
+ * and this service picks them up automatically.
+ */
+@AndroidEntryPoint
+class AuthDataListenerService : WearableListenerService() {
+
+    @Inject
+    lateinit var tokenStore: WearTokenStore
+
+    override fun onDataChanged(dataEvents: DataEventBuffer) {
+        for (event in dataEvents) {
+            if (event.type == DataEvent.TYPE_CHANGED && event.dataItem.uri.path == "/auth") {
+                val dataMap = DataMapItem.fromDataItem(event.dataItem).dataMap
+                val accessToken = dataMap.getString("access_token", "")
+                val refreshToken = dataMap.getString("refresh_token", "")
+                val expiresAt = dataMap.getLong("expires_at", 0)
+                val serverUrl = dataMap.getString("server_url", "")
+
+                if (accessToken.isNotEmpty() && refreshToken.isNotEmpty()) {
+                    tokenStore.setTokens(OAuthTokens(accessToken, refreshToken, expiresAt))
+                    if (serverUrl.isNotEmpty()) {
+                        tokenStore.setServerUrl(serverUrl)
+                    }
+                    Log.d("AuthDataListener", "Tokens synced from phone")
+                }
+            } else if (event.type == DataEvent.TYPE_DELETED && event.dataItem.uri.path == "/auth") {
+                tokenStore.clearTokens()
+                Log.d("AuthDataListener", "Tokens cleared (phone logged out)")
+            }
+        }
+    }
+}

--- a/android-app/wear/src/main/java/dev/convocados/wear/data/auth/WearGoogleSignIn.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/data/auth/WearGoogleSignIn.kt
@@ -16,7 +16,12 @@ import javax.inject.Singleton
 /**
  * Handles Google Sign-In directly on the Wear OS device.
  * Uses Credential Manager + Google Identity Services to get an ID token,
- * then exchanges it with the Convocados backend for OAuth tokens.
+ * then exchanges it with the Convocados backend via better-auth's
+ * existing social sign-in endpoint.
+ *
+ * The SERVER_CLIENT_ID must match the GOOGLE_CLIENT_ID env var configured
+ * on the backend (see .env.example). This is the *web* client ID from
+ * Google Cloud Console, NOT the Android client ID.
  *
  * This is the primary login method — prominent and seamless on the watch.
  * The Data Layer sync from the phone app is a secondary/fallback path.
@@ -31,7 +36,7 @@ class WearGoogleSignIn @Inject constructor(
 
     /**
      * Build the credential request for Google Sign-In.
-     * Uses the server client ID so the backend can verify the ID token.
+     * Uses the server (web) client ID so the backend can verify the ID token.
      */
     fun buildCredentialRequest(): GetCredentialRequest {
         val googleIdOption = GetGoogleIdOption.Builder()
@@ -47,7 +52,8 @@ class WearGoogleSignIn @Inject constructor(
 
     /**
      * Process the credential response from Google Sign-In.
-     * Extracts the ID token and exchanges it with the backend.
+     * Extracts the ID token and exchanges it with the backend using
+     * better-auth's social sign-in callback endpoint.
      */
     suspend fun handleSignInResult(result: GetCredentialResponse): Boolean {
         val credential = result.credential
@@ -80,8 +86,18 @@ class WearGoogleSignIn @Inject constructor(
     }
 
     companion object {
-        // This should match the Google OAuth client ID configured in the backend.
-        // In production, this would come from google-services.json or build config.
+        /**
+         * The Google OAuth *web* client ID — must match the GOOGLE_CLIENT_ID
+         * environment variable on the Convocados backend.
+         *
+         * To configure:
+         * 1. Go to Google Cloud Console → APIs & Services → Credentials
+         * 2. Use the "Web application" OAuth 2.0 Client ID
+         * 3. This is the same ID set in GOOGLE_CLIENT_ID in .env
+         *
+         * TODO: Move to BuildConfig field populated from google-services.json
+         *       or a local.properties value so it's not hardcoded.
+         */
         const val SERVER_CLIENT_ID = "YOUR_GOOGLE_CLIENT_ID.apps.googleusercontent.com"
     }
 }

--- a/android-app/wear/src/main/java/dev/convocados/wear/data/auth/WearGoogleSignIn.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/data/auth/WearGoogleSignIn.kt
@@ -1,0 +1,87 @@
+package dev.convocados.wear.data.auth
+
+import android.content.Context
+import android.util.Log
+import androidx.credentials.CredentialManager
+import androidx.credentials.CustomCredential
+import androidx.credentials.GetCredentialRequest
+import androidx.credentials.GetCredentialResponse
+import com.google.android.libraries.identity.googleid.GetGoogleIdOption
+import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dev.convocados.wear.data.api.WearApiClient
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Handles Google Sign-In directly on the Wear OS device.
+ * Uses Credential Manager + Google Identity Services to get an ID token,
+ * then exchanges it with the Convocados backend for OAuth tokens.
+ *
+ * This is the primary login method — prominent and seamless on the watch.
+ * The Data Layer sync from the phone app is a secondary/fallback path.
+ */
+@Singleton
+class WearGoogleSignIn @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val apiClient: WearApiClient,
+    private val tokenStore: WearTokenStore,
+) {
+    private val credentialManager = CredentialManager.create(context)
+
+    /**
+     * Build the credential request for Google Sign-In.
+     * Uses the server client ID so the backend can verify the ID token.
+     */
+    fun buildCredentialRequest(): GetCredentialRequest {
+        val googleIdOption = GetGoogleIdOption.Builder()
+            .setFilterByAuthorizedAccounts(false)
+            .setServerClientId(SERVER_CLIENT_ID)
+            .setAutoSelectEnabled(true)
+            .build()
+
+        return GetCredentialRequest.Builder()
+            .addCredentialOption(googleIdOption)
+            .build()
+    }
+
+    /**
+     * Process the credential response from Google Sign-In.
+     * Extracts the ID token and exchanges it with the backend.
+     */
+    suspend fun handleSignInResult(result: GetCredentialResponse): Boolean {
+        val credential = result.credential
+
+        if (credential is CustomCredential &&
+            credential.type == GoogleIdTokenCredential.TYPE_GOOGLE_ID_TOKEN_CREDENTIAL
+        ) {
+            val googleIdToken = GoogleIdTokenCredential.createFrom(credential.data)
+            val idToken = googleIdToken.idToken
+
+            return try {
+                val tokenResponse = apiClient.exchangeGoogleToken(idToken)
+                tokenStore.setTokens(
+                    OAuthTokens(
+                        accessToken = tokenResponse.accessToken,
+                        refreshToken = tokenResponse.refreshToken ?: "",
+                        expiresAt = System.currentTimeMillis() + tokenResponse.expiresIn * 1000,
+                    )
+                )
+                Log.d("WearGoogleSignIn", "Google Sign-In successful")
+                true
+            } catch (e: Exception) {
+                Log.e("WearGoogleSignIn", "Token exchange failed", e)
+                false
+            }
+        }
+
+        Log.w("WearGoogleSignIn", "Unexpected credential type: ${credential.javaClass.name}")
+        return false
+    }
+
+    companion object {
+        // This should match the Google OAuth client ID configured in the backend.
+        // In production, this would come from google-services.json or build config.
+        const val SERVER_CLIENT_ID = "YOUR_GOOGLE_CLIENT_ID.apps.googleusercontent.com"
+    }
+}

--- a/android-app/wear/src/main/java/dev/convocados/wear/data/auth/WearTokenStore.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/data/auth/WearTokenStore.kt
@@ -1,0 +1,81 @@
+package dev.convocados.wear.data.auth
+
+import android.content.Context
+import android.util.Log
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+data class OAuthTokens(
+    val accessToken: String,
+    val refreshToken: String,
+    val expiresAt: Long,
+)
+
+@Singleton
+class WearTokenStore @Inject constructor(@ApplicationContext context: Context) {
+
+    private val masterKey = MasterKey.Builder(context)
+        .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+        .build()
+
+    private val prefs = try {
+        createEncryptedPrefs(context)
+    } catch (e: Exception) {
+        Log.e("WearTokenStore", "EncryptedSharedPreferences init failed, clearing", e)
+        context.deleteSharedPreferences("convocados_wear_tokens")
+        createEncryptedPrefs(context)
+    }
+
+    private fun createEncryptedPrefs(context: Context) = EncryptedSharedPreferences.create(
+        context,
+        "convocados_wear_tokens",
+        masterKey,
+        EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+        EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
+    )
+
+    private val _isAuthenticated = MutableStateFlow(getTokens() != null)
+    val isAuthenticated: StateFlow<Boolean> = _isAuthenticated
+
+    fun getTokens(): OAuthTokens? {
+        val access = prefs.getString("access_token", null) ?: return null
+        val refresh = prefs.getString("refresh_token", null) ?: return null
+        val expires = prefs.getLong("expires_at", 0)
+        return OAuthTokens(access, refresh, expires)
+    }
+
+    fun setTokens(tokens: OAuthTokens) {
+        prefs.edit()
+            .putString("access_token", tokens.accessToken)
+            .putString("refresh_token", tokens.refreshToken)
+            .putLong("expires_at", tokens.expiresAt)
+            .apply()
+        _isAuthenticated.value = true
+    }
+
+    fun clearTokens() {
+        prefs.edit().clear().apply()
+        _isAuthenticated.value = false
+    }
+
+    fun isExpired(): Boolean {
+        val tokens = getTokens() ?: return true
+        return System.currentTimeMillis() >= tokens.expiresAt - 60_000
+    }
+
+    fun getServerUrl(): String =
+        prefs.getString("server_url", null) ?: DEFAULT_SERVER_URL
+
+    fun setServerUrl(url: String) {
+        prefs.edit().putString("server_url", url).apply()
+    }
+
+    companion object {
+        const val DEFAULT_SERVER_URL = "https://convocados.fly.dev"
+    }
+}

--- a/android-app/wear/src/main/java/dev/convocados/wear/data/local/WearDatabase.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/data/local/WearDatabase.kt
@@ -1,0 +1,25 @@
+package dev.convocados.wear.data.local
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import dev.convocados.wear.data.local.dao.PendingScoreDao
+import dev.convocados.wear.data.local.dao.WearGameDao
+import dev.convocados.wear.data.local.dao.WearHistoryDao
+import dev.convocados.wear.data.local.entity.PendingScoreEntity
+import dev.convocados.wear.data.local.entity.WearGameEntity
+import dev.convocados.wear.data.local.entity.WearHistoryEntity
+
+@Database(
+    entities = [
+        WearGameEntity::class,
+        PendingScoreEntity::class,
+        WearHistoryEntity::class,
+    ],
+    version = 1,
+    exportSchema = false,
+)
+abstract class WearDatabase : RoomDatabase() {
+    abstract fun gameDao(): WearGameDao
+    abstract fun historyDao(): WearHistoryDao
+    abstract fun pendingScoreDao(): PendingScoreDao
+}

--- a/android-app/wear/src/main/java/dev/convocados/wear/data/local/dao/Daos.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/data/local/dao/Daos.kt
@@ -1,0 +1,73 @@
+package dev.convocados.wear.data.local.dao
+
+import androidx.room.*
+import dev.convocados.wear.data.local.entity.PendingScoreEntity
+import dev.convocados.wear.data.local.entity.WearGameEntity
+import dev.convocados.wear.data.local.entity.WearHistoryEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface WearGameDao {
+    @Query("SELECT * FROM wear_games ORDER BY dateTime ASC")
+    fun getAllGames(): Flow<List<WearGameEntity>>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertAll(games: List<WearGameEntity>)
+
+    @Query("DELETE FROM wear_games WHERE type = :type")
+    suspend fun deleteByType(type: String)
+
+    @Transaction
+    suspend fun refreshGames(type: String, games: List<WearGameEntity>) {
+        deleteByType(type)
+        insertAll(games)
+    }
+
+    @Query("SELECT * FROM wear_games WHERE id = :id")
+    suspend fun getGame(id: String): WearGameEntity?
+}
+
+@Dao
+interface WearHistoryDao {
+    @Query("SELECT * FROM wear_history WHERE eventId = :eventId ORDER BY dateTime DESC LIMIT 1")
+    suspend fun getLatestHistory(eventId: String): WearHistoryEntity?
+
+    @Query("SELECT * FROM wear_history WHERE eventId = :eventId ORDER BY dateTime DESC LIMIT 1")
+    fun observeLatestHistory(eventId: String): Flow<WearHistoryEntity?>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertAll(history: List<WearHistoryEntity>)
+
+    @Query("DELETE FROM wear_history WHERE eventId = :eventId")
+    suspend fun deleteByEvent(eventId: String)
+
+    @Transaction
+    suspend fun refreshHistory(eventId: String, history: List<WearHistoryEntity>) {
+        deleteByEvent(eventId)
+        insertAll(history)
+    }
+
+    @Query("UPDATE wear_history SET scoreOne = :scoreOne, scoreTwo = :scoreTwo WHERE id = :historyId")
+    suspend fun updateScore(historyId: String, scoreOne: Int, scoreTwo: Int)
+}
+
+@Dao
+interface PendingScoreDao {
+    @Query("SELECT * FROM pending_scores ORDER BY createdAt ASC")
+    suspend fun getAll(): List<PendingScoreEntity>
+
+    @Query("SELECT COUNT(*) FROM pending_scores")
+    fun observeCount(): Flow<Int>
+
+    @Insert
+    suspend fun insert(score: PendingScoreEntity)
+
+    @Delete
+    suspend fun delete(score: PendingScoreEntity)
+
+    @Query("UPDATE pending_scores SET retryCount = retryCount + 1 WHERE id = :id")
+    suspend fun incrementRetry(id: Long)
+
+    @Query("DELETE FROM pending_scores WHERE retryCount >= 5")
+    suspend fun deleteStale()
+}

--- a/android-app/wear/src/main/java/dev/convocados/wear/data/local/entity/Entities.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/data/local/entity/Entities.kt
@@ -1,0 +1,48 @@
+package dev.convocados.wear.data.local.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+/** Cached game (event) for the game list screen. */
+@Entity(tableName = "wear_games")
+data class WearGameEntity(
+    @PrimaryKey val id: String,
+    val title: String,
+    val location: String,
+    val dateTime: String,
+    val sport: String,
+    val maxPlayers: Int,
+    val playerCount: Int,
+    val teamOneName: String,
+    val teamTwoName: String,
+    val isRecurring: Boolean,
+    val type: String, // "owned" | "joined"
+    val cachedAt: Long = System.currentTimeMillis(),
+)
+
+/** Pending score update queued for sync when online. */
+@Entity(tableName = "pending_scores")
+data class PendingScoreEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val eventId: String,
+    val historyId: String,
+    val scoreOne: Int,
+    val scoreTwo: Int,
+    val teamOneName: String,
+    val teamTwoName: String,
+    val createdAt: Long = System.currentTimeMillis(),
+    val retryCount: Int = 0,
+)
+
+/** Cached latest game history entry per event (for knowing the historyId). */
+@Entity(tableName = "wear_history")
+data class WearHistoryEntity(
+    @PrimaryKey val id: String,
+    val eventId: String,
+    val dateTime: String,
+    val scoreOne: Int?,
+    val scoreTwo: Int?,
+    val teamOneName: String,
+    val teamTwoName: String,
+    val editable: Boolean,
+)

--- a/android-app/wear/src/main/java/dev/convocados/wear/data/repository/WearGameRepository.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/data/repository/WearGameRepository.kt
@@ -1,0 +1,144 @@
+package dev.convocados.wear.data.repository
+
+import android.util.Log
+import dev.convocados.wear.data.api.WearApi
+import dev.convocados.wear.data.local.dao.PendingScoreDao
+import dev.convocados.wear.data.local.dao.WearGameDao
+import dev.convocados.wear.data.local.dao.WearHistoryDao
+import dev.convocados.wear.data.local.entity.PendingScoreEntity
+import dev.convocados.wear.data.local.entity.WearGameEntity
+import dev.convocados.wear.data.local.entity.WearHistoryEntity
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class WearGameRepository @Inject constructor(
+    private val api: WearApi,
+    private val gameDao: WearGameDao,
+    private val historyDao: WearHistoryDao,
+    private val pendingScoreDao: PendingScoreDao,
+) {
+    /** Observable list of all cached games, sorted by dateTime. */
+    fun observeGames(): Flow<List<WearGameEntity>> = gameDao.getAllGames()
+
+    /** Observable latest history for a game. */
+    fun observeLatestHistory(eventId: String): Flow<WearHistoryEntity?> =
+        historyDao.observeLatestHistory(eventId)
+
+    /** Observable count of pending (unsynced) scores. */
+    fun observePendingCount(): Flow<Int> = pendingScoreDao.observeCount()
+
+    /** Refresh games from the API, falling back to cache on failure. */
+    suspend fun refreshGames(): Result<Unit> = try {
+        val response = api.fetchMyGames()
+        val owned = response.owned.map { it.toEntity("owned") }
+        val joined = response.joined.map { it.toEntity("joined") }
+        gameDao.refreshGames("owned", owned)
+        gameDao.refreshGames("joined", joined)
+        Result.success(Unit)
+    } catch (e: Exception) {
+        Log.w("WearGameRepo", "Failed to refresh games", e)
+        Result.failure(e)
+    }
+
+    /** Refresh history for a specific event. */
+    suspend fun refreshHistory(eventId: String): Result<Unit> = try {
+        val history = api.fetchHistory(eventId)
+        historyDao.refreshHistory(
+            eventId,
+            history.data.map { it.toHistoryEntity(eventId) }
+        )
+        Result.success(Unit)
+    } catch (e: Exception) {
+        Log.w("WearGameRepo", "Failed to refresh history for $eventId", e)
+        Result.failure(e)
+    }
+
+    /** Get the latest history entry for a game (from cache). */
+    suspend fun getLatestHistory(eventId: String): WearHistoryEntity? =
+        historyDao.getLatestHistory(eventId)
+
+    /** Get a cached game by ID. */
+    suspend fun getGame(eventId: String): WearGameEntity? = gameDao.getGame(eventId)
+
+    /**
+     * Submit a score. Tries the API first; if offline, queues it locally.
+     * Updates the local cache optimistically either way.
+     */
+    suspend fun submitScore(
+        eventId: String,
+        historyId: String,
+        scoreOne: Int,
+        scoreTwo: Int,
+        teamOneName: String,
+        teamTwoName: String,
+    ): Result<Unit> {
+        // Optimistically update local cache
+        historyDao.updateScore(historyId, scoreOne, scoreTwo)
+
+        return try {
+            api.updateScore(eventId, historyId, scoreOne, scoreTwo)
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Log.w("WearGameRepo", "Score submit failed, queuing for sync", e)
+            pendingScoreDao.insert(
+                PendingScoreEntity(
+                    eventId = eventId,
+                    historyId = historyId,
+                    scoreOne = scoreOne,
+                    scoreTwo = scoreTwo,
+                    teamOneName = teamOneName,
+                    teamTwoName = teamTwoName,
+                )
+            )
+            Result.success(Unit) // Still "success" from user perspective — queued
+        }
+    }
+
+    /** Sync all pending scores. Returns number of successfully synced items. */
+    suspend fun syncPendingScores(): Int {
+        val pending = pendingScoreDao.getAll()
+        var synced = 0
+        for (score in pending) {
+            try {
+                api.updateScore(score.eventId, score.historyId, score.scoreOne, score.scoreTwo)
+                pendingScoreDao.delete(score)
+                synced++
+            } catch (e: Exception) {
+                pendingScoreDao.incrementRetry(score.id)
+                Log.w("WearGameRepo", "Failed to sync score ${score.id}", e)
+            }
+        }
+        pendingScoreDao.deleteStale()
+        return synced
+    }
+
+    // ── Mappers ──────────────────────────────────────────────────────────
+
+    private fun dev.convocados.wear.data.api.EventSummary.toEntity(type: String) = WearGameEntity(
+        id = id,
+        title = title,
+        location = location,
+        dateTime = dateTime,
+        sport = sport,
+        maxPlayers = maxPlayers,
+        playerCount = playerCount,
+        teamOneName = "Team 1",
+        teamTwoName = "Team 2",
+        isRecurring = isRecurring,
+        type = type,
+    )
+
+    private fun dev.convocados.wear.data.api.GameHistory.toHistoryEntity(eventId: String) =
+        WearHistoryEntity(
+            id = id,
+            eventId = eventId,
+            dateTime = dateTime,
+            scoreOne = scoreOne,
+            scoreTwo = scoreTwo,
+            teamOneName = teamOneName,
+            teamTwoName = teamTwoName,
+            editable = editable,
+        )
+}

--- a/android-app/wear/src/main/java/dev/convocados/wear/data/sync/ScoreSyncWorker.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/data/sync/ScoreSyncWorker.kt
@@ -1,0 +1,70 @@
+package dev.convocados.wear.data.sync
+
+import android.content.Context
+import android.util.Log
+import androidx.hilt.work.HiltWorker
+import androidx.work.*
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import dev.convocados.wear.data.repository.WearGameRepository
+import java.util.concurrent.TimeUnit
+
+/**
+ * WorkManager worker that syncs pending scores when connectivity is available.
+ * Enqueued as a unique periodic job and also triggered on-demand after score entry.
+ */
+@HiltWorker
+class ScoreSyncWorker @AssistedInject constructor(
+    @Assisted context: Context,
+    @Assisted params: WorkerParameters,
+    private val repository: WearGameRepository,
+) : CoroutineWorker(context, params) {
+
+    override suspend fun doWork(): Result {
+        return try {
+            val synced = repository.syncPendingScores()
+            Log.d("ScoreSyncWorker", "Synced $synced pending scores")
+            Result.success()
+        } catch (e: Exception) {
+            Log.e("ScoreSyncWorker", "Sync failed", e)
+            if (runAttemptCount < 3) Result.retry() else Result.failure()
+        }
+    }
+
+    companion object {
+        private const val UNIQUE_WORK_NAME = "score_sync"
+
+        /** Enqueue a one-time sync attempt (e.g. after entering a score offline). */
+        fun enqueueOneTime(context: Context) {
+            val request = OneTimeWorkRequestBuilder<ScoreSyncWorker>()
+                .setConstraints(
+                    Constraints.Builder()
+                        .setRequiredNetworkType(NetworkType.CONNECTED)
+                        .build()
+                )
+                .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 30, TimeUnit.SECONDS)
+                .build()
+
+            WorkManager.getInstance(context)
+                .enqueueUniqueWork(UNIQUE_WORK_NAME, ExistingWorkPolicy.REPLACE, request)
+        }
+
+        /** Schedule periodic sync every 15 minutes when connected. */
+        fun schedulePeriodic(context: Context) {
+            val request = PeriodicWorkRequestBuilder<ScoreSyncWorker>(15, TimeUnit.MINUTES)
+                .setConstraints(
+                    Constraints.Builder()
+                        .setRequiredNetworkType(NetworkType.CONNECTED)
+                        .build()
+                )
+                .build()
+
+            WorkManager.getInstance(context)
+                .enqueueUniquePeriodicWork(
+                    "${UNIQUE_WORK_NAME}_periodic",
+                    ExistingPeriodicWorkPolicy.KEEP,
+                    request,
+                )
+        }
+    }
+}

--- a/android-app/wear/src/main/java/dev/convocados/wear/di/WearDatabaseModule.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/di/WearDatabaseModule.kt
@@ -1,0 +1,34 @@
+package dev.convocados.wear.di
+
+import android.content.Context
+import androidx.room.Room
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import dev.convocados.wear.data.local.WearDatabase
+import dev.convocados.wear.data.local.dao.PendingScoreDao
+import dev.convocados.wear.data.local.dao.WearGameDao
+import dev.convocados.wear.data.local.dao.WearHistoryDao
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object WearDatabaseModule {
+
+    @Provides
+    @Singleton
+    fun provideDatabase(@ApplicationContext context: Context): WearDatabase =
+        Room.databaseBuilder(context, WearDatabase::class.java, "convocados_wear.db")
+            .build()
+
+    @Provides
+    fun provideGameDao(db: WearDatabase): WearGameDao = db.gameDao()
+
+    @Provides
+    fun provideHistoryDao(db: WearDatabase): WearHistoryDao = db.historyDao()
+
+    @Provides
+    fun providePendingScoreDao(db: WearDatabase): PendingScoreDao = db.pendingScoreDao()
+}

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/WearActivity.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/WearActivity.kt
@@ -1,0 +1,20 @@
+package dev.convocados.wear.ui
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import dagger.hilt.android.AndroidEntryPoint
+import dev.convocados.wear.ui.navigation.WearNavigation
+import dev.convocados.wear.ui.theme.ConvocadosWearTheme
+
+@AndroidEntryPoint
+class WearActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            ConvocadosWearTheme {
+                WearNavigation()
+            }
+        }
+    }
+}

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/navigation/WearNavigation.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/navigation/WearNavigation.kt
@@ -1,0 +1,59 @@
+package dev.convocados.wear.ui.navigation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.wear.compose.navigation.SwipeDismissableNavHost
+import androidx.wear.compose.navigation.composable
+import androidx.wear.compose.navigation.rememberSwipeDismissableNavController
+import dev.convocados.wear.ui.screen.auth.AuthScreen
+import dev.convocados.wear.ui.screen.auth.AuthViewModel
+import dev.convocados.wear.ui.screen.games.GamesScreen
+import dev.convocados.wear.ui.screen.games.GamesViewModel
+import dev.convocados.wear.ui.screen.score.ScoreScreen
+import dev.convocados.wear.ui.screen.score.ScoreViewModel
+
+@Composable
+fun WearNavigation() {
+    val navController = rememberSwipeDismissableNavController()
+    val authViewModel: AuthViewModel = hiltViewModel()
+    val isAuthenticated by authViewModel.isAuthenticated.collectAsState()
+
+    val startDestination = if (isAuthenticated) WearRoutes.GAMES else WearRoutes.AUTH
+
+    SwipeDismissableNavHost(
+        navController = navController,
+        startDestination = startDestination,
+    ) {
+        composable(WearRoutes.AUTH) {
+            AuthScreen(
+                onAuthenticated = {
+                    navController.navigate(WearRoutes.GAMES) {
+                        popUpTo(WearRoutes.AUTH) { inclusive = true }
+                    }
+                }
+            )
+        }
+
+        composable(WearRoutes.GAMES) {
+            val viewModel: GamesViewModel = hiltViewModel()
+            GamesScreen(
+                viewModel = viewModel,
+                onGameSelected = { eventId ->
+                    navController.navigate(WearRoutes.score(eventId))
+                },
+            )
+        }
+
+        composable(WearRoutes.SCORE) { backStackEntry ->
+            val eventId = backStackEntry.arguments?.getString("eventId") ?: return@composable
+            val viewModel: ScoreViewModel = hiltViewModel()
+            ScoreScreen(
+                eventId = eventId,
+                viewModel = viewModel,
+                onDone = { navController.popBackStack() },
+            )
+        }
+    }
+}

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/navigation/WearRoutes.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/navigation/WearRoutes.kt
@@ -1,0 +1,10 @@
+package dev.convocados.wear.ui.navigation
+
+/** Wear OS navigation routes. */
+object WearRoutes {
+    const val AUTH = "auth"
+    const val GAMES = "games"
+    const val SCORE = "score/{eventId}"
+
+    fun score(eventId: String) = "score/$eventId"
+}

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/auth/AuthScreen.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/auth/AuthScreen.kt
@@ -1,0 +1,117 @@
+package dev.convocados.wear.ui.screen.auth
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.credentials.CredentialManager
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.wear.compose.material.*
+import dev.convocados.wear.ui.theme.TextMuted
+import kotlinx.coroutines.launch
+
+/**
+ * Auth screen with prominent Google Sign-In button.
+ * Also supports passive token sync from the phone app via Data Layer.
+ */
+@Composable
+fun AuthScreen(
+    onAuthenticated: () -> Unit,
+    viewModel: AuthViewModel = hiltViewModel(),
+) {
+    val isAuthenticated by viewModel.isAuthenticated.collectAsState()
+    val uiState by viewModel.uiState.collectAsState()
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+
+    LaunchedEffect(isAuthenticated) {
+        if (isAuthenticated) onAuthenticated()
+    }
+
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.Center,
+        ) {
+            // App title
+            Text(
+                text = "Convocados",
+                style = MaterialTheme.typography.title2,
+                color = MaterialTheme.colors.primary,
+            )
+
+            Spacer(modifier = Modifier.height(10.dp))
+
+            // Primary: Google Sign-In button
+            if (uiState.isSigningIn) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(24.dp),
+                    strokeWidth = 2.dp,
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = "Signing in...",
+                    style = MaterialTheme.typography.caption3,
+                    color = MaterialTheme.colors.onSurfaceVariant,
+                )
+            } else {
+                Chip(
+                    onClick = {
+                        scope.launch {
+                            try {
+                                val credentialManager = CredentialManager.create(context)
+                                val request = viewModel.getGoogleSignInRequest()
+                                val result = credentialManager.getCredential(
+                                    context = context,
+                                    request = request,
+                                )
+                                viewModel.handleGoogleSignInResult(result)
+                            } catch (e: Exception) {
+                                viewModel.handleGoogleSignInError(e)
+                            }
+                        }
+                    },
+                    label = {
+                        Text(
+                            text = "Sign in with Google",
+                            style = MaterialTheme.typography.button,
+                        )
+                    },
+                    colors = ChipDefaults.chipColors(
+                        backgroundColor = MaterialTheme.colors.primary,
+                        contentColor = MaterialTheme.colors.onPrimary,
+                    ),
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+
+            // Error message
+            uiState.error?.let { error ->
+                Spacer(modifier = Modifier.height(6.dp))
+                Text(
+                    text = error,
+                    style = MaterialTheme.typography.caption3,
+                    color = MaterialTheme.colors.error,
+                    textAlign = TextAlign.Center,
+                )
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            // Secondary: phone sync hint
+            Text(
+                text = "or sign in on phone",
+                style = MaterialTheme.typography.caption3,
+                color = TextMuted,
+                textAlign = TextAlign.Center,
+            )
+        }
+    }
+}

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/auth/AuthViewModel.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/auth/AuthViewModel.kt
@@ -1,0 +1,66 @@
+package dev.convocados.wear.ui.screen.auth
+
+import android.app.Application
+import androidx.credentials.CredentialManager
+import androidx.credentials.GetCredentialRequest
+import androidx.credentials.exceptions.GetCredentialCancellationException
+import androidx.credentials.exceptions.NoCredentialException
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dev.convocados.wear.data.auth.WearGoogleSignIn
+import dev.convocados.wear.data.auth.WearTokenStore
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+data class AuthUiState(
+    val isSigningIn: Boolean = false,
+    val error: String? = null,
+)
+
+@HiltViewModel
+class AuthViewModel @Inject constructor(
+    application: Application,
+    private val tokenStore: WearTokenStore,
+    private val googleSignIn: WearGoogleSignIn,
+) : AndroidViewModel(application) {
+
+    val isAuthenticated: StateFlow<Boolean> = tokenStore.isAuthenticated
+
+    private val _uiState = MutableStateFlow(AuthUiState())
+    val uiState: StateFlow<AuthUiState> = _uiState.asStateFlow()
+
+    /** Returns the credential request to launch from the Activity. */
+    fun getGoogleSignInRequest(): GetCredentialRequest = googleSignIn.buildCredentialRequest()
+
+    /** Called after the Activity receives the credential response. */
+    fun handleGoogleSignInResult(result: androidx.credentials.GetCredentialResponse) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isSigningIn = true, error = null) }
+            val success = googleSignIn.handleSignInResult(result)
+            _uiState.update {
+                it.copy(
+                    isSigningIn = false,
+                    error = if (success) null else "Sign-in failed. Try again.",
+                )
+            }
+        }
+    }
+
+    fun handleGoogleSignInError(e: Exception) {
+        val message = when (e) {
+            is GetCredentialCancellationException -> null // User cancelled, no error
+            is NoCredentialException -> "No Google account found"
+            else -> "Sign-in failed: ${e.message}"
+        }
+        _uiState.update { it.copy(isSigningIn = false, error = message) }
+    }
+
+    fun clearError() {
+        _uiState.update { it.copy(error = null) }
+    }
+}

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/games/GamesScreen.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/games/GamesScreen.kt
@@ -1,0 +1,188 @@
+package dev.convocados.wear.ui.screen.games
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.foundation.lazy.ScalingLazyColumn
+import androidx.wear.compose.foundation.lazy.items
+import androidx.wear.compose.foundation.lazy.rememberScalingLazyListState
+import androidx.wear.compose.material.*
+import dev.convocados.wear.data.local.entity.WearGameEntity
+import dev.convocados.wear.ui.theme.Success
+import dev.convocados.wear.ui.theme.TextMuted
+import dev.convocados.wear.ui.theme.Warning
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
+
+@Composable
+fun GamesScreen(
+    viewModel: GamesViewModel,
+    onGameSelected: (String) -> Unit,
+) {
+    val state by viewModel.uiState.collectAsState()
+    val listState = rememberScalingLazyListState()
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        when {
+            state.isLoading && state.games.isEmpty() -> {
+                Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    CircularProgressIndicator()
+                }
+            }
+            state.games.isEmpty() -> {
+                Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    Text(
+                        text = "No games yet",
+                        style = MaterialTheme.typography.body1,
+                        color = MaterialTheme.colors.onSurfaceVariant,
+                        textAlign = TextAlign.Center,
+                    )
+                }
+            }
+            else -> {
+                // Sort: suggested game first, then by time proximity
+                val sortedGames = state.games.sortedWith(
+                    compareBy<WearGameEntity> { it.id != state.suggestedGameId }
+                        .thenBy { parseInstant(it.dateTime)?.let { t -> kotlin.math.abs(ChronoUnit.MINUTES.between(Instant.now(), t)) } ?: Long.MAX_VALUE }
+                )
+
+                ScalingLazyColumn(
+                    state = listState,
+                    modifier = Modifier.fillMaxSize(),
+                    contentPadding = PaddingValues(
+                        top = 32.dp,
+                        bottom = 16.dp,
+                        start = 8.dp,
+                        end = 8.dp,
+                    ),
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    // Header
+                    item {
+                        Text(
+                            text = "Games",
+                            style = MaterialTheme.typography.title3,
+                            color = MaterialTheme.colors.primary,
+                            modifier = Modifier.padding(bottom = 4.dp),
+                        )
+                    }
+
+                    // Pending sync indicator
+                    if (state.pendingSyncCount > 0) {
+                        item {
+                            Text(
+                                text = "${state.pendingSyncCount} score(s) pending sync",
+                                style = MaterialTheme.typography.caption3,
+                                color = Warning,
+                            )
+                        }
+                    }
+
+                    // Offline indicator
+                    if (state.isOffline) {
+                        item {
+                            Text(
+                                text = "Offline — showing cached",
+                                style = MaterialTheme.typography.caption3,
+                                color = TextMuted,
+                            )
+                        }
+                    }
+
+                    items(sortedGames, key = { it.id }) { game ->
+                        GameChip(
+                            game = game,
+                            isSuggested = game.id == state.suggestedGameId,
+                            onClick = { onGameSelected(game.id) },
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun GameChip(
+    game: WearGameEntity,
+    isSuggested: Boolean,
+    onClick: () -> Unit,
+) {
+    val timeLabel = formatRelativeTime(game.dateTime)
+    val chipColors = if (isSuggested) {
+        ChipDefaults.chipColors(
+            backgroundColor = MaterialTheme.colors.primary.copy(alpha = 0.2f),
+        )
+    } else {
+        ChipDefaults.secondaryChipColors()
+    }
+
+    Chip(
+        onClick = onClick,
+        label = {
+            Text(
+                text = game.title,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        },
+        secondaryLabel = {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                if (isSuggested) {
+                    Text(
+                        text = "NOW ",
+                        style = MaterialTheme.typography.caption3,
+                        color = Success,
+                    )
+                }
+                Text(
+                    text = timeLabel,
+                    style = MaterialTheme.typography.caption3,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        },
+        colors = chipColors,
+        modifier = Modifier.fillMaxWidth(),
+    )
+}
+
+private fun formatRelativeTime(dateTime: String): String {
+    val instant = parseInstant(dateTime) ?: return dateTime
+    val now = Instant.now()
+    val minutes = ChronoUnit.MINUTES.between(now, instant)
+
+    return when {
+        minutes in -120..0 -> "In progress"
+        minutes in 1..59 -> "In ${minutes}m"
+        minutes in 60..1440 -> "In ${minutes / 60}h ${minutes % 60}m"
+        minutes > 1440 -> {
+            val zoned = instant.atZone(ZoneId.systemDefault())
+            zoned.format(DateTimeFormatter.ofPattern("EEE HH:mm"))
+        }
+        minutes in -1440..-121 -> {
+            val ago = kotlin.math.abs(minutes)
+            "${ago / 60}h ago"
+        }
+        else -> {
+            val zoned = instant.atZone(ZoneId.systemDefault())
+            zoned.format(DateTimeFormatter.ofPattern("MMM d"))
+        }
+    }
+}
+
+private fun parseInstant(dateTime: String): Instant? = try {
+    ZonedDateTime.parse(dateTime, DateTimeFormatter.ISO_DATE_TIME).toInstant()
+} catch (_: Exception) {
+    try { Instant.parse(dateTime) } catch (_: Exception) { null }
+}

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/games/GamesViewModel.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/games/GamesViewModel.kt
@@ -1,0 +1,105 @@
+package dev.convocados.wear.ui.screen.games
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dev.convocados.wear.data.local.entity.WearGameEntity
+import dev.convocados.wear.data.repository.WearGameRepository
+import dev.convocados.wear.data.sync.ScoreSyncWorker
+import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.launch
+import java.time.Instant
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
+import javax.inject.Inject
+import kotlin.math.abs
+
+data class GamesUiState(
+    val games: List<WearGameEntity> = emptyList(),
+    val suggestedGameId: String? = null,
+    val isLoading: Boolean = true,
+    val isOffline: Boolean = false,
+    val pendingSyncCount: Int = 0,
+)
+
+@HiltViewModel
+class GamesViewModel @Inject constructor(
+    application: Application,
+    private val repository: WearGameRepository,
+) : AndroidViewModel(application) {
+
+    private val _uiState = MutableStateFlow(GamesUiState())
+    val uiState: StateFlow<GamesUiState> = _uiState.asStateFlow()
+
+    init {
+        // Schedule periodic sync
+        ScoreSyncWorker.schedulePeriodic(application)
+
+        // Observe cached games
+        viewModelScope.launch {
+            repository.observeGames().combine(repository.observePendingCount()) { games, pending ->
+                val suggested = findBestGame(games)
+                _uiState.value = _uiState.value.copy(
+                    games = games,
+                    suggestedGameId = suggested?.id,
+                    isLoading = false,
+                    pendingSyncCount = pending,
+                )
+            }.collect()
+        }
+
+        // Initial refresh
+        refresh()
+    }
+
+    fun refresh() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true) }
+            val result = repository.refreshGames()
+            _uiState.update {
+                it.copy(
+                    isLoading = false,
+                    isOffline = result.isFailure,
+                )
+            }
+        }
+    }
+
+    /**
+     * Smart game selection: pick the game whose dateTime is closest to "now".
+     * Prefers games that are currently happening (within duration window)
+     * or about to start (within next 2 hours).
+     */
+    private fun findBestGame(games: List<WearGameEntity>): WearGameEntity? {
+        if (games.isEmpty()) return null
+        val now = Instant.now()
+
+        return games.minByOrNull { game ->
+            val gameTime = parseDateTime(game.dateTime) ?: return@minByOrNull Long.MAX_VALUE
+            val diffMinutes = ChronoUnit.MINUTES.between(now, gameTime)
+
+            when {
+                // Currently happening (started within last 120 min)
+                diffMinutes in -120..0 -> abs(diffMinutes)
+                // Starting soon (next 2 hours) — slight preference
+                diffMinutes in 1..120 -> diffMinutes + 10
+                // Future games
+                diffMinutes > 120 -> diffMinutes * 2
+                // Past games (ended more than 2h ago)
+                else -> abs(diffMinutes) * 3
+            }
+        }
+    }
+
+    private fun parseDateTime(dateTime: String): Instant? = try {
+        ZonedDateTime.parse(dateTime, DateTimeFormatter.ISO_DATE_TIME).toInstant()
+    } catch (_: Exception) {
+        try {
+            Instant.parse(dateTime)
+        } catch (_: Exception) {
+            null
+        }
+    }
+}

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/score/ScoreScreen.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/score/ScoreScreen.kt
@@ -1,0 +1,233 @@
+package dev.convocados.wear.ui.screen.score
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.wear.compose.material.*
+import dev.convocados.wear.ui.theme.Success
+import dev.convocados.wear.ui.theme.TextMuted
+import dev.convocados.wear.ui.theme.Warning
+
+@Composable
+fun ScoreScreen(
+    eventId: String,
+    viewModel: ScoreViewModel,
+    onDone: () -> Unit,
+) {
+    LaunchedEffect(eventId) { viewModel.load(eventId) }
+
+    val state by viewModel.uiState.collectAsState()
+
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        when {
+            state.isLoading -> {
+                CircularProgressIndicator()
+            }
+            state.history == null -> {
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    modifier = Modifier.padding(16.dp),
+                ) {
+                    Text(
+                        text = "No game history",
+                        style = MaterialTheme.typography.body1,
+                        color = MaterialTheme.colors.onSurfaceVariant,
+                    )
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        text = "Start the game from\nthe phone app first",
+                        style = MaterialTheme.typography.caption3,
+                        color = TextMuted,
+                        textAlign = TextAlign.Center,
+                    )
+                }
+            }
+            state.saved -> {
+                SavedConfirmation(
+                    isOfflineQueued = state.isOfflineQueued,
+                    onDone = onDone,
+                )
+            }
+            else -> {
+                ScoreEditor(
+                    state = state,
+                    onIncrementOne = viewModel::incrementScoreOne,
+                    onDecrementOne = viewModel::decrementScoreOne,
+                    onIncrementTwo = viewModel::incrementScoreTwo,
+                    onDecrementTwo = viewModel::decrementScoreTwo,
+                    onSave = viewModel::saveScore,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ScoreEditor(
+    state: ScoreUiState,
+    onIncrementOne: () -> Unit,
+    onDecrementOne: () -> Unit,
+    onIncrementTwo: () -> Unit,
+    onDecrementTwo: () -> Unit,
+    onSave: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        // Game title
+        Text(
+            text = state.game?.title ?: "Score",
+            style = MaterialTheme.typography.caption1,
+            color = MaterialTheme.colors.primary,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+
+        Spacer(modifier = Modifier.height(6.dp))
+
+        // Score row: Team1 [-] score [+]  vs  Team2 [-] score [+]
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceEvenly,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            // Team 1 score
+            ScoreColumn(
+                teamName = state.teamOneName,
+                score = state.scoreOne,
+                onIncrement = onIncrementOne,
+                onDecrement = onDecrementOne,
+            )
+
+            Text(
+                text = ":",
+                fontSize = 24.sp,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colors.onSurface,
+            )
+
+            // Team 2 score
+            ScoreColumn(
+                teamName = state.teamTwoName,
+                score = state.scoreTwo,
+                onIncrement = onIncrementTwo,
+                onDecrement = onDecrementTwo,
+            )
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        // Save button
+        CompactChip(
+            onClick = onSave,
+            label = {
+                Text(
+                    text = if (state.isSaving) "Saving..." else "Save",
+                    style = MaterialTheme.typography.caption1,
+                )
+            },
+            colors = ChipDefaults.chipColors(
+                backgroundColor = MaterialTheme.colors.primary,
+                contentColor = MaterialTheme.colors.onPrimary,
+            ),
+        )
+    }
+}
+
+@Composable
+private fun ScoreColumn(
+    teamName: String,
+    score: Int,
+    onIncrement: () -> Unit,
+    onDecrement: () -> Unit,
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(2.dp),
+    ) {
+        // Team name (truncated)
+        Text(
+            text = teamName,
+            style = MaterialTheme.typography.caption3,
+            color = MaterialTheme.colors.onSurfaceVariant,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.widthIn(max = 60.dp),
+        )
+
+        // + button
+        Button(
+            onClick = onIncrement,
+            modifier = Modifier.size(32.dp),
+            colors = ButtonDefaults.secondaryButtonColors(),
+        ) {
+            Text("+", fontSize = 16.sp, fontWeight = FontWeight.Bold)
+        }
+
+        // Score display
+        Text(
+            text = "$score",
+            fontSize = 28.sp,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colors.onSurface,
+        )
+
+        // - button
+        Button(
+            onClick = onDecrement,
+            modifier = Modifier.size(32.dp),
+            colors = ButtonDefaults.secondaryButtonColors(),
+        ) {
+            Text("-", fontSize = 16.sp, fontWeight = FontWeight.Bold)
+        }
+    }
+}
+
+@Composable
+private fun SavedConfirmation(
+    isOfflineQueued: Boolean,
+    onDone: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Text(
+            text = "Score saved!",
+            style = MaterialTheme.typography.title3,
+            color = Success,
+        )
+
+        if (isOfflineQueued) {
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = "Will sync when online",
+                style = MaterialTheme.typography.caption3,
+                color = Warning,
+                textAlign = TextAlign.Center,
+            )
+        }
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        CompactChip(
+            onClick = onDone,
+            label = { Text("Done") },
+            colors = ChipDefaults.secondaryChipColors(),
+        )
+    }
+}

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/score/ScoreViewModel.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/score/ScoreViewModel.kt
@@ -1,0 +1,116 @@
+package dev.convocados.wear.ui.screen.score
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dev.convocados.wear.data.local.entity.WearGameEntity
+import dev.convocados.wear.data.local.entity.WearHistoryEntity
+import dev.convocados.wear.data.repository.WearGameRepository
+import dev.convocados.wear.data.sync.ScoreSyncWorker
+import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+data class ScoreUiState(
+    val game: WearGameEntity? = null,
+    val history: WearHistoryEntity? = null,
+    val scoreOne: Int = 0,
+    val scoreTwo: Int = 0,
+    val teamOneName: String = "Team 1",
+    val teamTwoName: String = "Team 2",
+    val isLoading: Boolean = true,
+    val isSaving: Boolean = false,
+    val saved: Boolean = false,
+    val error: String? = null,
+    val isOfflineQueued: Boolean = false,
+)
+
+@HiltViewModel
+class ScoreViewModel @Inject constructor(
+    private val application: Application,
+    private val repository: WearGameRepository,
+) : AndroidViewModel(application) {
+
+    private val _uiState = MutableStateFlow(ScoreUiState())
+    val uiState: StateFlow<ScoreUiState> = _uiState.asStateFlow()
+
+    private var eventId: String = ""
+
+    fun load(eventId: String) {
+        if (this.eventId == eventId) return
+        this.eventId = eventId
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true) }
+
+            // Load cached game info
+            val game = repository.getGame(eventId)
+
+            // Try to refresh history from API
+            repository.refreshHistory(eventId)
+
+            // Observe latest history
+            repository.observeLatestHistory(eventId).collect { history ->
+                _uiState.update { state ->
+                    state.copy(
+                        game = game,
+                        history = history,
+                        scoreOne = history?.scoreOne ?: state.scoreOne,
+                        scoreTwo = history?.scoreTwo ?: state.scoreTwo,
+                        teamOneName = history?.teamOneName ?: game?.teamOneName ?: "Team 1",
+                        teamTwoName = history?.teamTwoName ?: game?.teamTwoName ?: "Team 2",
+                        isLoading = false,
+                    )
+                }
+            }
+        }
+    }
+
+    fun incrementScoreOne() {
+        _uiState.update { it.copy(scoreOne = it.scoreOne + 1, saved = false) }
+    }
+
+    fun decrementScoreOne() {
+        _uiState.update { it.copy(scoreOne = maxOf(0, it.scoreOne - 1), saved = false) }
+    }
+
+    fun incrementScoreTwo() {
+        _uiState.update { it.copy(scoreTwo = it.scoreTwo + 1, saved = false) }
+    }
+
+    fun decrementScoreTwo() {
+        _uiState.update { it.copy(scoreTwo = maxOf(0, it.scoreTwo - 1), saved = false) }
+    }
+
+    fun saveScore() {
+        val state = _uiState.value
+        val historyId = state.history?.id ?: return
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(isSaving = true, error = null) }
+
+            val result = repository.submitScore(
+                eventId = eventId,
+                historyId = historyId,
+                scoreOne = state.scoreOne,
+                scoreTwo = state.scoreTwo,
+                teamOneName = state.teamOneName,
+                teamTwoName = state.teamTwoName,
+            )
+
+            // Trigger sync worker in case it was queued offline
+            ScoreSyncWorker.enqueueOneTime(application)
+
+            _uiState.update {
+                it.copy(
+                    isSaving = false,
+                    saved = true,
+                    // If the repo caught an exception but queued it, it returns success
+                    // We detect offline queueing by checking if pending count increased
+                    isOfflineQueued = false, // Will be updated by observation
+                )
+            }
+        }
+    }
+}

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/theme/Color.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/theme/Color.kt
@@ -1,0 +1,18 @@
+package dev.convocados.wear.ui.theme
+
+import androidx.compose.ui.graphics.Color
+
+// Matches the phone app's dark theme
+val Primary = Color(0xFF7EDCAB)
+val PrimaryDark = Color(0xFF1B6B4A)
+val OnPrimary = Color(0xFF003822)
+val Bg = Color(0xFF111412)
+val Surface = Color(0xFF1A1D1B)
+val SurfaceHover = Color(0xFF242724)
+val Border = Color(0xFF3A3F3B)
+val TextPrimary = Color(0xFFE1E3DE)
+val TextSecondary = Color(0xFFC2C9C1)
+val TextMuted = Color(0xFF8C9389)
+val Error = Color(0xFFFFB4AB)
+val Success = Color(0xFF7EDCAB)
+val Warning = Color(0xFFFFB74D)

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/theme/Theme.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/theme/Theme.kt
@@ -1,0 +1,27 @@
+package dev.convocados.wear.ui.theme
+
+import androidx.compose.runtime.Composable
+import androidx.wear.compose.material.Colors
+import androidx.wear.compose.material.MaterialTheme
+
+private val WearColors = Colors(
+    primary = Primary,
+    onPrimary = OnPrimary,
+    secondary = PrimaryDark,
+    onSecondary = TextPrimary,
+    background = Bg,
+    onBackground = TextPrimary,
+    surface = Surface,
+    onSurface = TextPrimary,
+    onSurfaceVariant = TextSecondary,
+    error = Error,
+    onError = OnPrimary,
+)
+
+@Composable
+fun ConvocadosWearTheme(content: @Composable () -> Unit) {
+    MaterialTheme(
+        colors = WearColors,
+        content = content,
+    )
+}

--- a/android-app/wear/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/android-app/wear/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <group android:translateX="27" android:translateY="27">
+        <path
+            android:fillColor="#7EDCAB"
+            android:pathData="M27,0C41.91,0 54,12.09 54,27C54,41.91 41.91,54 27,54C12.09,54 0,41.91 0,27C0,12.09 12.09,0 27,0Z"/>
+        <path
+            android:fillColor="#003822"
+            android:pathData="M37,18L17,18L17,36L37,36L37,31L22,31L22,23L37,23Z"/>
+    </group>
+</vector>

--- a/android-app/wear/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/android-app/wear/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/ic_launcher_background"/>
+    <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+</adaptive-icon>

--- a/android-app/wear/src/main/res/values/colors.xml
+++ b/android-app/wear/src/main/res/values/colors.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="ic_launcher_background">#1B6B4A</color>
+</resources>

--- a/android-app/wear/src/main/res/values/strings.xml
+++ b/android-app/wear/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Convocados</string>
+</resources>


### PR DESCRIPTION
## Wear OS App

New standalone Wear OS app for players to select games and set scores directly from their watch.

### Features

**Authentication**
- **Google Sign-In** (prominent) — seamless one-tap login directly on the watch via Credential Manager + Google Identity Services. Uses better-auth's existing `/api/auth/callback/google` endpoint — no new backend code needed.
- **Phone sync** (secondary) — tokens auto-sync from the phone app via Wearable Data Layer API when the user logs in on the phone
- Encrypted token storage (EncryptedSharedPreferences)

**Smart Game Selection**
- Games sorted by time proximity — in-progress games appear first with a "NOW" badge
- Upcoming games (next 2h) get priority over distant future games
- Offline indicator when showing cached data
- Pending sync count displayed when scores are queued

**Score Entry**
- Large tap targets (+/-) optimized for the round watch screen
- Team names displayed with score counters
- Optimistic local update — score appears saved immediately

**Offline-First Architecture**
- Room database caches games and history locally
- Scores entered offline are queued in `pending_scores` table
- WorkManager syncs pending scores when connectivity returns (exponential backoff)
- Periodic 15-minute sync check
- Stale entries cleaned up after 5 failed retries

### Architecture

```
wear/
├── data/
│   ├── api/          # WearApiClient, WearApi, Models (Ktor)
│   ├── auth/         # WearTokenStore, WearGoogleSignIn, AuthDataListenerService
│   ├── local/        # Room DB (WearDatabase, DAOs, Entities)
│   ├── repository/   # WearGameRepository (offline-first)
│   └── sync/         # ScoreSyncWorker (WorkManager)
├── di/               # Hilt DI modules
└── ui/
    ├── theme/        # Wear Material theme (matches phone app colors)
    ├── navigation/   # SwipeDismissableNavHost (3 routes)
    └── screen/
        ├── auth/     # Google Sign-In + phone sync fallback
        ├── games/    # Smart game list with time-based sorting
        └── score/    # Score entry with +/- buttons
```

### CI/CD Changes

- **CI (`test.yml`)**: Phone and Wear OS builds run as separate parallel jobs (`android` and `android-wear`)
- **Release (`release.yml`)**: Wear OS APK built, signed, and uploaded separately as `convocados-wear-X.Y.Z.apk`
- Both apps share the same keystore but produce independent APKs with different applicationIds

### Phone App Changes

- `AuthManager` now syncs tokens to paired watch on login/logout via `WearAuthSync`
- Added `play-services-wearable` dependency to the phone app

### Separate Play Store Deployment

The Wear OS app uses a distinct `applicationId` (`com.cabeda.convocados.wear`) so it can be published as a separate listing on the Play Store, independent of the phone app.

### Setup Required

Before the Google Sign-In works in production:
1. Set `SERVER_CLIENT_ID` in `WearGoogleSignIn.kt` to the same value as the `GOOGLE_CLIENT_ID` env var on the backend (the **web** client ID from Google Cloud Console → APIs & Services → Credentials)
2. Add the Wear OS app's SHA-1 fingerprint to the Google Cloud Console (same project as the phone app: `convocados-a24da`)
3. That's it — the backend already handles Google sign-in via better-auth's `socialProviders.google` config. No new endpoint needed.

### Tech Stack
- Kotlin + Jetpack Compose for Wear OS
- Hilt (DI), Room (offline DB), Ktor (networking), WorkManager (sync)
- Credential Manager + Google Identity Services (auth)
- Wearable Data Layer API (phone-to-watch token sync)
- better-auth social sign-in (existing backend infrastructure)
