### PR TITLE
fix: notification shows literal {title} and fires on unchanged datetime

### DIFF
--- a/src/components/event/EventHeader.tsx
+++ b/src/components/event/EventHeader.tsx
@@ -137,7 +137,7 @@ export function EventHeader({
     if (titleDraft.trim() && titleDraft.trim() !== event.title) {
       promises.push(onSaveTitle(titleDraft.trim()));
     }
-    if (locationDraft !== event.location) {
+    if (locationDraft !== (event.location || "")) {
       promises.push(onSaveLocation(locationDraft));
     }
     if (dateTimeDraft !== toDateTimeLocalValue(new Date(event.dateTime), event.timezone || "UTC") || timezoneDraft !== (event.timezone || "UTC")) {

--- a/src/pages/api/events/[id]/datetime.ts
+++ b/src/pages/api/events/[id]/datetime.ts
@@ -66,15 +66,16 @@ export const PUT: APIRoute = async ({ params, request }) => {
     },
   });
 
-  // Notify subscribers if dateTime changed
-  if (updates.dateTime) {
+  // Notify subscribers only if dateTime actually changed
+  const dateTimeActuallyChanged = updates.dateTime && updates.dateTime.getTime() !== event.dateTime.getTime();
+  if (dateTimeActuallyChanged) {
     const activePlayers = await prisma.player.count({ where: { eventId, archivedAt: null } });
     const spotsLeft = Math.max(0, event.maxPlayers - activePlayers);
     const url = `/events/${eventId}`;
     await enqueueNotification(eventId, "event_details", {
       title: event.title,
       key: "notifyEventDetailsChanged" as const,
-      params: {},
+      params: { title: event.title },
       url,
       spotsLeft,
     });


### PR DESCRIPTION
## Problem

1. Push notifications for event detail changes showed literal `{title}` instead of the actual event title (e.g. "Event details updated: {title}")
2. Notifications fired even when the dateTime value sent was identical to the stored value
3. The edit form triggered a spurious location save when `event.location` was `null` (compared against `""`)

## Fix

- **`datetime.ts`**: Pass `{ title: event.title }` in notification `params` so the i18n placeholder is interpolated
- **`datetime.ts`**: Only send notification when `updates.dateTime.getTime() !== event.dateTime.getTime()`
- **`EventHeader.tsx`**: Compare `locationDraft` against `event.location || ""` to avoid false positives

## Testing

- All 1385 tests pass
- Typecheck clean