### PR TITLE
fix: display event times in event timezone instead of browser timezone

### DIFF
--- a/src/components/EventPage.tsx
+++ b/src/components/EventPage.tsx
@@ -12,6 +12,7 @@ import type { Imatch } from "~/lib/random";
 import { useT } from "~/lib/useT";
 import { detectLocale } from "~/lib/i18n";
 import { addKnownName, getQjName } from "~/lib/knownNames";
+import { formatDateInTz } from "~/lib/timezones";
 import { useSession } from "~/lib/auth.client";
 
 import {
@@ -488,7 +489,7 @@ export default function EventPage({ eventId }: { eventId: string }) {
             {wasReset && (
               <Alert severity="info" icon={<EventRepeatIcon />}>
                 {t("recurringResetAlert", {
-                  date: gameDate.toLocaleDateString(locale === "pt" ? "pt-PT" : "en-GB", {
+                  date: formatDateInTz(gameDate, locale === "pt" ? "pt-PT" : "en-GB", event.timezone, {
                     weekday: "long", month: "long", day: "numeric",
                   }),
                 })}

--- a/src/components/GameCard.tsx
+++ b/src/components/GameCard.tsx
@@ -4,12 +4,14 @@ import LocationOnIcon from "@mui/icons-material/LocationOn";
 import AccessTimeIcon from "@mui/icons-material/AccessTime";
 import { detectLocale } from "~/lib/i18n";
 import { useT } from "~/lib/useT";
+import { formatDateInTz } from "~/lib/timezones";
 
 export interface GameSummary {
   id: string;
   title: string;
   location: string;
   dateTime: string;
+  timezone?: string;
   sport: string;
   maxPlayers: number;
   playerCount: number;
@@ -52,7 +54,7 @@ export function GameCard({ game, dimPast = false }: { game: GameSummary; dimPast
           <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
             <AccessTimeIcon fontSize="small" color="action" />
             <Typography variant="body2" color="text.secondary">
-              {date.toLocaleString(locale === "pt" ? "pt-PT" : "en-GB", {
+              {formatDateInTz(date, locale === "pt" ? "pt-PT" : "en-GB", game.timezone || "UTC", {
                 weekday: "short", month: "short", day: "numeric", hour: "2-digit", minute: "2-digit",
               })}
             </Typography>

--- a/src/components/HistoryPage.tsx
+++ b/src/components/HistoryPage.tsx
@@ -26,6 +26,7 @@ import { detectLocale } from "~/lib/i18n";
 import { useSession } from "~/lib/auth.client";
 import { matchesWithName } from "~/lib/stringMatch";
 import { computeGameUpdates, type EloUpdate } from "~/lib/elo";
+import { formatDateInTz } from "~/lib/timezones";
 import { ScoreRoller } from "./event/ScoreRoller";
 import { PlayerAutocomplete } from "./event/PlayerAutocomplete";
 
@@ -382,9 +383,11 @@ function HistoryCardFull({
   playerRatings,
   isOwner,
   userName,
+  timezone,
 }: {
   entry: HistoryEntry;
   eventId: string;
+  timezone: string;
   onUpdate: (updated: HistoryEntry) => void;
   onDelete: (id: string) => void;
   isAuthenticated: boolean;
@@ -633,12 +636,12 @@ function HistoryCardFull({
       }}>
         <Box>
           <Typography variant="h6" fontWeight={700} sx={{ lineHeight: 1.3 }}>
-            {date.toLocaleDateString(localeStr, {
+            {formatDateInTz(date, localeStr, timezone, {
               weekday: "long", day: "numeric", month: "long", year: "numeric",
             })}
           </Typography>
           <Typography variant="body2" color="text.secondary" sx={{ mt: 0.25 }}>
-            {date.toLocaleTimeString(localeStr, { hour: "2-digit", minute: "2-digit" })}
+            {formatDateInTz(date, localeStr, timezone, { hour: "2-digit", minute: "2-digit" })}
           </Typography>
         </Box>
         <Stack direction="row" spacing={1} alignItems="center">
@@ -1071,7 +1074,7 @@ function HistoryCardFull({
               </Button>
               <Typography variant="caption" color="text.disabled" sx={{ ml: "auto !important" }}>
                 {t("editableUntil", {
-                  date: editableUntil.toLocaleDateString(localeStr, {
+                  date: formatDateInTz(editableUntil, localeStr, timezone, {
                     day: "numeric", month: "short", year: "numeric",
                   }),
                 })}
@@ -1111,6 +1114,7 @@ export default function HistoryPage({ eventId }: { eventId: string }) {
   const [playerRatings, setPlayerRatings] = useState<{ name: string; rating: number; gamesPlayed: number }[]>([]);
   const [ownerId, setOwnerId] = useState<string | null>(null);
   const [isAdmin, setIsAdmin] = useState(false);
+  const [timezone, setTimezone] = useState("UTC");
   const [showAddHistorical, setShowAddHistorical] = useState(false);
   const isOwner = !!(session?.user && ownerId && session.user.id === ownerId);
 
@@ -1127,6 +1131,7 @@ export default function HistoryPage({ eventId }: { eventId: string }) {
     setTeamTwoName(ev.teamTwoName ?? "Team B");
     setOwnerId(ev.ownerId ?? null);
     setIsAdmin(!!ev.isAdmin);
+    setTimezone(ev.timezone || "UTC");
     setHistory(hist.data);
     setNextCursor(hist.nextCursor);
     setHasMore(hist.hasMore);
@@ -1249,7 +1254,7 @@ export default function HistoryPage({ eventId }: { eventId: string }) {
             ) : (
               <>
                 {history.map((entry) => (
-                  <HistoryCardFull key={entry.id} entry={entry} eventId={eventId} onUpdate={handleUpdate}
+                  <HistoryCardFull key={entry.id} entry={entry} eventId={eventId} timezone={timezone} onUpdate={handleUpdate}
                     onDelete={handleDelete} isAuthenticated={isAuthenticated} knownPlayers={knownPlayers}
                     playerRatings={playerRatings} isOwner={isOwner || isAdmin}
                     userName={session?.user?.name ?? null} />

--- a/src/components/PublicGamesPage.tsx
+++ b/src/components/PublicGamesPage.tsx
@@ -17,6 +17,7 @@ import { ResponsiveLayout } from "./ResponsiveLayout";
 import { useT } from "~/lib/useT";
 import { detectLocale } from "~/lib/i18n";
 import { getSportPreset } from "~/lib/sports";
+import { formatDateInTz } from "~/lib/timezones";
 
 interface PublicEvent {
   id: string;
@@ -26,6 +27,7 @@ interface PublicEvent {
   longitude: number | null;
   sport: string;
   dateTime: string;
+  timezone?: string;
   maxPlayers: number;
   playerCount: number;
   spotsLeft: number;
@@ -88,7 +90,7 @@ function CardView({ events, locale, t }: {
                 <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
                   <AccessTimeIcon fontSize="small" color="action" />
                   <Typography variant="body2" color="text.secondary">
-                    {date.toLocaleString(locale === "pt" ? "pt-PT" : "en-GB", {
+                    {formatDateInTz(date, locale === "pt" ? "pt-PT" : "en-GB", ev.timezone || "UTC", {
                       weekday: "short", month: "short", day: "numeric",
                       hour: "2-digit", minute: "2-digit",
                     })}
@@ -175,7 +177,7 @@ function TableView({ events, locale, t }: {
                 </TableCell>
                 <TableCell>
                   <Typography variant="body2" color="text.secondary" noWrap>
-                    {date.toLocaleString(locale === "pt" ? "pt-PT" : "en-GB", {
+                    {formatDateInTz(date, locale === "pt" ? "pt-PT" : "en-GB", ev.timezone || "UTC", {
                       weekday: "short", month: "short", day: "numeric",
                       hour: "2-digit", minute: "2-digit",
                     })}

--- a/src/components/event/EventHeader.tsx
+++ b/src/components/event/EventHeader.tsx
@@ -25,7 +25,7 @@ import { detectLocale } from "~/lib/i18n";
 import { describeRecurrenceRule, parseRecurrenceRule } from "~/lib/recurrence";
 import { getSportPreset, SPORT_PRESETS } from "~/lib/sports";
 import { googleCalendarUrl } from "~/lib/calendar";
-import { COMMON_TIMEZONES } from "~/lib/timezones";
+import { COMMON_TIMEZONES, formatDateInTz, toDateTimeLocalValue } from "~/lib/timezones";
 import type { EventData } from "./types";
 import type { Imatch } from "~/lib/random";
 import { ShareBar } from "./ShareBar";
@@ -97,7 +97,7 @@ export function EventHeader({
           if (!prev) {
             setTitleDraft(event.title);
             setLocationDraft(event.location || "");
-            setDateTimeDraft(event.dateTime.slice(0, 16));
+            setDateTimeDraft(toDateTimeLocalValue(new Date(event.dateTime), event.timezone || "UTC"));
             setTimezoneDraft(event.timezone || "UTC");
             setSportDraft(sport);
           }
@@ -123,7 +123,7 @@ export function EventHeader({
   const openEdit = () => {
     setTitleDraft(event.title);
     setLocationDraft(event.location || "");
-    setDateTimeDraft(event.dateTime.slice(0, 16));
+    setDateTimeDraft(toDateTimeLocalValue(new Date(event.dateTime), event.timezone || "UTC"));
     setTimezoneDraft(event.timezone || "UTC");
     setSportDraft(sport);
     setEditMode(true);
@@ -140,7 +140,7 @@ export function EventHeader({
     if (locationDraft !== event.location) {
       promises.push(onSaveLocation(locationDraft));
     }
-    if (dateTimeDraft !== event.dateTime.slice(0, 16) || timezoneDraft !== (event.timezone || "UTC")) {
+    if (dateTimeDraft !== toDateTimeLocalValue(new Date(event.dateTime), event.timezone || "UTC") || timezoneDraft !== (event.timezone || "UTC")) {
       promises.push(onSaveDateTime(dateTimeDraft, timezoneDraft));
     }
     if (sportDraft && sportDraft !== sport) {
@@ -160,7 +160,7 @@ export function EventHeader({
   const progressPct = event.maxPlayers > 0 ? (activePlayers / event.maxPlayers) * 100 : 0;
   const isFull = activePlayers >= event.maxPlayers;
 
-  const formattedDate = gameDate.toLocaleString(locale === "pt" ? "pt-PT" : "en-GB", {
+  const formattedDate = formatDateInTz(gameDate, locale === "pt" ? "pt-PT" : "en-GB", event.timezone, {
     weekday: "short", month: "short", day: "numeric", hour: "2-digit", minute: "2-digit",
   });
 
@@ -438,7 +438,7 @@ export function EventHeader({
             {/* ── Row 6: Actions ── */}
             <Box sx={{ display: "flex", gap: 1, alignItems: "center", flexWrap: "wrap" }}>
               <ShareBar
-                title={event.title} dateTime={gameDate} location={event.location}
+                title={event.title} dateTime={gameDate} timezone={event.timezone} location={event.location}
                 maxPlayers={event.maxPlayers} playerCount={event.players.length}
               />
 

--- a/src/components/event/ShareBar.tsx
+++ b/src/components/event/ShareBar.tsx
@@ -3,16 +3,18 @@ import { IconButton, Tooltip, Snackbar, Box, Typography } from "@mui/material";
 import ShareIcon from "@mui/icons-material/Share";
 import { useT } from "~/lib/useT";
 import { detectLocale } from "~/lib/i18n";
+import { formatDateInTz } from "~/lib/timezones";
 
 interface Props {
   title: string;
   dateTime: Date;
+  timezone: string;
   location?: string | null;
   maxPlayers: number;
   playerCount: number;
 }
 
-export function ShareBar({ title, dateTime, location, maxPlayers, playerCount }: Props) {
+export function ShareBar({ title, dateTime, timezone, location, maxPlayers, playerCount }: Props) {
   const t = useT();
   const locale = detectLocale();
   const [snackbar, setSnackbar] = useState<string | null>(null);
@@ -20,7 +22,7 @@ export function ShareBar({ title, dateTime, location, maxPlayers, playerCount }:
   const spotsLeft = maxPlayers - playerCount;
   const url = typeof window !== "undefined" ? window.location.href : "";
 
-  const formattedDate = dateTime.toLocaleString(locale === "pt" ? "pt-PT" : "en-GB", {
+  const formattedDate = formatDateInTz(dateTime, locale === "pt" ? "pt-PT" : "en-GB", timezone, {
     weekday: "long",
     hour: "2-digit",
     minute: "2-digit",

--- a/src/lib/timezones.ts
+++ b/src/lib/timezones.ts
@@ -52,3 +52,44 @@ export function detectTimezone(): string {
     return "UTC";
   }
 }
+
+/**
+ * Format a Date in a specific IANA timezone using toLocaleString.
+ * Passes `timeZone` into the Intl options so the formatted output reflects
+ * the event's timezone rather than the browser's local timezone.
+ */
+export function formatDateInTz(
+  date: Date,
+  locale: string,
+  timezone: string,
+  options: Intl.DateTimeFormatOptions = {},
+): string {
+  return date.toLocaleString(locale, { ...options, timeZone: timezone || "UTC" });
+}
+
+/**
+ * Convert a UTC Date to a `datetime-local` input value (YYYY-MM-DDTHH:mm)
+ * in the given IANA timezone.
+ *
+ * We use Intl.DateTimeFormat to extract the date/time parts in the target
+ * timezone, then assemble them into the format expected by `<input type="datetime-local">`.
+ */
+export function toDateTimeLocalValue(date: Date, timezone: string): string {
+  const tz = timezone || "UTC";
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone: tz,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).formatToParts(date);
+
+  const get = (type: Intl.DateTimeFormatPartTypes) =>
+    parts.find((p) => p.type === type)?.value ?? "00";
+
+  // en-CA gives YYYY-MM-DD ordering; hour may be "24" at midnight in some engines
+  const hour = get("hour") === "24" ? "00" : get("hour");
+  return `${get("year")}-${get("month")}-${get("day")}T${hour}:${get("minute")}`;
+}

--- a/src/pages/api/events/public.ts
+++ b/src/pages/api/events/public.ts
@@ -24,6 +24,7 @@ export const GET: APIRoute = async ({ request }) => {
     longitude: e.longitude,
     sport: e.sport,
     dateTime: e.dateTime.toISOString(),
+    timezone: e.timezone,
     maxPlayers: e.maxPlayers,
     playerCount: e.players.length,
     spotsLeft: Math.max(0, e.maxPlayers - e.players.length),

--- a/src/pages/api/me/games.ts
+++ b/src/pages/api/me/games.ts
@@ -21,6 +21,7 @@ export const GET: APIRoute = async ({ request }) => {
     title: true,
     location: true,
     dateTime: true,
+    timezone: true,
     sport: true,
     maxPlayers: true,
     archivedAt: true,

--- a/src/test/timezones.test.ts
+++ b/src/test/timezones.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from "vitest";
+import { formatDateInTz, toDateTimeLocalValue, detectTimezone } from "~/lib/timezones";
+
+describe("formatDateInTz", () => {
+  // 2024-07-15T19:00:00Z — summer, so Europe/Lisbon is UTC+1 (WEST)
+  const summerUtc = new Date("2024-07-15T19:00:00Z");
+
+  // 2024-01-15T19:00:00Z — winter, so Europe/Lisbon is UTC+0 (WET)
+  const winterUtc = new Date("2024-01-15T19:00:00Z");
+
+  it("formats time in the event timezone, not browser local", () => {
+    // 19:00 UTC in Europe/Lisbon during summer (UTC+1) should show 20:00
+    const result = formatDateInTz(summerUtc, "en-GB", "Europe/Lisbon", {
+      hour: "2-digit", minute: "2-digit",
+    });
+    expect(result).toContain("20:00");
+  });
+
+  it("formats time in UTC when timezone is UTC", () => {
+    const result = formatDateInTz(summerUtc, "en-GB", "UTC", {
+      hour: "2-digit", minute: "2-digit",
+    });
+    expect(result).toContain("19:00");
+  });
+
+  it("formats winter time correctly for Europe/Lisbon (UTC+0)", () => {
+    // 19:00 UTC in winter Lisbon (UTC+0) should show 19:00
+    const result = formatDateInTz(winterUtc, "en-GB", "Europe/Lisbon", {
+      hour: "2-digit", minute: "2-digit",
+    });
+    expect(result).toContain("19:00");
+  });
+
+  it("formats time in America/New_York (UTC-4 summer)", () => {
+    // 19:00 UTC in summer New York (UTC-4) should show 15:00
+    const result = formatDateInTz(summerUtc, "en-GB", "America/New_York", {
+      hour: "2-digit", minute: "2-digit",
+    });
+    expect(result).toContain("15:00");
+  });
+
+  it("includes date parts when requested", () => {
+    const result = formatDateInTz(summerUtc, "en-GB", "UTC", {
+      weekday: "short", month: "short", day: "numeric",
+    });
+    expect(result).toContain("Mon");
+    expect(result).toContain("15");
+    expect(result).toContain("Jul");
+  });
+
+  it("falls back to UTC for empty timezone string", () => {
+    const result = formatDateInTz(summerUtc, "en-GB", "", {
+      hour: "2-digit", minute: "2-digit",
+    });
+    expect(result).toContain("19:00");
+  });
+});
+
+describe("toDateTimeLocalValue", () => {
+  // 2024-07-15T19:00:00Z — summer
+  const summerUtc = new Date("2024-07-15T19:00:00Z");
+
+  it("converts UTC date to event timezone for datetime-local input", () => {
+    // 19:00 UTC in Europe/Lisbon summer (UTC+1) → 2024-07-15T20:00
+    const result = toDateTimeLocalValue(summerUtc, "Europe/Lisbon");
+    expect(result).toBe("2024-07-15T20:00");
+  });
+
+  it("returns UTC time when timezone is UTC", () => {
+    const result = toDateTimeLocalValue(summerUtc, "UTC");
+    expect(result).toBe("2024-07-15T19:00");
+  });
+
+  it("handles America/New_York (UTC-4 summer)", () => {
+    // 19:00 UTC → 15:00 EDT
+    const result = toDateTimeLocalValue(summerUtc, "America/New_York");
+    expect(result).toBe("2024-07-15T15:00");
+  });
+
+  it("handles date rollover across timezone boundary", () => {
+    // 2024-07-16T01:00:00Z in Asia/Tokyo (UTC+9) → 2024-07-16T10:00
+    const date = new Date("2024-07-16T01:00:00Z");
+    const result = toDateTimeLocalValue(date, "Asia/Tokyo");
+    expect(result).toBe("2024-07-16T10:00");
+  });
+
+  it("handles date rollback across timezone boundary", () => {
+    // 2024-07-16T02:00:00Z in America/Los_Angeles (UTC-7 summer) → 2024-07-15T19:00
+    const date = new Date("2024-07-16T02:00:00Z");
+    const result = toDateTimeLocalValue(date, "America/Los_Angeles");
+    expect(result).toBe("2024-07-15T19:00");
+  });
+
+  it("falls back to UTC for empty timezone", () => {
+    const result = toDateTimeLocalValue(summerUtc, "");
+    expect(result).toBe("2024-07-15T19:00");
+  });
+
+  it("winter Europe/Lisbon (UTC+0) keeps same time", () => {
+    const winterUtc = new Date("2024-01-15T19:00:00Z");
+    const result = toDateTimeLocalValue(winterUtc, "Europe/Lisbon");
+    expect(result).toBe("2024-01-15T19:00");
+  });
+});
+
+describe("detectTimezone", () => {
+  it("returns a non-empty string", () => {
+    const tz = detectTimezone();
+    expect(tz).toBeTruthy();
+    expect(typeof tz).toBe("string");
+  });
+});


### PR DESCRIPTION
## Bug

When an event is set to 19:00 Europe/Lisbon, the event page displays 20:00 during summer (WEST/UTC+1). The edit form correctly shows 19:00, creating a confusing inconsistency.

**Reported for**: https://convocados.fly.dev/events/cmmkfrx8b0000o2ixrix1yp2m

## Root Cause

The `dateTime` is stored as UTC in the database. The display code used `gameDate.toLocaleString()` which converts from UTC to the **browser's local timezone**, not the event's configured timezone. During summer, Europe/Lisbon is UTC+1, so 19:00 UTC was displayed as 20:00.

The edit form happened to show the correct time because it sliced the raw UTC ISO string (`event.dateTime.slice(0, 16)`), which coincidentally matched the intended time — but for the wrong reason.

## Fix

- Added `formatDateInTz(date, locale, timezone, options)` helper that passes `timeZone` to `Intl.DateTimeFormat`, ensuring dates are always formatted in the event's timezone
- Added `toDateTimeLocalValue(date, timezone)` helper that converts a UTC Date to a `datetime-local` input value in the correct timezone
- Updated all date display locations to use the event's timezone:
  - `EventHeader.tsx` — main event page time display + edit form
  - `EventPage.tsx` — recurring reset alert
  - `ShareBar.tsx` — share text
  - `HistoryPage.tsx` — game history dates
  - `GameCard.tsx` — game cards on user profile
  - `PublicGamesPage.tsx` — public games listing
- Added `timezone` field to public games and my-games API responses
- 14 new tests covering timezone formatting and datetime-local conversion

## Testing

- 1385 tests pass (84 files)
- 95%+ coverage maintained
- New `timezones.test.ts` covers: summer/winter DST transitions, cross-timezone formatting, date rollover across timezone boundaries, empty timezone fallback