### PR TITLE
ci: speed up Fly.io deploy with Docker Buildx + GitHub Actions cache

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,3 +10,13 @@ mobile/node_modules
 mobile/android
 mobile/ios
 mobile/.expo
+android-app
+bruno
+challenges
+coverage
+test-results
+.github
+.vscode
+.astro
+*.md
+!README.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -365,9 +365,25 @@ jobs:
         with:
           ref: v${{ needs.release.outputs.version }}
 
+      - uses: docker/setup-buildx-action@v3
+
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
+      - name: Authenticate to Fly registry
+        run: flyctl auth docker
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_DEPLOY_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: registry.fly.io/convocados:${{ needs.release.outputs.version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
       - name: Deploy to Fly.io
-        run: flyctl deploy --remote-only
+        run: flyctl deploy --image registry.fly.io/convocados:${{ needs.release.outputs.version }}
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_DEPLOY_TOKEN }}


### PR DESCRIPTION
## Problem

The deploy job uses `flyctl deploy --remote-only`, which builds the Docker image on Fly's remote builders with no persistent layer cache. Every deploy rebuilds everything from scratch — `pnpm install` twice, `prisma generate`, `astro build`, and the Litestream download.

## Solution

Build the Docker image locally in GitHub Actions using Docker Buildx with GitHub Actions cache, then deploy the pre-built image to Fly.

### Changes

- **`release.yml`**: Replace `flyctl deploy --remote-only` with:
  1. `docker/setup-buildx-action` — enables Buildx for multi-stage caching
  2. `flyctl auth docker` — authenticates to Fly's registry
  3. `docker/build-push-action` — builds with GHA cache (`type=gha,mode=max`), pushes to `registry.fly.io/convocados:<version>`
  4. `flyctl deploy --image` — deploys the pre-built image (no build on Fly)

- **`.dockerignore`**: Exclude `android-app/`, `bruno/`, `.github/`, `coverage/`, etc. to reduce build context size

### Expected improvement

On cached builds (lockfile unchanged):
- `deps` stage: fully cached (~30s saved)
- `prod-deps` stage: fully cached (~20s saved)
- Litestream download: cached (~5s saved)
- Only the Astro build + final COPY steps run

First build will be slower (populating cache), subsequent deploys should be significantly faster.

## Note

You'll need to verify that `flyctl auth docker` works with the existing `FLY_DEPLOY_TOKEN` secret. If it doesn't, you may need to use `flyctl auth token` or set the `FLY_API_TOKEN` env var for the Docker login step (which is already set).