### PR TITLE
feat: add hideEloInTeams setting and reorganize event settings

### DIFF
--- a/android-app/app/src/main/java/dev/convocados/data/api/ConvocadosApi.kt
+++ b/android-app/app/src/main/java/dev/convocados/data/api/ConvocadosApi.kt
@@ -73,6 +73,9 @@ class ConvocadosApi @Inject constructor(private val client: ApiClient) {
     suspend fun updateElo(eventId: String, enabled: Boolean): OkResponse =
         client.put("/api/events/$eventId/elo", EloRequest(enabled))
 
+    suspend fun updateHideEloInTeams(eventId: String, hide: Boolean): OkResponse =
+        client.put("/api/events/$eventId/hide-elo-in-teams", HideEloInTeamsRequest(hide))
+
     suspend fun updateSplitCosts(eventId: String, enabled: Boolean): OkResponse =
         client.put("/api/events/$eventId/split-costs", SplitCostsRequest(enabled))
 
@@ -167,6 +170,7 @@ data class CreateEventRequest(
 @Serializable data class MaxPlayersRequest(val maxPlayers: Int)
 @Serializable data class VisibilityRequest(val isPublic: Boolean)
 @Serializable data class EloRequest(val eloEnabled: Boolean)
+@Serializable data class HideEloInTeamsRequest(val hideEloInTeams: Boolean)
 @Serializable data class SplitCostsRequest(val splitCostsEnabled: Boolean)
 @Serializable data class PasswordRequest(val password: String?)
 @Serializable data class PasswordVerifyRequest(val password: String)

--- a/android-app/app/src/main/java/dev/convocados/data/api/Models.kt
+++ b/android-app/app/src/main/java/dev/convocados/data/api/Models.kt
@@ -74,6 +74,7 @@ data class EventDetail(
     val isAdmin: Boolean = false,
     val hasPassword: Boolean = false,
     val eloEnabled: Boolean = false,
+    val hideEloInTeams: Boolean = false,
     val splitCostsEnabled: Boolean = false,
     val balanced: Boolean = false,
     val archivedAt: String? = null,

--- a/android-app/app/src/main/java/dev/convocados/ui/screen/settings/EventSettingsScreen.kt
+++ b/android-app/app/src/main/java/dev/convocados/ui/screen/settings/EventSettingsScreen.kt
@@ -48,6 +48,7 @@ class EventSettingsViewModel @Inject constructor(private val api: ConvocadosApi)
     fun saveSport(id: String, s: String) = exec { api.updateSport(id, s); load(id) }
     fun togglePublic(id: String, v: Boolean) = exec { api.updateVisibility(id, v); load(id) }
     fun toggleElo(id: String, v: Boolean) = exec { api.updateElo(id, v); load(id) }
+    fun toggleHideEloInTeams(id: String, v: Boolean) = exec { api.updateHideEloInTeams(id, v); load(id) }
     fun toggleSplitCosts(id: String, v: Boolean) = exec { api.updateSplitCosts(id, v); load(id) }
     fun savePassword(id: String, pw: String?) = exec { api.updatePassword(id, pw); load(id) }
     fun archive(id: String) = exec { api.archiveEvent(id) }
@@ -74,6 +75,7 @@ fun EventSettingsScreen(
     var sport by remember(event) { mutableStateOf(event?.sport ?: "") }
     var isPublic by remember(event) { mutableStateOf(event?.isPublic ?: false) }
     var eloEnabled by remember(event) { mutableStateOf(event?.eloEnabled ?: false) }
+    var hideEloInTeams by remember(event) { mutableStateOf(event?.hideEloInTeams ?: false) }
     var splitCosts by remember(event) { mutableStateOf(event?.splitCostsEnabled ?: false) }
     var showPassword by remember { mutableStateOf(false) }
     var password by remember { mutableStateOf("") }
@@ -118,10 +120,17 @@ fun EventSettingsScreen(
                 }
             }
 
-            // Toggles
-            Spacer(Modifier.height(16.dp))
+            // General
+            SectionTitle("General")
             ToggleRow("Public game", isPublic) { isPublic = it; viewModel.togglePublic(eventId, it) }
+
+            // Teams & Ratings
+            SectionTitle("Teams & Ratings")
             ToggleRow("ELO ratings", eloEnabled) { eloEnabled = it; viewModel.toggleElo(eventId, it) }
+            ToggleRow("Hide ELO in teams", hideEloInTeams, enabled = ev.balanced) { hideEloInTeams = it; viewModel.toggleHideEloInTeams(eventId, it) }
+
+            // Features
+            SectionTitle("Features")
             ToggleRow("Split costs", splitCosts) { splitCosts = it; viewModel.toggleSplitCosts(eventId, it) }
 
             // Password
@@ -159,11 +168,11 @@ fun EventSettingsScreen(
 @Composable private fun NavButton(text: String, onClick: () -> Unit) = Card(colors = CardDefaults.cardColors(containerColor = Surface), modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp), onClick = onClick) { Text(text, color = TextPrimary, fontWeight = FontWeight.SemiBold, fontSize = 14.sp, modifier = Modifier.padding(14.dp)) }
 
 @Composable
-private fun ToggleRow(label: String, checked: Boolean, onCheckedChange: (Boolean) -> Unit) {
+private fun ToggleRow(label: String, checked: Boolean, enabled: Boolean = true, onCheckedChange: (Boolean) -> Unit) {
     Card(colors = CardDefaults.cardColors(containerColor = Surface), modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp)) {
         Row(Modifier.padding(14.dp), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.SpaceBetween) {
-            Text(label, color = TextPrimary, fontSize = 15.sp, modifier = Modifier.weight(1f))
-            Switch(checked = checked, onCheckedChange = onCheckedChange, colors = SwitchDefaults.colors(checkedThumbColor = Primary, checkedTrackColor = PrimaryDark))
+            Text(label, color = if (enabled) TextPrimary else TextSecondary, fontSize = 15.sp, modifier = Modifier.weight(1f))
+            Switch(checked = checked, onCheckedChange = onCheckedChange, enabled = enabled, colors = SwitchDefaults.colors(checkedThumbColor = Primary, checkedTrackColor = PrimaryDark))
         }
     }
 }

--- a/prisma/migrations/20260417120000_add_hide_elo_in_teams/migration.sql
+++ b/prisma/migrations/20260417120000_add_hide_elo_in_teams/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Event" ADD COLUMN "hideEloInTeams" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -126,6 +126,7 @@ model Event {
 
   // Rating settings
   eloEnabled        Boolean @default(true)
+  hideEloInTeams    Boolean @default(false)
   allowManualRating Boolean @default(false)
 
   // Cost tracking

--- a/src/components/EventPage.tsx
+++ b/src/components/EventPage.tsx
@@ -602,7 +602,7 @@ export default function EventPage({ eventId }: { eventId: string }) {
                         : m.team === event.teamTwoName ? teamTwoName : m.team,
                     }))}
                     onResultChange={handleTeamChange}
