### PR TITLE
fix: convert datetime-local value from event timezone to UTC before saving

### DIFF
--- a/src/components/EventPage.tsx
+++ b/src/components/EventPage.tsx
@@ -12,7 +12,7 @@ import type { Imatch } from "~/lib/random";
 import { useT } from "~/lib/useT";
 import { detectLocale } from "~/lib/i18n";
 import { addKnownName, getQjName } from "~/lib/knownNames";
-import { formatDateInTz } from "~/lib/timezones";
+import { formatDateInTz, fromDateTimeLocalValue } from "~/lib/timezones";
 import { useSession } from "~/lib/auth.client";
 
 import {
@@ -355,10 +355,12 @@ export default function EventPage({ eventId }: { eventId: string }) {
   };
 
   const handleSaveDateTime = async (dateTime: string, timezone: string) => {
+    // Convert the datetime-local value (in the event's timezone) to a UTC ISO string
+    const utcIso = fromDateTimeLocalValue(dateTime, timezone);
     await fetch(`/api/events/${eventId}/datetime`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ dateTime, timezone }),
+      body: JSON.stringify({ dateTime: utcIso, timezone }),
     });
     fetchEvent();
   };

--- a/src/lib/timezones.ts
+++ b/src/lib/timezones.ts
@@ -93,3 +93,51 @@ export function toDateTimeLocalValue(date: Date, timezone: string): string {
   const hour = get("hour") === "24" ? "00" : get("hour");
   return `${get("year")}-${get("month")}-${get("day")}T${hour}:${get("minute")}`;
 }
+
+/**
+ * Convert a `datetime-local` input value (YYYY-MM-DDTHH:mm) in a given IANA
+ * timezone back to a UTC ISO string suitable for the API.
+ *
+ * Uses a binary-search approach on the UTC offset: we create a candidate UTC
+ * Date, format it in the target timezone, and adjust until the formatted
+ * local time matches the desired input.
+ */
+export function fromDateTimeLocalValue(localValue: string, timezone: string): string {
+  const tz = timezone || "UTC";
+
+  // Parse the local value components
+  const [datePart, timePart] = localValue.split("T");
+  const [year, month, day] = datePart.split("-").map(Number);
+  const [hour, minute] = timePart.split(":").map(Number);
+
+  // Start with a naive UTC guess: treat the local value as if it were UTC
+  const naiveUtc = new Date(Date.UTC(year, month - 1, day, hour, minute, 0, 0));
+
+  // Format that guess in the target timezone to find the offset
+  const formatted = toDateTimeLocalValue(naiveUtc, tz);
+  const [fDatePart, fTimePart] = formatted.split("T");
+  const [fYear, fMonth, fDay] = fDatePart.split("-").map(Number);
+  const [fHour, fMinute] = fTimePart.split(":").map(Number);
+
+  // Compute the difference between what we got and what we wanted
+  const got = new Date(Date.UTC(fYear, fMonth - 1, fDay, fHour, fMinute, 0, 0));
+  const wanted = naiveUtc;
+  const offsetMs = got.getTime() - wanted.getTime();
+
+  // Adjust: if formatting added +1h (timezone is UTC+1), subtract that offset
+  const corrected = new Date(naiveUtc.getTime() - offsetMs);
+
+  // Verify the correction is accurate (handles DST edge cases)
+  const verify = toDateTimeLocalValue(corrected, tz);
+  if (verify !== localValue) {
+    // DST boundary edge case — try ±1h adjustments
+    for (const delta of [-3600000, 3600000]) {
+      const attempt = new Date(corrected.getTime() + delta);
+      if (toDateTimeLocalValue(attempt, tz) === localValue) {
+        return attempt.toISOString();
+      }
+    }
+  }
+
+  return corrected.toISOString();
+}