-                    ratingsMap={balanced ? ratingsMap : undefined}
+                    ratingsMap={balanced && !event.hideEloInTeams ? ratingsMap : undefined}
                     onTeamNameSave={canEditSettings ? (teamIdx, newName) => {
                       if (teamIdx === 0) {
                         setTeamOneName(newName);

--- a/src/components/EventSettingsPage.tsx
+++ b/src/components/EventSettingsPage.tsx
@@ -239,13 +239,18 @@ export default function EventSettingsPage({ eventId }: Props) {
   };
 
   const handleToggleElo = (v: boolean) => {
-    setEvent((e: any) => e ? { ...e, eloEnabled: v, ...(v ? {} : { balanced: false }) } : e);
+    setEvent((e: any) => e ? { ...e, eloEnabled: v, ...(v ? {} : { balanced: false, hideEloInTeams: false }) } : e);
     updateSetting("elo", { eloEnabled: v });
   };
 
   const handleToggleManualRating = (v: boolean) => {
     setEvent((e: any) => e ? { ...e, allowManualRating: v } : e);
     updateSetting("manual-rating", { allowManualRating: v });
+  };
+
+  const handleToggleHideEloInTeams = (v: boolean) => {
+    setEvent((e: any) => e ? { ...e, hideEloInTeams: v } : e);
+    updateSetting("hide-elo-in-teams", { hideEloInTeams: v });
   };
 
   const handleToggleSplitCosts = (v: boolean) => {
@@ -528,30 +533,6 @@ export default function EventSettingsPage({ eventId }: Props) {
                 label={<Typography variant="body2">{t("makePublic")}</Typography>}
               />
             </Tooltip>
-            <Tooltip title={t("eloEnabledTooltip")}>
-              <FormControlLabel
-                control={<Switch size="small" checked={event.eloEnabled ?? true} onChange={(e) => handleToggleElo(e.target.checked)} disabled={!canEdit} />}
-                label={<Typography variant="body2">{t("eloEnabled")}</Typography>}
-              />
-            </Tooltip>
-            <Tooltip title={t("balancedTeamsTooltip")}>
-              <FormControlLabel
-                control={<Switch size="small" checked={event.balanced} onChange={(e) => handleToggleBalanced(e.target.checked)} disabled={!canEdit || !(event.eloEnabled ?? true)} />}
-                label={<Typography variant="body2" color={!(event.eloEnabled ?? true) ? "text.disabled" : undefined}>{t("balancedTeams")}</Typography>}
-              />
-            </Tooltip>
-            <Tooltip title={t("splitCostsEnabledTooltip")}>
-              <FormControlLabel
-                control={<Switch size="small" checked={event.splitCostsEnabled ?? true} onChange={(e) => handleToggleSplitCosts(e.target.checked)} disabled={!canEdit} />}
-                label={<Typography variant="body2">{t("splitCostsEnabled")}</Typography>}
-              />
-            </Tooltip>
-            <Tooltip title={t("allowManualRatingTooltip")}>
-              <FormControlLabel
-                control={<Switch size="small" checked={event.allowManualRating ?? false} onChange={(e) => handleToggleManualRating(e.target.checked)} disabled={!canEdit || !(event.eloEnabled ?? true)} />}
-                label={<Typography variant="body2" color={!(event.eloEnabled ?? true) ? "text.disabled" : undefined}>{t("allowManualRating")}</Typography>}
-              />
-            </Tooltip>
           </Box>
           <Box>
             <Typography variant="body2" color="text.secondary" gutterBottom>{t("sport")}</Typography>
@@ -601,6 +582,48 @@ export default function EventSettingsPage({ eventId }: Props) {
             />
           </Box>
 
+        </Stack>
+      </SectionCard>
+
+      {/* ── Teams & Ratings ── */}
+      <SectionCard title={t("eventSettingsTeams")} icon={<StarIcon color="action" />}>
+        <Stack spacing={1}>
+          <Tooltip title={t("eloEnabledTooltip")}>
+            <FormControlLabel
+              control={<Switch size="small" checked={event.eloEnabled ?? true} onChange={(e) => handleToggleElo(e.target.checked)} disabled={!canEdit} />}
+              label={<Typography variant="body2">{t("eloEnabled")}</Typography>}
+            />
+          </Tooltip>
+          <Tooltip title={t("balancedTeamsTooltip")}>
+            <FormControlLabel
+              control={<Switch size="small" checked={event.balanced} onChange={(e) => handleToggleBalanced(e.target.checked)} disabled={!canEdit || !(event.eloEnabled ?? true)} />}
+              label={<Typography variant="body2" color={!(event.eloEnabled ?? true) ? "text.disabled" : undefined}>{t("balancedTeams")}</Typography>}
+            />
+          </Tooltip>
+          <Tooltip title={t("hideEloInTeamsTooltip")}>
+            <FormControlLabel
+              control={<Switch size="small" checked={event.hideEloInTeams ?? false} onChange={(e) => handleToggleHideEloInTeams(e.target.checked)} disabled={!canEdit || !event.balanced} />}
+              label={<Typography variant="body2" color={!event.balanced ? "text.disabled" : undefined}>{t("hideEloInTeams")}</Typography>}
+            />
+          </Tooltip>
+          <Tooltip title={t("allowManualRatingTooltip")}>
+            <FormControlLabel
+              control={<Switch size="small" checked={event.allowManualRating ?? false} onChange={(e) => handleToggleManualRating(e.target.checked)} disabled={!canEdit || !(event.eloEnabled ?? true)} />}
+              label={<Typography variant="body2" color={!(event.eloEnabled ?? true) ? "text.disabled" : undefined}>{t("allowManualRating")}</Typography>}
+            />
+          </Tooltip>
+        </Stack>
+      </SectionCard>
+
+      {/* ── Features ── */}
+      <SectionCard title={t("eventSettingsFeatures")} icon={<IntegrationInstructionsIcon color="action" />}>
+        <Stack spacing={1}>
+          <Tooltip title={t("splitCostsEnabledTooltip")}>
+            <FormControlLabel
+              control={<Switch size="small" checked={event.splitCostsEnabled ?? true} onChange={(e) => handleToggleSplitCosts(e.target.checked)} disabled={!canEdit} />}
+              label={<Typography variant="body2">{t("splitCostsEnabled")}</Typography>}
+            />
+          </Tooltip>
         </Stack>
       </SectionCard>
 

--- a/src/components/event/types.ts
+++ b/src/components/event/types.ts
@@ -29,6 +29,7 @@ export interface EventData {
   isPublic: boolean;
   balanced: boolean;
   eloEnabled: boolean;
+  hideEloInTeams: boolean;
   splitCostsEnabled: boolean;
   sport: string;
   recurrenceRule: string | null;

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -193,6 +193,8 @@ const de: TranslationKeys = {
   eloEnabledTooltip: "Spieler-Fähigkeitsbewertungen mit dem ELO-System verfolgen",
   balancedTeams: "ELO-ausgeglichene Teams",
   balancedTeamsTooltip: "ELO-Bewertungen verwenden, um Teams beim Zufallsmodus auszugleichen",
+  hideEloInTeams: "ELO in Teams ausblenden",
+  hideEloInTeamsTooltip: "ELO zum Ausgleichen verwenden, aber Bewertungen in der Teamansicht ausblenden",
   ratings: "Bewertungen",
   rating: "Rating",
   gamesPlayed: "Spiele",
@@ -319,6 +321,8 @@ const de: TranslationKeys = {
   eventSettings: "Event-Einstellungen",
   eventSettingsDesc: "Sichtbarkeit, Sportart, ausgeglichene Teams und Integrationen",
   eventSettingsGeneral: "Allgemein",
+  eventSettingsTeams: "Teams & Bewertungen",
+  eventSettingsFeatures: "Funktionen",
   settingsOwnerOnly: "Nur der Event-Besitzer kann auf die Einstellungen zugreifen.",
 
   // Access control

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -221,6 +221,8 @@ const en = {
   eloEnabledTooltip: "Track player skill ratings using the ELO system",
   balancedTeams: "ELO-balanced teams",
   balancedTeamsTooltip: "Use ELO ratings to balance teams when randomizing",
+  hideEloInTeams: "Hide ELO in teams",
+  hideEloInTeamsTooltip: "Use ELO to balance teams but hide ratings from the team view",
   ratings: "Ratings",
   rating: "Rating",
   gamesPlayed: "Games",
@@ -365,6 +367,8 @@ const en = {
   eventSettings: "Event Settings",
   eventSettingsDesc: "Visibility, sport, balanced teams, and integrations",
   eventSettingsGeneral: "General",
+  eventSettingsTeams: "Teams & Ratings",
+  eventSettingsFeatures: "Features",
   settingsOwnerOnly: "Only the event owner can access settings.",
 
   // Access control

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -193,6 +193,8 @@ const es: TranslationKeys = {
   eloEnabledTooltip: "Seguir las clasificaciones de habilidad de los jugadores usando el sistema ELO",
   balancedTeams: "Equipos equilibrados por ELO",
   balancedTeamsTooltip: "Usar clasificaciones ELO para equilibrar equipos al sortear",
+  hideEloInTeams: "Ocultar ELO en equipos",
+  hideEloInTeamsTooltip: "Usar ELO para equilibrar equipos pero ocultar las clasificaciones en la vista de equipos",
   ratings: "Clasificaciones",
   rating: "Rating",
   gamesPlayed: "Juegos",
@@ -319,6 +321,8 @@ const es: TranslationKeys = {
   eventSettings: "Configuración del Evento",
   eventSettingsDesc: "Visibilidad, deporte, equipos equilibrados e integraciones",
   eventSettingsGeneral: "General",
+  eventSettingsTeams: "Equipos y clasificaciones",
+  eventSettingsFeatures: "Funciones",
   settingsOwnerOnly: "Solo el propietario del evento puede acceder a la configuración.",
 
   // Access control

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -193,6 +193,8 @@ const fr: TranslationKeys = {
   eloEnabledTooltip: "Suivre les classements de compétence des joueurs avec le système ELO",
   balancedTeams: "Équipes équilibrées par ELO",
   balancedTeamsTooltip: "Utiliser les classements ELO pour équilibrer les équipes lors du tirage",
+  hideEloInTeams: "Masquer l'ELO dans les équipes",
+  hideEloInTeamsTooltip: "Utiliser l'ELO pour équilibrer les équipes mais masquer les classements dans la vue des équipes",
   ratings: "Classements",
   rating: "Rating",
   gamesPlayed: "Matchs",
@@ -319,6 +321,8 @@ const fr: TranslationKeys = {
   eventSettings: "Paramètres de l'Événement",
   eventSettingsDesc: "Visibilité, sport, équipes équilibrées et intégrations",
   eventSettingsGeneral: "Général",
+  eventSettingsTeams: "Équipes et classements",
+  eventSettingsFeatures: "Fonctionnalités",
   settingsOwnerOnly: "Seul le propriétaire de l'événement peut accéder aux paramètres.",
 
   // Access control

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -193,6 +193,8 @@ const it: TranslationKeys = {
   eloEnabledTooltip: "Traccia le classifiche di abilità dei giocatori usando il sistema ELO",
   balancedTeams: "Squadre bilanciate per ELO",
   balancedTeamsTooltip: "Usa le classifiche ELO per bilanciare le squadre durante il sorteggio",
+  hideEloInTeams: "Nascondi ELO nelle squadre",
+  hideEloInTeamsTooltip: "Usa l'ELO per bilanciare le squadre ma nascondi le classifiche nella vista delle squadre",
   ratings: "Classifiche",
   rating: "Rating",
   gamesPlayed: "Partite",
@@ -319,6 +321,8 @@ const it: TranslationKeys = {
   eventSettings: "Impostazioni Evento",
   eventSettingsDesc: "Visibilità, sport, squadre equilibrate e integrazioni",
   eventSettingsGeneral: "Generale",
+  eventSettingsTeams: "Squadre e classifiche",
+  eventSettingsFeatures: "Funzionalità",
   settingsOwnerOnly: "Solo il proprietario dell'evento può accedere alle impostazioni.",
 
   // Access control

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -222,6 +222,8 @@ const pt: TranslationKeys = {
   eloEnabledTooltip: "Acompanhar classificações de habilidade dos jogadores usando o sistema ELO",
   balancedTeams: "Equipas equilibradas por ELO",
   balancedTeamsTooltip: "Usar classificações ELO para equilibrar equipas ao sortear",
+  hideEloInTeams: "Esconder ELO nas equipas",
+  hideEloInTeamsTooltip: "Usar ELO para equilibrar equipas mas esconder classificações na vista de equipas",
   ratings: "Classificações",
   rating: "Rating",
   gamesPlayed: "Jogos",
@@ -366,6 +368,8 @@ const pt: TranslationKeys = {
   eventSettings: "Definições do Evento",
   eventSettingsDesc: "Visibilidade, desporto, equipas equilibradas e integrações",
   eventSettingsGeneral: "Geral",
+  eventSettingsTeams: "Equipas e classificações",
+  eventSettingsFeatures: "Funcionalidades",
   settingsOwnerOnly: "Apenas o dono do evento pode aceder às definições.",
 
   // Access control

--- a/src/pages/api/events/[id]/hide-elo-in-teams.ts
+++ b/src/pages/api/events/[id]/hide-elo-in-teams.ts
@@ -16,17 +16,12 @@ export const PUT: APIRoute = async ({ params, request }) => {
   }
 
   const body = await request.json();
-  const eloEnabled = Boolean(body.eloEnabled);
-
-  // When disabling ELO, also disable balanced teams and hide ELO in teams
-  const data: { eloEnabled: boolean; balanced?: boolean; hideEloInTeams?: boolean } = { eloEnabled };
-  if (!eloEnabled) { data.balanced = false; data.hideEloInTeams = false; }
+  const hideEloInTeams = Boolean(body.hideEloInTeams);
 
   await prisma.event.update({
     where: { id: params.id },
-    data,
+    data: { hideEloInTeams },
   });
 
-
-  return Response.json({ eloEnabled });
+  return Response.json({ hideEloInTeams });
 };

--- a/src/test/api-extended.test.ts
+++ b/src/test/api-extended.test.ts
@@ -12,6 +12,7 @@ import { GET as getHealth } from "~/pages/api/health";
 import { PUT as updateBalanced } from "~/pages/api/events/[id]/balanced";
 import { PUT as updateVisibility } from "~/pages/api/events/[id]/visibility";
 import { PUT as updateElo } from "~/pages/api/events/[id]/elo";
+import { PUT as updateHideEloInTeams } from "~/pages/api/events/[id]/hide-elo-in-teams";
 import { PUT as updateLocation } from "~/pages/api/events/[id]/location";
 import { PUT as updateTitle } from "~/pages/api/events/[id]/title";
 import { POST as claimOwnership, DELETE as relinquishOwnership } from "~/pages/api/events/[id]/claim";
@@ -180,6 +181,39 @@ describe("PUT /api/events/[id]/elo", () => {
     const id = await seedEvent({ ownerId: user.id });
     const res = await updateElo(putCtx({ id }, { eloEnabled: false }));
     expect(res.status).toBe(403);
+  });
+});
+
+// ─── PUT /api/events/[id]/hide-elo-in-teams ──────────────────────────────────
+
+describe("PUT /api/events/[id]/hide-elo-in-teams", () => {
+  it("toggles hideEloInTeams", async () => {
+    const id = await seedEvent();
+    const res = await updateHideEloInTeams(putCtx({ id }, { hideEloInTeams: true }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.hideEloInTeams).toBe(true);
+  });
+
+  it("returns 404 for unknown event", async () => {
+    const res = await updateHideEloInTeams(putCtx({ id: "nonexistent" }, { hideEloInTeams: true }));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 when event has owner and request is not from owner", async () => {
+    const user = await seedUser();
+    const id = await seedEvent({ ownerId: user.id });
+    const res = await updateHideEloInTeams(putCtx({ id }, { hideEloInTeams: true }));
+    expect(res.status).toBe(403);
+  });
+
+  it("disabling ELO also resets hideEloInTeams", async () => {
+    const id = await seedEvent();
+    await updateHideEloInTeams(putCtx({ id }, { hideEloInTeams: true }));
+    await updateElo(putCtx({ id }, { eloEnabled: false }));
+    const event = await prisma.event.findUnique({ where: { id } });
+    expect(event!.hideEloInTeams).toBe(false);
+    expect(event!.eloEnabled).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

Closes #301

Adds a new **Hide ELO in teams** toggle that allows balanced teams to use ELO ratings for team generation while hiding individual player ratings and team averages from the team view. Also reorganizes event settings into logical sections for better clarity.

## Changes

### New feature: Hide ELO in teams
- New `hideEloInTeams` boolean field on the Event model (defaults to `false`)
- New `PUT /api/events/[id]/hide-elo-in-teams` API endpoint
- When enabled, the TeamPicker no longer shows individual ELO ratings or team average ELO chips
- The toggle is only enabled when balanced teams mode is active
- Disabling ELO automatically resets both `balanced` and `hideEloInTeams`

### Reorganized event settings
- **Web**: Split the flat toggle list into three sections:
  - **General** — Public visibility, sport, game duration
  - **Teams & Ratings** — ELO ratings, balanced teams, hide ELO in teams, manual rating editing
  - **Features** — Cost splitting
- **Android**: Same section structure (General, Teams & Ratings, Features) with section headers

### Files changed
- `prisma/schema.prisma` + migration — new `hideEloInTeams` field
- `src/pages/api/events/[id]/hide-elo-in-teams.ts` — new endpoint
- `src/pages/api/events/[id]/elo.ts` — reset `hideEloInTeams` when disabling ELO
- `src/components/EventSettingsPage.tsx` — reorganized settings + new toggle
- `src/components/EventPage.tsx` — respect `hideEloInTeams` when passing ratings to TeamPicker
- `src/components/event/types.ts` — added `hideEloInTeams` to EventData interface
- All 6 i18n locale files — new translation keys
- Android: `Models.kt`, `ConvocadosApi.kt`, `EventSettingsScreen.kt` — new field + toggle + sections
- `src/test/api-extended.test.ts` — 4 new tests

### Testing
- All 1401 tests pass
- TypeScript typecheck passes
- 4 new tests covering the hide-elo-in-teams endpoint (toggle, 404, 403, cascade reset)