--- a/src/test/timezones.test.ts
+++ b/src/test/timezones.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { formatDateInTz, toDateTimeLocalValue, detectTimezone } from "~/lib/timezones";
+import { formatDateInTz, toDateTimeLocalValue, fromDateTimeLocalValue, detectTimezone } from "~/lib/timezones";
 
 describe("formatDateInTz", () => {
   // 2024-07-15T19:00:00Z — summer, so Europe/Lisbon is UTC+1 (WEST)
@@ -108,5 +108,67 @@ describe("detectTimezone", () => {
     const tz = detectTimezone();
     expect(tz).toBeTruthy();
     expect(typeof tz).toBe("string");
+  });
+});
+
+describe("fromDateTimeLocalValue", () => {
+  it("converts Lisbon summer time to UTC (UTC+1 → subtract 1h)", () => {
+    // 20:00 Lisbon summer (UTC+1) → 19:00 UTC
+    const result = fromDateTimeLocalValue("2024-07-15T20:00", "Europe/Lisbon");
+    expect(result).toBe("2024-07-15T19:00:00.000Z");
+  });
+
+  it("converts Lisbon winter time to UTC (UTC+0 → same)", () => {
+    // 19:00 Lisbon winter (UTC+0) → 19:00 UTC
+    const result = fromDateTimeLocalValue("2024-01-15T19:00", "Europe/Lisbon");
+    expect(result).toBe("2024-01-15T19:00:00.000Z");
+  });
+
+  it("converts UTC to UTC (no change)", () => {
+    const result = fromDateTimeLocalValue("2024-07-15T19:00", "UTC");
+    expect(result).toBe("2024-07-15T19:00:00.000Z");
+  });
+
+  it("converts New York summer time to UTC (UTC-4 → add 4h)", () => {
+    // 15:00 EDT (UTC-4) → 19:00 UTC
+    const result = fromDateTimeLocalValue("2024-07-15T15:00", "America/New_York");
+    expect(result).toBe("2024-07-15T19:00:00.000Z");
+  });
+
+  it("handles date rollover (Tokyo UTC+9)", () => {
+    // 10:00 JST (UTC+9) → 01:00 UTC same day
+    const result = fromDateTimeLocalValue("2024-07-16T10:00", "Asia/Tokyo");
+    expect(result).toBe("2024-07-16T01:00:00.000Z");
+  });
+
+  it("handles date rollback (LA UTC-7 summer)", () => {
+    // 19:00 PDT (UTC-7) on Jul 15 → 02:00 UTC on Jul 16
+    const result = fromDateTimeLocalValue("2024-07-15T19:00", "America/Los_Angeles");
+    expect(result).toBe("2024-07-16T02:00:00.000Z");
+  });
+
+  it("falls back to UTC for empty timezone", () => {
+    const result = fromDateTimeLocalValue("2024-07-15T19:00", "");
+    expect(result).toBe("2024-07-15T19:00:00.000Z");
+  });
+
+  it("round-trips with toDateTimeLocalValue", () => {
+    const original = new Date("2024-07-15T19:00:00.000Z");
+    const timezones = ["Europe/Lisbon", "America/New_York", "Asia/Tokyo", "UTC", "America/Los_Angeles"];
+    for (const tz of timezones) {
+      const local = toDateTimeLocalValue(original, tz);
+      const backToUtc = fromDateTimeLocalValue(local, tz);
+      expect(backToUtc).toBe(original.toISOString());
+    }
+  });
+
+  it("round-trips winter dates correctly", () => {
+    const original = new Date("2024-01-15T19:00:00.000Z");
+    const timezones = ["Europe/Lisbon", "America/New_York", "Asia/Tokyo", "UTC"];
+    for (const tz of timezones) {
+      const local = toDateTimeLocalValue(original, tz);
+      const backToUtc = fromDateTimeLocalValue(local, tz);
+      expect(backToUtc).toBe(original.toISOString());
+    }
   });
 });


### PR DESCRIPTION
## Problem

When editing an event's time, the `datetime-local` input correctly displays the time in the event's timezone (e.g. 19:00 Lisbon). But when saving, the raw value (`"2024-11-20T19:00"`) was sent to the API, which parsed it as UTC on the server (`new Date("2024-11-20T19:00")`). This caused the stored time to be off by the timezone offset.

For example: setting 19:00 in Europe/Lisbon (UTC+1 summer) stored `19:00 UTC` instead of `18:00 UTC`.

## Fix

- Add `fromDateTimeLocalValue(localValue, timezone)` in `timezones.ts` — the inverse of `toDateTimeLocalValue`. Converts a datetime-local string in a given IANA timezone back to a UTC ISO string.
- Use it in `handleSaveDateTime` (`EventPage.tsx`) to convert the local datetime to UTC before sending to the API.
- Add comprehensive round-trip tests for summer/winter across multiple timezones (Lisbon, New York, Tokyo, LA, UTC).

## Testing

- 1394 tests pass (9 new timezone tests)
- Typecheck clean
- Round-trip verified: `fromDateTimeLocalValue(toDateTimeLocalValue(date, tz), tz) === date.toISOString()`