### PR TITLE
feat: landing page hero + move claim player to rankings page

### DIFF
--- a/android-app/app/src/main/java/dev/convocados/ui/screen/event/EventDetailScreen.kt
+++ b/android-app/app/src/main/java/dev/convocados/ui/screen/event/EventDetailScreen.kt
@@ -250,7 +250,6 @@ fun EventDetailScreen(
                 val isOwner = user?.id == event.ownerId
                 val myPlayer = user?.let { u -> event.players.find { it.name.equals(u.name, true) } }
                 val isOnBench = myPlayer != null && event.players.indexOf(myPlayer) >= event.maxPlayers
-                val canClaim = user != null && event.players.none { it.userId == user?.id }
                 val currentNames = event.players.map { it.name.lowercase() }.toSet()
                 val suggestions = state.knownPlayers.filter { it.name.lowercase() !in currentNames }.take(5)
 
@@ -393,9 +392,8 @@ fun EventDetailScreen(
                         SectionTitle("Playing (${activePlayers.size}/${event.maxPlayers})")
                         activePlayers.forEach { p ->
                             PlayerRow(
-                                player = p, isMe = p.userId == user?.id, canClaim = canClaim && p.userId == null,
+                                player = p, isMe = p.userId == user?.id,
                                 onRemove = { viewModel.removePlayer(eventId, p.id) },
-                                onClaim = { viewModel.claimPlayer(eventId, p.id) },
                                 canRemove = isOwner || p.userId == user?.id || p.userId == null,
                             )
                         }
@@ -468,8 +466,8 @@ fun SectionTitle(text: String) {
 @Composable
 fun PlayerRow(
     player: Player, isMe: Boolean = false, isBench: Boolean = false,
-    canClaim: Boolean = false, canRemove: Boolean = false,
-    onRemove: () -> Unit = {}, onClaim: () -> Unit = {},
+    canRemove: Boolean = false,
+    onRemove: () -> Unit = {},
 ) {
     Card(
         colors = CardDefaults.cardColors(containerColor = Surface),
@@ -481,9 +479,6 @@ fun PlayerRow(
                 color = if (isBench) TextMuted else TextPrimary, fontSize = 14.sp,
                 modifier = Modifier.weight(1f),
             )
-            if (canClaim) {
-                TextButton(onClick = onClaim) { Text("Claim", color = TextMuted, fontSize = 11.sp) }
-            }
             if (canRemove) {
                 IconButton(onClick = onRemove, modifier = Modifier.size(32.dp)) {
                     Icon(Icons.Default.Close, "Remove", tint = TextMuted, modifier = Modifier.size(16.dp))

--- a/android-app/app/src/main/java/dev/convocados/ui/screen/rankings/RankingsScreen.kt
+++ b/android-app/app/src/main/java/dev/convocados/ui/screen/rankings/RankingsScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.HowToReg
 import androidx.compose.material3.*
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.*
@@ -15,56 +16,201 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dev.convocados.data.api.ConvocadosApi
+import dev.convocados.data.api.EventDetail
+import dev.convocados.data.api.Player
 import dev.convocados.data.api.PlayerRating
+import dev.convocados.data.api.UserProfile
 import dev.convocados.ui.theme.*
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+data class RankingRow(
+    val name: String,
+    val rating: Int?,
+    val gamesPlayed: Int,
+    val wins: Int,
+    val draws: Int,
+    val losses: Int,
+    val playerId: String?,
+    val userId: String?,
+)
+
 @HiltViewModel
-class RankingsViewModel @Inject constructor(private val api: ConvocadosApi) : ViewModel() {
+class RankingsViewModel @Inject constructor(
+    private val api: ConvocadosApi,
+) : ViewModel() {
     private val _ratings = MutableStateFlow<List<PlayerRating>>(emptyList())
     val ratings: StateFlow<List<PlayerRating>> = _ratings
+    private val _event = MutableStateFlow<EventDetail?>(null)
+    val event: StateFlow<EventDetail?> = _event
     private val _loading = MutableStateFlow(true)
     val loading: StateFlow<Boolean> = _loading
+    private val _refreshing = MutableStateFlow(false)
+    val refreshing: StateFlow<Boolean> = _refreshing
+    private val _user = MutableStateFlow<UserProfile?>(null)
+    val user: StateFlow<UserProfile?> = _user
+
+    init {
+        viewModelScope.launch { runCatching { _user.value = api.fetchUserInfo() } }
+    }
 
     fun load(id: String) {
         viewModelScope.launch {
             _loading.value = true
-            runCatching { api.fetchRatings(id) }.onSuccess { _ratings.value = it.data }
+            val evResult = runCatching { api.fetchEvent(id) }
+            val ratResult = runCatching { api.fetchRatings(id) }
+            evResult.onSuccess { _event.value = it }
+            ratResult.onSuccess { _ratings.value = it.data }
             _loading.value = false
+            _refreshing.value = false
+        }
+    }
+
+    fun refresh(id: String) {
+        _refreshing.value = true
+        load(id)
+    }
+
+    fun claimPlayer(eventId: String, playerId: String) {
+        viewModelScope.launch {
+            runCatching { api.claimPlayer(eventId, playerId) }
+                .onSuccess { load(eventId) }
         }
     }
 }
 
+private fun mergeRows(
+    ratings: List<PlayerRating>,
+    players: List<Player>,
+): List<RankingRow> {
+    val seen = mutableSetOf<String>()
+    val rows = mutableListOf<RankingRow>()
+
+    for (r in ratings) {
+        val p = players.find { it.name.lowercase() == r.name.lowercase() }
+        rows.add(RankingRow(
+            name = r.name,
+            rating = r.rating,
+            gamesPlayed = r.gamesPlayed,
+            wins = r.wins,
+            draws = r.draws,
+            losses = r.losses,
+            playerId = p?.id,
+            userId = p?.userId,
+        ))
+        seen.add(r.name.lowercase())
+    }
+
+    for (p in players) {
+        if (p.name.lowercase() !in seen) {
+            rows.add(RankingRow(
+                name = p.name,
+                rating = null,
+                gamesPlayed = 0,
+                wins = 0,
+                draws = 0,
+                losses = 0,
+                playerId = p.id,
+                userId = p.userId,
+            ))
+        }
+    }
+
+    return rows
+}
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun RankingsScreen(eventId: String, onBack: () -> Unit, viewModel: RankingsViewModel = hiltViewModel()) {
-    val ratings by viewModel.ratings.collectAsState()
-    val loading by viewModel.loading.collectAsState()
+fun RankingsScreen(
+    eventId: String,
+    onBack: () -> Unit,
+    viewModel: RankingsViewModel = hiltViewModel(),
+) {
+    val ratings by viewModel.ratings.collectAsStateWithLifecycle()
+    val event by viewModel.event.collectAsStateWithLifecycle()
+    val loading by viewModel.loading.collectAsStateWithLifecycle()
+    val refreshing by viewModel.refreshing.collectAsStateWithLifecycle()
+    val user by viewModel.user.collectAsStateWithLifecycle()
+
     LaunchedEffect(eventId) { viewModel.load(eventId) }
 
+    val players = event?.players ?: emptyList()
+    val rows = mergeRows(ratings, players)
+    val userHasLinkedPlayer = user != null && players.any { it.userId == user?.id }
+
     Scaffold(
-        topBar = { TopAppBar(title = { Text("\uD83C\uDFC6 Rankings") }, navigationIcon = { IconButton(onClick = onBack) { Icon(Icons.AutoMirrored.Filled.ArrowBack, "Back") } }, colors = TopAppBarDefaults.topAppBarColors(containerColor = Bg)) },
+        topBar = {
+            TopAppBar(
+                title = { Text("\uD83C\uDFC6 Rankings") },
+                navigationIcon = { IconButton(onClick = onBack) { Icon(Icons.AutoMirrored.Filled.ArrowBack, "Back") } },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = Bg),
+            )
+        },
         containerColor = Bg,
     ) { padding ->
-        if (loading) { Box(Modifier.fillMaxSize().padding(padding), Alignment.Center) { CircularProgressIndicator(color = Primary) }; return@Scaffold }
-        if (ratings.isEmpty()) { Box(Modifier.fillMaxSize().padding(padding), Alignment.Center) { Text("No ratings yet", color = TextMuted) }; return@Scaffold }
+        if (loading) {
+            Box(Modifier.fillMaxSize().padding(padding), Alignment.Center) {
+                CircularProgressIndicator(color = Primary)
+            }
+            return@Scaffold
+        }
 
-        LazyColumn(contentPadding = PaddingValues(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.padding(padding)) {
-            itemsIndexed(ratings, key = { _, r -> r.id }) { index, r ->
-                Card(colors = CardDefaults.cardColors(containerColor = Surface), modifier = Modifier.fillMaxWidth()) {
-                    Row(Modifier.padding(14.dp), verticalAlignment = Alignment.CenterVertically) {
-                        Text("#${index + 1}", color = TextMuted, fontWeight = FontWeight.Bold, modifier = Modifier.width(28.dp))
-                        Column(Modifier.weight(1f)) {
-                            Text(r.name, color = TextPrimary, fontWeight = FontWeight.Bold, fontSize = 15.sp)
-                            Text("${r.gamesPlayed}g · W${r.wins}/D${r.draws}/L${r.losses}", color = TextSecondary, fontSize = 12.sp)
+        if (rows.isEmpty()) {
+            Box(Modifier.fillMaxSize().padding(padding), Alignment.Center) {
+                Text("No ratings yet", color = TextMuted)
+            }
+            return@Scaffold
+        }
+
+        PullToRefreshBox(
+            isRefreshing = refreshing,
+            onRefresh = { viewModel.refresh(eventId) },
+            modifier = Modifier.fillMaxSize().padding(padding),
+        ) {
+            LazyColumn(contentPadding = PaddingValues(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                itemsIndexed(rows, key = { _, r -> r.name }) { index, r ->
+                    val canClaim = user != null && !userHasLinkedPlayer && r.userId == null && r.playerId != null
+
+                    Card(colors = CardDefaults.cardColors(containerColor = Surface), modifier = Modifier.fillMaxWidth()) {
+                        Row(Modifier.padding(14.dp), verticalAlignment = Alignment.CenterVertically) {
+                            Text("#${index + 1}", color = TextMuted, fontWeight = FontWeight.Bold, modifier = Modifier.width(28.dp))
+                            Column(Modifier.weight(1f)) {
+                                Text(r.name, color = TextPrimary, fontWeight = FontWeight.Bold, fontSize = 15.sp)
+                                if (r.rating != null) {
+                                    Text("${r.gamesPlayed}g \u00B7 W${r.wins}/D${r.draws}/L${r.losses}", color = TextSecondary, fontSize = 12.sp)
+                                } else {
+                                    Text("New player", color = TextSecondary, fontSize = 12.sp)
+                                }
+                            }
+                            if (r.rating != null) {
+                                Text(
+                                    "${r.rating}",
+                                    color = when {
+                                        r.rating >= 1200 -> Success
+                                        r.rating >= 1000 -> Primary
+                                        else -> Warning
+                                    },
+                                    fontSize = 16.sp,
+                                    fontWeight = FontWeight.ExtraBold,
+                                )
+                            } else {
+                                Text("\u2014", color = TextMuted, fontSize = 16.sp, fontWeight = FontWeight.ExtraBold)
+                            }
+                            if (canClaim) {
+                                IconButton(
+                                    onClick = { viewModel.claimPlayer(eventId, r.playerId!!) },
+                                    modifier = Modifier.size(36.dp).padding(start = 8.dp),
+                                ) {
+                                    Icon(Icons.Default.HowToReg, "Claim as me", tint = Primary, modifier = Modifier.size(24.dp))
+                                }
+                            }
                         }
-                        Text("${r.rating}", color = when { r.rating >= 1200 -> Success; r.rating >= 1000 -> Primary; else -> Warning }, fontSize = 16.sp, fontWeight = FontWeight.ExtraBold)
                     }
                 }
             }

--- a/android-app/app/src/main/java/dev/convocados/ui/screen/rankings/RankingsScreen.kt
+++ b/android-app/app/src/main/java/dev/convocados/ui/screen/rankings/RankingsScreen.kt
@@ -144,6 +144,9 @@ fun RankingsScreen(
     val rows = mergeRows(ratings, players)
     val userHasLinkedPlayer = user != null && players.any { it.userId == user?.id }
 
+    // Claim confirmation dialog state
+    var claimTarget by remember { mutableStateOf<RankingRow?>(null) }
+
     Scaffold(
         topBar = {
             TopAppBar(
@@ -203,9 +206,10 @@ fun RankingsScreen(
                                 Text("\u2014", color = TextMuted, fontSize = 16.sp, fontWeight = FontWeight.ExtraBold)
                             }
                             if (canClaim) {
+                                Spacer(Modifier.width(8.dp))
                                 IconButton(
-                                    onClick = { viewModel.claimPlayer(eventId, r.playerId!!) },
-                                    modifier = Modifier.size(36.dp).padding(start = 8.dp),
+                                    onClick = { claimTarget = r },
+                                    modifier = Modifier.size(48.dp),
                                 ) {
                                     Icon(Icons.Default.HowToReg, "Claim as me", tint = Primary, modifier = Modifier.size(24.dp))
                                 }
@@ -215,5 +219,29 @@ fun RankingsScreen(
                 }
             }
         }
+    }
+
+    // Claim player confirmation dialog
+    claimTarget?.let { target ->
+        AlertDialog(
+            onDismissRequest = { claimTarget = null },
+            title = { Text("Claim player", color = TextPrimary) },
+            text = {
+                Text(
+                    "Are you sure you want to claim \"${target.name}\"? This player will be linked to your account.",
+                    color = TextSecondary,
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    target.playerId?.let { viewModel.claimPlayer(eventId, it) }
+                    claimTarget = null
+                }) { Text("Claim", color = Primary, fontWeight = FontWeight.Bold) }
+            },
+            dismissButton = {
+                TextButton(onClick = { claimTarget = null }) { Text("Cancel", color = TextMuted) }
+            },
+            containerColor = Surface,
+        )
     }
 }

--- a/e2e/notifications.spec.ts
+++ b/e2e/notifications.spec.ts
@@ -161,9 +161,11 @@ test.describe("Snackbar notifications", () => {
     await page.goto(`/events/${eventId}`);
     await expect(page.locator("text=AnonymousPlayer")).toBeVisible({ timeout: 10_000 });
 
-    // Look for the "It's me" / claim button on the anonymous player
-    // This appears as a small button or icon next to unclaimed players for authenticated users
-    const claimBtn = page.locator('button:has-text("It\'s me"), button[aria-label*="claim"], button[aria-label*="Claim"]').first();
+    // Look for the "Claim as me" button in the rankings page
+    await page.goto(`/events/${eventId}/rankings`);
+    await expect(page.locator("text=AnonymousPlayer")).toBeVisible({ timeout: 10_000 });
+
+    const claimBtn = page.locator('button:has-text("Claim as me"), button[aria-label*="claim"], button[aria-label*="Claim"]').first();
 
     if (await claimBtn.isVisible({ timeout: 3_000 }).catch(() => false)) {
       await claimBtn.click();

--- a/src/components/CreateEventForm.tsx
+++ b/src/components/CreateEventForm.tsx
@@ -56,7 +56,7 @@ function minDateTime() {
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
 }
 
-export default function CreateEventForm() {
+export default function CreateEventForm({ bare }: { bare?: boolean }) {
   const t = useT();
   const locale = detectLocale();
   const [title, setTitle] = useState(() => getRandomTitle(locale as TitleLocale));
@@ -150,11 +150,11 @@ export default function CreateEventForm() {
     window.location.href = `/events/${json.id}`;
   };
 
-  return (
-    <ThemeModeProvider>
-      <ResponsiveLayout>
+  const inner = (
+    <>
         <Container maxWidth="sm" sx={{ py: 6 }}>
           <Stack spacing={4}>
+            {!bare && (
             <Box textAlign="center">
               <SportsIcon sx={{ fontSize: 56, color: "primary.main", mb: 1 }} />
               <Typography variant="h4" fontWeight={700}>{t("createGame")}</Typography>
@@ -162,6 +162,7 @@ export default function CreateEventForm() {
                 {t("createGameSubtitle")}
               </Typography>
             </Box>
+            )}
 
             <Paper elevation={2} sx={{ borderRadius: 3, p: { xs: 3, sm: 4 } }}>
               <form onSubmit={handleSubmit}>
@@ -425,6 +426,15 @@ export default function CreateEventForm() {
             setLocationCoord(coord ? { lat: coord.lat, lon: coord.lng } : undefined);
           }}
         />
+    </>
+  );
+
+  if (bare) return inner;
+
+  return (
+    <ThemeModeProvider>
+      <ResponsiveLayout>
+        {inner}
       </ResponsiveLayout>
     </ThemeModeProvider>
   );

--- a/src/components/CreateEventForm.tsx
+++ b/src/components/CreateEventForm.tsx
@@ -152,7 +152,7 @@ export default function CreateEventForm({ bare }: { bare?: boolean }) {
 
   const inner = (
     <>
-        <Container maxWidth="sm" sx={{ py: 6 }}>
+        <Container maxWidth="sm" sx={{ py: bare ? { xs: 1, md: 3 } : 6 }}>
           <Stack spacing={4}>
             {!bare && (
             <Box textAlign="center">

--- a/src/components/EventPage.tsx
+++ b/src/components/EventPage.tsx
@@ -42,8 +42,6 @@ export default function EventPage({ eventId }: { eventId: string }) {
   const [isPublic, setIsPublic] = useState(false);
   const [sport, setSport] = useState("football-5v5");
   const [relinquishConfirmOpen, setRelinquishConfirmOpen] = useState(false);
-  const [claimPlayerConfirmOpen, setClaimPlayerConfirmOpen] = useState(false);
-  const [playerToClaim, setPlayerToClaim] = useState<{ id: string; name: string } | null>(null);
   const [postGameStatus, setPostGameStatus] = useState<PostGameStatus | null>(null);
   const [paymentExpanded, setPaymentExpanded] = useState<boolean | undefined>(undefined);
   const [bannerRefreshKey, setBannerRefreshKey] = useState(0);
@@ -248,31 +246,6 @@ export default function EventPage({ eventId }: { eventId: string }) {
     return () => clearTimeout(timer);
   }, [undoData]);
 
-  // ── Claim player ────────────────────────────────────────────────────────────
-
-  const handleClaimPlayerConfirm = async () => {
-    if (!playerToClaim) return;
-    setClaimPlayerConfirmOpen(false);
-    const res = await fetch(`/api/events/${eventId}/claim-player`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ playerId: playerToClaim.id }),
-    });
-    if (res.ok) {
-      setSnackbar(t("claimPlayerSuccess"));
-      fetchEvent();
-    } else {
-      const json = await res.json();
-      setPlayerError(json.error);
-    }
-    setPlayerToClaim(null);
-  };
-
-  const openClaimPlayerDialog = (playerId: string, playerName: string) => {
-    setPlayerToClaim({ id: playerId, name: playerName });
-    setClaimPlayerConfirmOpen(true);
-  };
-
   // ── Player reorder ──────────────────────────────────────────────────────────
 
   const reorderPlayers = useCallback(async (reorderedIds: string[]) => {
@@ -403,8 +376,6 @@ export default function EventPage({ eventId }: { eventId: string }) {
   const isOwnerless = !event?.ownerId;
   const isAdmin = !!event?.isAdmin;
   const canEditSettings = isOwnerless || isOwner || isAdmin;
-  const userHasLinkedPlayer = isAuthenticated && (event?.players ?? []).some((p: any) => p.userId === session.user.id);
-  const canClaimPlayer = isAuthenticated && !userHasLinkedPlayer;
 
   const canRemovePlayer = (player: Player) => {
     if (isOwner || isAdmin) return true;
@@ -575,7 +546,6 @@ export default function EventPage({ eventId }: { eventId: string }) {
               players={event.players}
               maxPlayers={event.maxPlayers}
               isOwner={isOwner}
-              canClaimPlayer={canClaimPlayer}
               hasTeams={!!(localMatches && localMatches.length > 0)}
               availableSuggestions={availableSuggestions}
               playerError={playerError}
@@ -586,7 +556,6 @@ export default function EventPage({ eventId }: { eventId: string }) {
               onResetPlayerOrder={resetPlayerOrder}
               onRandomize={doRandomize}
               onConfirmReRandomize={() => setConfirmOpen(true)}
-              onOpenClaimPlayerDialog={openClaimPlayerDialog}
               canRemovePlayer={canRemovePlayer}
             />
 
@@ -627,10 +596,6 @@ export default function EventPage({ eventId }: { eventId: string }) {
           relinquishConfirmOpen={relinquishConfirmOpen}
           onRelinquishClose={() => setRelinquishConfirmOpen(false)}
           onRelinquishConfirm={handleRelinquishOwnership}
-          claimPlayerConfirmOpen={claimPlayerConfirmOpen}
-          playerToClaim={playerToClaim}
-          onClaimPlayerClose={() => { setClaimPlayerConfirmOpen(false); setPlayerToClaim(null); }}
-          onClaimPlayerConfirm={handleClaimPlayerConfirm}
           snackbar={snackbar}
           onSnackbarClose={() => setSnackbar(null)}
           undoData={undoData}

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -30,9 +30,8 @@ function HeroContent() {
       display: "flex",
       flexDirection: "column",
       justifyContent: "center",
-      py: isMobile ? 3 : 6,
+      py: isMobile ? 3 : 4,
       px: isMobile ? 2 : 4,
-      minHeight: isMobile ? undefined : "60vh",
     }}>
       <Typography
         variant={isMobile ? "h4" : "h3"}
@@ -103,7 +102,7 @@ export default function LandingPage() {
     <Box sx={{
       display: "flex",
       flexDirection: isMobile ? "column" : "row",
-      alignItems: isMobile ? "stretch" : "flex-start",
+      alignItems: isMobile ? "stretch" : "center",
       maxWidth: 1200,
       mx: "auto",
       width: "100%",

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -1,0 +1,136 @@
+import React from "react";
+import {
+  Box, Typography, Stack, useTheme, useMediaQuery, Chip,
+} from "@mui/material";
+import CasinoIcon from "@mui/icons-material/Casino";
+import PaymentsIcon from "@mui/icons-material/Payments";
+import EmojiEventsIcon from "@mui/icons-material/EmojiEvents";
+import NotificationsActiveIcon from "@mui/icons-material/NotificationsActive";
+import AlarmIcon from "@mui/icons-material/Alarm";
+import { ThemeModeProvider } from "./ThemeModeProvider";
+import { ResponsiveLayout } from "./ResponsiveLayout";
+import CreateEventForm from "./CreateEventForm";
+import { useT } from "~/lib/useT";
+
+const FEATURES = [
+  { icon: CasinoIcon, key: "landingFeatureTeams" },
+  { icon: PaymentsIcon, key: "landingFeaturePayments" },
+  { icon: EmojiEventsIcon, key: "landingFeatureRankings" },
+  { icon: NotificationsActiveIcon, key: "landingFeatureNotifications" },
+  { icon: AlarmIcon, key: "landingFeatureReminders" },
+] as const;
+
+function HeroContent() {
+  const t = useT();
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("md"));
+
+  return (
+    <Box sx={{
+      display: "flex",
+      flexDirection: "column",
+      justifyContent: "center",
+      py: isMobile ? 3 : 6,
+      px: isMobile ? 2 : 4,
+      minHeight: isMobile ? undefined : "60vh",
+    }}>
+      <Typography
+        variant={isMobile ? "h4" : "h3"}
+        component="h1"
+        sx={{
+          fontWeight: 800,
+          lineHeight: 1.15,
+          mb: 1.5,
+          color: theme.palette.text.primary,
+        }}
+      >
+        {t("landingHeadline")}
+      </Typography>
+
+      <Typography
+        variant={isMobile ? "body1" : "h6"}
+        sx={{
+          color: theme.palette.text.secondary,
+          fontWeight: 400,
+          mb: 3,
+          maxWidth: 420,
+        }}
+      >
+        {t("landingSubtitle")}
+      </Typography>
+
+      {isMobile ? (
+        <Stack direction="row" spacing={1} sx={{ flexWrap: "wrap", gap: 1, mb: 2 }}>
+          {FEATURES.map(({ icon: Icon, key }) => (
+            <Chip
+              key={key}
+              icon={<Icon sx={{ fontSize: 16 }} />}
+              label={t(key as any)}
+              size="small"
+              variant="outlined"
+              sx={{ borderColor: theme.palette.primary.main, color: theme.palette.text.secondary, fontSize: "0.75rem" }}
+            />
+          ))}
+        </Stack>
+      ) : (
+        <Stack spacing={1.5} sx={{ mb: 4 }}>
+          {FEATURES.map(({ icon: Icon, key }) => (
+            <Stack key={key} direction="row" spacing={1.5} alignItems="center">
+              <Icon sx={{ color: theme.palette.primary.main, fontSize: 22 }} />
+              <Typography variant="body1" color="text.secondary">
+                {t(key as any)}
+              </Typography>
+            </Stack>
+          ))}
+        </Stack>
+      )}
+
+      <Typography
+        variant="caption"
+        sx={{ color: theme.palette.text.disabled, letterSpacing: 0.5 }}
+      >
+        {t("landingOpenSource")}
+      </Typography>
+    </Box>
+  );
+}
+
+export default function LandingPage() {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("md"));
+
+  return (
+    <Box sx={{
+      display: "flex",
+      flexDirection: isMobile ? "column" : "row",
+      alignItems: isMobile ? "stretch" : "flex-start",
+      maxWidth: 1200,
+      mx: "auto",
+      width: "100%",
+    }}>
+      <Box sx={{
+        flex: isMobile ? "none" : "0 0 42%",
+        position: isMobile ? "static" : "sticky",
+        top: 64,
+      }}>
+        <HeroContent />
+      </Box>
+      <Box sx={{
+        flex: isMobile ? "none" : 1,
+        minWidth: 0,
+      }}>
+        <CreateEventForm bare />
+      </Box>
+    </Box>
+  );
+}
+
+export function LandingPageWithProviders() {
+  return (
+    <ThemeModeProvider>
+      <ResponsiveLayout>
+        <LandingPage />
+      </ResponsiveLayout>
+    </ThemeModeProvider>
+  );
+}

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -30,16 +30,16 @@ function HeroContent() {
       display: "flex",
       flexDirection: "column",
       justifyContent: "center",
-      py: isMobile ? 3 : 4,
+      py: isMobile ? 2 : 4,
       px: isMobile ? 2 : 4,
     }}>
       <Typography
-        variant={isMobile ? "h4" : "h3"}
+        variant={isMobile ? "h5" : "h3"}
         component="h1"
         sx={{
           fontWeight: 800,
           lineHeight: 1.15,
-          mb: 1.5,
+          mb: 1,
           color: theme.palette.text.primary,
         }}
       >
@@ -47,11 +47,11 @@ function HeroContent() {
       </Typography>
 
       <Typography
-        variant={isMobile ? "body1" : "h6"}
+        variant={isMobile ? "body2" : "h6"}
         sx={{
           color: theme.palette.text.secondary,
           fontWeight: 400,
-          mb: 3,
+          mb: isMobile ? 1.5 : 3,
           maxWidth: 420,
         }}
       >
@@ -59,15 +59,15 @@ function HeroContent() {
       </Typography>
 
       {isMobile ? (
-        <Stack direction="row" spacing={1} sx={{ flexWrap: "wrap", gap: 1, mb: 2 }}>
+        <Stack direction="row" sx={{ flexWrap: "wrap", gap: 0.75, mb: 1 }}>
           {FEATURES.map(({ icon: Icon, key }) => (
             <Chip
               key={key}
-              icon={<Icon sx={{ fontSize: 16 }} />}
+              icon={<Icon sx={{ fontSize: 14 }} />}
               label={t(key as any)}
               size="small"
               variant="outlined"
-              sx={{ borderColor: theme.palette.primary.main, color: theme.palette.text.secondary, fontSize: "0.75rem" }}
+              sx={{ borderColor: theme.palette.primary.main, color: theme.palette.text.secondary, fontSize: "0.7rem", height: 26 }}
             />
           ))}
         </Stack>
@@ -84,12 +84,14 @@ function HeroContent() {
         </Stack>
       )}
 
-      <Typography
-        variant="caption"
-        sx={{ color: theme.palette.text.disabled, letterSpacing: 0.5 }}
-      >
-        {t("landingOpenSource")}
-      </Typography>
+      {!isMobile && (
+        <Typography
+          variant="caption"
+          sx={{ color: theme.palette.text.disabled, letterSpacing: 0.5 }}
+        >
+          {t("landingOpenSource")}
+        </Typography>
+      )}
     </Box>
   );
 }
@@ -103,14 +105,14 @@ export default function LandingPage() {
       display: "flex",
       flexDirection: isMobile ? "column" : "row",
       alignItems: isMobile ? "stretch" : "center",
+      justifyContent: "center",
+      minHeight: isMobile ? undefined : "calc(100vh - 130px)",
       maxWidth: 1200,
       mx: "auto",
       width: "100%",
     }}>
       <Box sx={{
         flex: isMobile ? "none" : "0 0 42%",
-        position: isMobile ? "static" : "sticky",
-        top: 64,
       }}>
         <HeroContent />
       </Box>

--- a/src/components/RankingsPage.tsx
+++ b/src/components/RankingsPage.tsx
@@ -326,7 +326,7 @@ export default function RankingsPage({ eventId }: { eventId: string }) {
                         <TableCell align="center" sx={{ fontWeight: 700, color: "success.main" }}>{t("wins")}</TableCell>
                         <TableCell align="center" sx={{ fontWeight: 700, color: "text.secondary" }}>{t("draws")}</TableCell>
                         <TableCell align="center" sx={{ fontWeight: 700, color: "error.main" }}>{t("losses")}</TableCell>
-                        {showActionsCol && <TableCell sx={{ width: 72 }} />}
+                        {showActionsCol && <TableCell sx={{ width: 110 }} />}
                       </TableRow>
                     </TableHead>
                     <TableBody>
@@ -399,28 +399,30 @@ export default function RankingsPage({ eventId }: { eventId: string }) {
                               <Typography variant="body2" color="error.main" fontWeight={600}>{r.losses}</Typography>
                             </TableCell>
                             {showActionsCol && (
-                              <TableCell align="center" sx={{ px: 0.5 }}>
-                                {isUnclaimed && r.playerId && (
-                                  <Tooltip title={t("claimPlayer")}>
-                                    <IconButton size="small" color="primary" onClick={() => setClaimTarget({ id: r.playerId!, name: r.name })}>
-                                      <HowToRegIcon sx={{ fontSize: 20 }} />
-                                    </IconButton>
-                                  </Tooltip>
-                                )}
-                                {canEdit && r.rating != null && (
-                                  <Tooltip title={t("setInitialRating")}>
-                                    <IconButton size="small" onClick={() => openEditDialog(r as PlayerRating)}>
-                                      <EditIcon sx={{ fontSize: 18 }} />
-                                    </IconButton>
-                                  </Tooltip>
-                                )}
-                                {canManage && (
-                                  <Tooltip title={t("purgePlayer")}>
-                                    <IconButton size="small" color="error" onClick={() => setPurgeTarget(r.name)}>
-                                      <DeleteIcon sx={{ fontSize: 18 }} />
-                                    </IconButton>
-                                  </Tooltip>
-                                )}
+                              <TableCell align="right" sx={{ px: 0.5 }}>
+                                <Box sx={{ display: "inline-flex", alignItems: "center", gap: 0.25 }}>
+                                  {isUnclaimed && r.playerId && (
+                                    <Tooltip title={t("claimPlayer")}>
+                                      <IconButton size="small" color="primary" onClick={() => setClaimTarget({ id: r.playerId!, name: r.name })}>
+                                        <HowToRegIcon sx={{ fontSize: 20 }} />
+                                      </IconButton>
+                                    </Tooltip>
+                                  )}
+                                  {canEdit && r.rating != null && (
+                                    <Tooltip title={t("setInitialRating")}>
+                                      <IconButton size="small" onClick={() => openEditDialog(r as PlayerRating)}>
+                                        <EditIcon sx={{ fontSize: 20 }} />
+                                      </IconButton>
+                                    </Tooltip>
+                                  )}
+                                  {canManage && (
+                                    <Tooltip title={t("purgePlayer")}>
+                                      <IconButton size="small" color="error" sx={{ ml: 0.5 }} onClick={() => setPurgeTarget(r.name)}>
+                                        <DeleteIcon sx={{ fontSize: 20 }} />
+                                      </IconButton>
+                                    </Tooltip>
+                                  )}
+                                </Box>
                               </TableCell>
                             )}
                           </TableRow>

--- a/src/components/RankingsPage.tsx
+++ b/src/components/RankingsPage.tsx
@@ -3,12 +3,13 @@ import {
   Container, Paper, Typography, Box, Stack, Chip, Button, Avatar,
   CircularProgress, alpha, useTheme, IconButton, Tooltip, Snackbar, Alert,
   Table, TableBody, TableCell, TableContainer, TableHead, TableRow,
-  Dialog, DialogTitle, DialogContent, DialogActions, TextField,
+  Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions, TextField,
 } from "@mui/material";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import EmojiEventsIcon from "@mui/icons-material/EmojiEvents";
 import EditIcon from "@mui/icons-material/Edit";
 import DeleteIcon from "@mui/icons-material/Delete";
+import HowToRegIcon from "@mui/icons-material/HowToReg";
 import { ThemeModeProvider } from "./ThemeModeProvider";
 import { ResponsiveLayout } from "./ResponsiveLayout";
 import { useT } from "~/lib/useT";
@@ -24,6 +25,24 @@ interface PlayerRating {
   losses: number;
 }
 
+interface EventPlayer {
+  id: string;
+  name: string;
+  userId: string | null;
+}
+
+interface TableRowData {
+  name: string;
+  rating: number | null;
+  initialRating: number | null;
+  gamesPlayed: number;
+  wins: number;
+  draws: number;
+  losses: number;
+  playerId: string | null;
+  userId: string | null;
+}
+
 const PODIUM_COLORS = ["#FFD700", "#C0C0C0", "#CD7F32"] as const;
 
 export default function RankingsPage({ eventId }: { eventId: string }) {
@@ -32,6 +51,7 @@ export default function RankingsPage({ eventId }: { eventId: string }) {
   const { data: session } = useSession();
   const [title, setTitle] = useState("");
   const [ratings, setRatings] = useState<PlayerRating[]>([]);
+  const [players, setPlayers] = useState<EventPlayer[]>([]);
   const [loading, setLoading] = useState(true);
   const [notFound, setNotFound] = useState(false);
   const [nextCursor, setNextCursor] = useState<string | null>(null);
@@ -51,6 +71,10 @@ export default function RankingsPage({ eventId }: { eventId: string }) {
   const [purgeTarget, setPurgeTarget] = useState<string | null>(null);
   const [purging, setPurging] = useState(false);
 
+  // Claim player state
+  const [claimTarget, setClaimTarget] = useState<{ id: string; name: string } | null>(null);
+  const [claiming, setClaiming] = useState(false);
+
   const load = useCallback(async () => {
     const [evRes, ratRes] = await Promise.all([
       fetch(`/api/events/${eventId}`),
@@ -63,7 +87,7 @@ export default function RankingsPage({ eventId }: { eventId: string }) {
     setRatings(rat.data);
     setNextCursor(rat.nextCursor);
     setHasMore(rat.hasMore);
-    // Owner or admin can edit ratings (only if allowManualRating is enabled)
+    setPlayers((ev.players ?? []).map((p: any) => ({ id: p.id, name: p.name, userId: p.userId ?? null })));
     const isOwner = !!(session?.user && ev.ownerId && session.user.id === ev.ownerId);
     const hasEditPermission = isOwner || ev.isAdmin || !ev.ownerId;
     setCanEdit(hasEditPermission && !!ev.allowManualRating);
@@ -91,7 +115,6 @@ export default function RankingsPage({ eventId }: { eventId: string }) {
       const data = await res.json();
       if (res.ok) {
         setSnack({ msg: t("ratingsRecalculated", { n: data.gamesProcessed }), severity: "success" });
-        // Reload ratings
         const ratRes = await fetch(`/api/events/${eventId}/ratings`);
         const rat = ratRes.ok ? await ratRes.json() : { data: [], nextCursor: null, hasMore: false };
         setRatings(rat.data);
@@ -148,7 +171,6 @@ export default function RankingsPage({ eventId }: { eventId: string }) {
       if (res.ok) {
         const msg = data.needsRecalculate ? t("initialRatingNeedsRecalculate") : t("initialRatingSaved");
         setSnack({ msg, severity: "success" });
-        // Update local state
         setRatings((prev) => prev.map((r) =>
           r.name === editPlayer
             ? { ...r, rating: data.rating, initialRating: data.initialRating }
@@ -163,6 +185,77 @@ export default function RankingsPage({ eventId }: { eventId: string }) {
     }
     setSaving(false);
   };
+
+  const handleClaimPlayer = async () => {
+    if (!claimTarget) return;
+    setClaiming(true);
+    try {
+      const res = await fetch(`/api/events/${eventId}/claim-player`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ playerId: claimTarget.id }),
+      });
+      if (res.ok) {
+        setSnack({ msg: t("claimPlayerSuccess"), severity: "success" });
+        setClaimTarget(null);
+        load();
+      } else {
+        const data = await res.json();
+        setSnack({ msg: data.error || "Error", severity: "error" });
+        setClaimTarget(null);
+      }
+    } catch {
+      setSnack({ msg: "Error", severity: "error" });
+      setClaimTarget(null);
+    }
+    setClaiming(false);
+  };
+
+  const isAuthenticated = !!session?.user;
+  const userHasLinkedPlayer = isAuthenticated && players.some((p) => p.userId === session!.user!.id);
+  const canClaimPlayer = isAuthenticated && !userHasLinkedPlayer;
+
+  const playerByName = new Map(players.map((p) => [p.name, p]));
+
+  const tableRows: TableRowData[] = (() => {
+    const ratingByName = new Map(ratings.map((r) => [r.name, r]));
+    const rows: TableRowData[] = [];
+    const seen = new Set<string>();
+
+    for (const r of ratings) {
+      const p = playerByName.get(r.name);
+      rows.push({
+        name: r.name,
+        rating: r.rating,
+        initialRating: r.initialRating,
+        gamesPlayed: r.gamesPlayed,
+        wins: r.wins,
+        draws: r.draws,
+        losses: r.losses,
+        playerId: p?.id ?? null,
+        userId: p?.userId ?? null,
+      });
+      seen.add(r.name.toLowerCase());
+    }
+
+    for (const p of players) {
+      if (!seen.has(p.name.toLowerCase())) {
+        rows.push({
+          name: p.name,
+          rating: null,
+          initialRating: null,
+          gamesPlayed: 0,
+          wins: 0,
+          draws: 0,
+          losses: 0,
+          playerId: p.id,
+          userId: p.userId,
+        });
+      }
+    }
+
+    return rows;
+  })();
 
   if (loading) return (
     <ThemeModeProvider>
@@ -186,6 +279,7 @@ export default function RankingsPage({ eventId }: { eventId: string }) {
   );
 
   const editError = editValue !== "" && (isNaN(parseInt(editValue, 10)) || parseInt(editValue, 10) < 500 || parseInt(editValue, 10) > 1500);
+  const showActionsCol = canEdit || canManage || canClaimPlayer;
 
   return (
     <ThemeModeProvider>
@@ -214,7 +308,7 @@ export default function RankingsPage({ eventId }: { eventId: string }) {
               )}
             </Box>
 
-            {ratings.length === 0 ? (
+            {tableRows.length === 0 ? (
               <Paper elevation={2} sx={{ borderRadius: 3, p: 4, textAlign: "center" }}>
                 <EmojiEventsIcon sx={{ fontSize: 48, color: "text.disabled", mb: 1 }} />
                 <Typography variant="h6" color="text.secondary">{t("noRatings")}</Typography>
@@ -232,26 +326,26 @@ export default function RankingsPage({ eventId }: { eventId: string }) {
                         <TableCell align="center" sx={{ fontWeight: 700, color: "success.main" }}>{t("wins")}</TableCell>
                         <TableCell align="center" sx={{ fontWeight: 700, color: "text.secondary" }}>{t("draws")}</TableCell>
                         <TableCell align="center" sx={{ fontWeight: 700, color: "error.main" }}>{t("losses")}</TableCell>
-                        {canEdit && <TableCell sx={{ width: 48 }} />}
-                        {!canEdit && canManage && <TableCell sx={{ width: 48 }} />}
+                        {showActionsCol && <TableCell sx={{ width: 72 }} />}
                       </TableRow>
                     </TableHead>
                     <TableBody>
-                      {ratings.map((r, i) => {
-                        const podiumColor = i < 3 ? PODIUM_COLORS[i] : undefined;
+                      {tableRows.map((r, i) => {
+                        const podiumColor = i < 3 && r.rating != null ? PODIUM_COLORS[i] : undefined;
+                        const isUnclaimed = canClaimPlayer && r.playerId && !r.userId;
                         return (
                           <TableRow
                             key={r.name}
                             sx={{
                               "&:last-child td": { borderBottom: 0 },
-                              bgcolor: i < 3 ? alpha(podiumColor!, 0.06) : undefined,
+                              bgcolor: podiumColor ? alpha(podiumColor, 0.06) : undefined,
                             }}
                           >
                             <TableCell>
-                              {i < 3 ? (
+                              {podiumColor ? (
                                 <Avatar sx={{
                                   width: 28, height: 28, fontSize: "0.8rem", fontWeight: 700,
-                                  bgcolor: alpha(podiumColor!, 0.25),
+                                  bgcolor: alpha(podiumColor, 0.25),
                                   color: theme.palette.text.primary,
                                 }}>
                                   {i + 1}
@@ -263,22 +357,26 @@ export default function RankingsPage({ eventId }: { eventId: string }) {
                               )}
                             </TableCell>
                             <TableCell>
-                              <Typography variant="body2" fontWeight={i < 3 ? 700 : 500}>
+                              <Typography variant="body2" fontWeight={podiumColor ? 700 : 500}>
                                 {r.name}
                               </Typography>
                             </TableCell>
                             <TableCell align="center">
                               <Box sx={{ display: "flex", alignItems: "center", justifyContent: "center", gap: 0.5 }}>
-                                <Chip
-                                  label={Math.round(r.rating)}
-                                  size="small"
-                                  variant="outlined"
-                                  sx={{
-                                    fontWeight: 700, fontSize: "0.8rem", minWidth: 52,
-                                    bgcolor: alpha(theme.palette.primary.main, 0.1),
-                                    borderColor: alpha(theme.palette.primary.main, 0.2),
-                                  }}
-                                />
+                                {r.rating != null ? (
+                                  <Chip
+                                    label={Math.round(r.rating)}
+                                    size="small"
+                                    variant="outlined"
+                                    sx={{
+                                      fontWeight: 700, fontSize: "0.8rem", minWidth: 52,
+                                      bgcolor: alpha(theme.palette.primary.main, 0.1),
+                                      borderColor: alpha(theme.palette.primary.main, 0.2),
+                                    }}
+                                  />
+                                ) : (
+                                  <Typography variant="body2" color="text.secondary">—</Typography>
+                                )}
                                 {r.initialRating != null && (
                                   <Tooltip title={`${t("initialRating")}: ${r.initialRating}`}>
                                     <Typography variant="caption" color="text.secondary" sx={{ fontSize: "0.65rem" }}>
@@ -300,19 +398,26 @@ export default function RankingsPage({ eventId }: { eventId: string }) {
                             <TableCell align="center">
                               <Typography variant="body2" color="error.main" fontWeight={600}>{r.losses}</Typography>
                             </TableCell>
-                            {(canEdit || canManage) && (
+                            {showActionsCol && (
                               <TableCell align="center" sx={{ px: 0.5 }}>
-                                {canEdit && (
+                                {isUnclaimed && r.playerId && (
+                                  <Tooltip title={t("claimPlayer")}>
+                                    <IconButton size="small" color="primary" onClick={() => setClaimTarget({ id: r.playerId!, name: r.name })}>
+                                      <HowToRegIcon sx={{ fontSize: 20 }} />
+                                    </IconButton>
+                                  </Tooltip>
+                                )}
+                                {canEdit && r.rating != null && (
                                   <Tooltip title={t("setInitialRating")}>
-                                    <IconButton size="small" onClick={() => openEditDialog(r)}>
-                                      <EditIcon sx={{ fontSize: 16 }} />
+                                    <IconButton size="small" onClick={() => openEditDialog(r as PlayerRating)}>
+                                      <EditIcon sx={{ fontSize: 18 }} />
                                     </IconButton>
                                   </Tooltip>
                                 )}
                                 {canManage && (
                                   <Tooltip title={t("purgePlayer")}>
                                     <IconButton size="small" color="error" onClick={() => setPurgeTarget(r.name)}>
-                                      <DeleteIcon sx={{ fontSize: 16 }} />
+                                      <DeleteIcon sx={{ fontSize: 18 }} />
                                     </IconButton>
                                   </Tooltip>
                                 )}
@@ -336,6 +441,22 @@ export default function RankingsPage({ eventId }: { eventId: string }) {
             )}
           </Stack>
         </Container>
+
+        {/* Claim player confirmation dialog */}
+        <Dialog open={!!claimTarget} onClose={() => !claiming && setClaimTarget(null)} maxWidth="xs" fullWidth>
+          <DialogTitle>{t("claimPlayerTitle")}</DialogTitle>
+          <DialogContent>
+            <DialogContentText>
+              {t("claimPlayerConfirmDesc", { name: claimTarget?.name ?? "" })}
+            </DialogContentText>
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={() => setClaimTarget(null)} disabled={claiming}>{t("cancel")}</Button>
+            <Button variant="contained" onClick={handleClaimPlayer} disabled={claiming}>
+              {t("claimPlayer")}
+            </Button>
+          </DialogActions>
+        </Dialog>
 
         {/* Purge player confirmation dialog */}
         <Dialog open={!!purgeTarget} onClose={() => !purging && setPurgeTarget(null)} maxWidth="xs" fullWidth>

--- a/src/components/ResponsiveLayout.tsx
+++ b/src/components/ResponsiveLayout.tsx
@@ -403,7 +403,7 @@ export const ResponsiveLayout: React.FC<{ children: React.ReactNode }> = ({ chil
                 <Button
                   color="inherit"
                   component="a"
-                  href={`/auth/signin?callbackURL=${encodeURIComponent(window.location.pathname + window.location.search)}`}
+                  href={`/auth/signin?callbackURL=${encodeURIComponent(window.location.pathname === "/" ? "/dashboard" : window.location.pathname + window.location.search)}`}
                   size="small"
                   sx={{ textTransform: "none", fontWeight: 600 }}
                 >

--- a/src/components/SignInPage.tsx
+++ b/src/components/SignInPage.tsx
@@ -24,16 +24,22 @@ export default function SignInPage() {
   const [loading, setLoading] = useState(false);
   const [magicLinkSent, setMagicLinkSent] = useState(false);
 
-  const callbackURL = typeof window !== "undefined"
+  const rawCallback = typeof window !== "undefined"
     ? new URLSearchParams(window.location.search).get("callbackURL") || "/"
     : "/";
+
+  // Sanitize callbackURL: only allow relative paths to prevent open redirects
+  const callbackURL = rawCallback.startsWith("/") && !rawCallback.startsWith("//") ? rawCallback : "/";
+
+  // Compute the safe post-login destination
+  const postLoginURL = callbackURL === "/" ? "/dashboard" : callbackURL;
 
   // Redirect already-authenticated users
   React.useEffect(() => {
     if (!isPending && session?.user) {
-      window.location.href = callbackURL === "/" ? "/dashboard" : callbackURL;
+      window.location.href = postLoginURL;
     }
-  }, [isPending, session, callbackURL]);
+  }, [isPending, session, postLoginURL]);
 
   const handlePasswordSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -51,7 +57,7 @@ export default function SignInPage() {
           setError(t("authError"));
         }
       } else {
-        window.location.href = callbackURL === "/" ? "/dashboard" : callbackURL;
+        window.location.href = postLoginURL;
       }
     } catch {
       setError(t("authError"));

--- a/src/components/SignInPage.tsx
+++ b/src/components/SignInPage.tsx
@@ -7,7 +7,7 @@ import EmailIcon from "@mui/icons-material/Email";
 import { ThemeModeProvider } from "./ThemeModeProvider";
 import { ResponsiveLayout } from "./ResponsiveLayout";
 import { useT } from "~/lib/useT";
-import { signIn } from "~/lib/auth.client";
+import { signIn, useSession } from "~/lib/auth.client";
 
 function TabPanel({ children, value, index }: { children: React.ReactNode; value: number; index: number }) {
   return value === index ? <Box>{children}</Box> : null;
@@ -15,6 +15,7 @@ function TabPanel({ children, value, index }: { children: React.ReactNode; value
 
 export default function SignInPage() {
   const t = useT();
+  const { data: session, isPending } = useSession();
   const [tab, setTab] = useState(0);
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -26,6 +27,13 @@ export default function SignInPage() {
   const callbackURL = typeof window !== "undefined"
     ? new URLSearchParams(window.location.search).get("callbackURL") || "/"
     : "/";
+
+  // Redirect already-authenticated users
+  React.useEffect(() => {
+    if (!isPending && session?.user) {
+      window.location.href = callbackURL === "/" ? "/dashboard" : callbackURL;
+    }
+  }, [isPending, session, callbackURL]);
 
   const handlePasswordSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -43,7 +51,7 @@ export default function SignInPage() {
           setError(t("authError"));
         }
       } else {
-        window.location.href = callbackURL;
+        window.location.href = callbackURL === "/" ? "/dashboard" : callbackURL;
       }
     } catch {
       setError(t("authError"));

--- a/src/components/event/EventDialogs.tsx
+++ b/src/components/event/EventDialogs.tsx
@@ -14,11 +14,6 @@ interface Props {
   relinquishConfirmOpen: boolean;
   onRelinquishClose: () => void;
   onRelinquishConfirm: () => void;
-  // Claim player
-  claimPlayerConfirmOpen: boolean;
-  playerToClaim: { id: string; name: string } | null;
-  onClaimPlayerClose: () => void;
-  onClaimPlayerConfirm: () => void;
   // Snackbar
   snackbar: string | null;
   onSnackbarClose: () => void;
@@ -31,7 +26,6 @@ interface Props {
 export function EventDialogs({
   confirmOpen, onConfirmClose, onConfirmRandomize,
   relinquishConfirmOpen, onRelinquishClose, onRelinquishConfirm,
-  claimPlayerConfirmOpen, playerToClaim, onClaimPlayerClose, onClaimPlayerConfirm,
   snackbar, onSnackbarClose,
   undoData, onUndoDismiss, onUndo,
 }: Props) {
@@ -60,22 +54,6 @@ export function EventDialogs({
           <Button onClick={onRelinquishClose}>{t("cancelEdit")}</Button>
           <Button onClick={onRelinquishConfirm} color="warning" variant="contained">
             {t("relinquishOwnership")}
-          </Button>
-        </DialogActions>
-      </Dialog>
-
-      {/* Claim player confirmation */}
-      <Dialog open={claimPlayerConfirmOpen} onClose={onClaimPlayerClose}>
-        <DialogTitle>{t("claimPlayerTitle")}</DialogTitle>
-        <DialogContent>
-          <DialogContentText>
-            {t("claimPlayerConfirmDesc", { name: playerToClaim?.name || "" })}
-          </DialogContentText>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={onClaimPlayerClose}>{t("cancel")}</Button>
-          <Button onClick={onClaimPlayerConfirm} variant="contained">
-            {t("claimPlayer")}
           </Button>
         </DialogActions>
       </Dialog>

--- a/src/components/event/PlayerList.tsx
+++ b/src/components/event/PlayerList.tsx
@@ -25,7 +25,6 @@ interface Props {
   players: Player[];
   maxPlayers: number;
   isOwner: boolean;
-  canClaimPlayer: boolean;
   hasTeams: boolean;
   availableSuggestions: PlayerSuggestion[];
   playerError: string | null;
@@ -36,15 +35,14 @@ interface Props {
   onResetPlayerOrder: () => Promise<void>;
   onRandomize: () => void;
   onConfirmReRandomize: () => void;
-  onOpenClaimPlayerDialog: (playerId: string, playerName: string) => void;
   canRemovePlayer: (player: Player) => boolean;
 }
 
 export function PlayerList({
-  players, maxPlayers, isOwner, canClaimPlayer, hasTeams,
+  players, maxPlayers, isOwner, hasTeams,
   availableSuggestions, playerError, onPlayerErrorChange,
   onAddPlayer, onRemovePlayer, onReorderPlayers, onResetPlayerOrder,
-  onRandomize, onConfirmReRandomize, onOpenClaimPlayerDialog, canRemovePlayer,
+  onRandomize, onConfirmReRandomize, canRemovePlayer,
 }: Props) {
   const t = useT();
   const theme = useTheme();
@@ -267,27 +265,18 @@ export function PlayerList({
                     <DragIndicatorIcon fontSize="small" sx={{ color: "text.disabled", mr: 0.5, flexShrink: 0 }} />
                   )}
                   {player.userId ? (
-                    <Tooltip title={t("protectedPlayer")}>
-                      <ShieldIcon fontSize="small" sx={{ color: "primary.main", mr: 0.5, flexShrink: 0 }} />
-                    </Tooltip>
-                  ) : canClaimPlayer ? (
-                    <Chip
-                      label={t("thisIsMe")}
-                      size="small"
-                      variant="outlined"
-                      color="info"
-                      onClick={() => onOpenClaimPlayerDialog(player.id, player.name)}
-                      sx={{ mr: 0.5, flexShrink: 0, cursor: "pointer", fontSize: "0.7rem", height: 22 }}
-                    />
-                  ) : null}
-                  <ListItemText
-                    primary={player.userId ? (
-                      <a href={`/users/${player.userId}`} style={{ textDecoration: "none", color: "inherit", fontWeight: 500 }}>
-                        {player.name}
-                      </a>
-                    ) : player.name}
-                    primaryTypographyProps={{ fontWeight: 500, fontSize: "0.9rem" }}
-                  />
+                     <Tooltip title={t("protectedPlayer")}>
+                       <ShieldIcon fontSize="small" sx={{ color: "primary.main", mr: 0.5, flexShrink: 0 }} />
+                     </Tooltip>
+                   ) : null}
+                   <ListItemText
+                     primary={player.userId ? (
+                       <a href={`/users/${player.userId}`} style={{ textDecoration: "none", color: "inherit", fontWeight: 500 }}>
+                         {player.name}
+                       </a>
+                     ) : player.name}
+                     primaryTypographyProps={{ fontWeight: 500, fontSize: "0.9rem" }}
+                   />
                 </ListItem>
               ))}
             </List>
@@ -342,15 +331,6 @@ export function PlayerList({
                         <Tooltip title={t("protectedPlayer")}>
                           <ShieldIcon fontSize="small" sx={{ color: "warning.main", mr: 0.5, flexShrink: 0 }} />
                         </Tooltip>
-                      ) : canClaimPlayer ? (
-                        <Chip
-                          label={t("thisIsMe")}
-                          size="small"
-                          variant="outlined"
-                          color="info"
-                          onClick={() => onOpenClaimPlayerDialog(player.id, player.name)}
-                          sx={{ mr: 0.5, flexShrink: 0, cursor: "pointer", fontSize: "0.7rem", height: 22 }}
-                        />
                       ) : null}
                       <ListItemText
                         primary={player.userId ? (

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -808,6 +808,16 @@ const de: TranslationKeys = {
   overrideCleared: "Auf Standard-Zahlungsmethoden zurückgesetzt.",
   logOverrideSet: "{actor} hat eine temporäre Überschreibung der Zahlungsmethoden festgelegt",
   logOverrideCleared: "{actor} hat die temporäre Überschreibung der Zahlungsmethoden entfernt",
+
+  // Landing page (#203)
+  landingHeadline: "Organisiere dein Spiel in 30 Sekunden",
+  landingSubtitle: "Teile einen Link, sammle Spieler, lose Teams aus — fertig.",
+  landingFeatureTeams: "Lose ausgeglichene Teams",
+  landingFeaturePayments: "Teile Kosten mit Spielern",
+  landingFeatureRankings: "Verfolge ELO-Bewertungen",
+  landingFeatureNotifications: "Erhalte Push-Benachrichtigungen",
+  landingFeatureReminders: "Erinnerungen zum Spielen und Bezahlen",
+  landingOpenSource: "Open Source · Für immer kostenlos",
 };
 
 export default de;

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -855,6 +855,16 @@ const en = {
   overrideCleared: "Reverted to default payment methods.",
   logOverrideSet: "{actor} set a temporary payment method override",
   logOverrideCleared: "{actor} cleared the temporary payment method override",
+
+  // Landing page (#203)
+  landingHeadline: "Organize your game in 30 seconds",
+  landingSubtitle: "Share a link, collect players, randomize teams — done.",
+  landingFeatureTeams: "Randomize balanced teams",
+  landingFeaturePayments: "Split costs with players",
+  landingFeatureRankings: "Track ELO rankings",
+  landingFeatureNotifications: "Get push notifications",
+  landingFeatureReminders: "Reminders to play and pay",
+  landingOpenSource: "Open source · Free forever",
 } as const;
 
 export default en;

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -808,6 +808,16 @@ const es: TranslationKeys = {
   overrideCleared: "Se han restaurado los métodos de pago predeterminados.",
   logOverrideSet: "{actor} estableció una sustitución temporal de los métodos de pago",
   logOverrideCleared: "{actor} eliminó la sustitución temporal de los métodos de pago",
+
+  // Landing page (#203)
+  landingHeadline: "Organiza tu partido en 30 segundos",
+  landingSubtitle: "Comparte un enlace, reúne jugadores, sortea equipos — listo.",
+  landingFeatureTeams: "Sortea equipos equilibrados",
+  landingFeaturePayments: "Divide costes con los jugadores",
+  landingFeatureRankings: "Sigue clasificaciones ELO",
+  landingFeatureNotifications: "Recibe notificaciones push",
+  landingFeatureReminders: "Recordatorios para jugar y pagar",
+  landingOpenSource: "Open source · Gratis para siempre",
 };
 
 export default es;

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -808,6 +808,16 @@ const fr: TranslationKeys = {
   overrideCleared: "Retour aux moyens de paiement par défaut.",
   logOverrideSet: "{actor} a défini un remplacement temporaire des moyens de paiement",
   logOverrideCleared: "{actor} a supprimé le remplacement temporaire des moyens de paiement",
+
+  // Landing page (#203)
+  landingHeadline: "Organise ton match en 30 secondes",
+  landingSubtitle: "Partage un lien, rassemble les joueurs, tire les équipes au sort — c'est fait.",
+  landingFeatureTeams: "Tire des équipes équilibrées",
+  landingFeaturePayments: "Partage les frais avec les joueurs",
+  landingFeatureRankings: "Suis les classements ELO",
+  landingFeatureNotifications: "Reçois des notifications push",
+  landingFeatureReminders: "Rappels pour jouer et payer",
+  landingOpenSource: "Open source · Gratuit pour toujours",
 };
 
 export default fr;

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -808,6 +808,16 @@ const it: TranslationKeys = {
   overrideCleared: "Ripristinati i metodi di pagamento predefiniti.",
   logOverrideSet: "{actor} ha impostato una sostituzione temporanea dei metodi di pagamento",
   logOverrideCleared: "{actor} ha rimosso la sostituzione temporanea dei metodi di pagamento",
+
+  // Landing page (#203)
+  landingHeadline: "Organizza la tua partita in 30 secondi",
+  landingSubtitle: "Condividi un link, raccogli giocatori, sorteggia le squadre — fatto.",
+  landingFeatureTeams: "Sorteggia squadre bilanciate",
+  landingFeaturePayments: "Dividi i costi con i giocatori",
+  landingFeatureRankings: "Segui le classifiche ELO",
+  landingFeatureNotifications: "Ricevi notifiche push",
+  landingFeatureReminders: "Promemoria per giocare e pagare",
+  landingOpenSource: "Open source · Gratis per sempre",
 };
 
 export default it;

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -854,6 +854,16 @@ const pt: TranslationKeys = {
   overrideCleared: "Revertido para os métodos de pagamento padrão.",
   logOverrideSet: "{actor} definiu uma substituição temporária dos métodos de pagamento",
   logOverrideCleared: "{actor} removeu a substituição temporária dos métodos de pagamento",
+
+  // Landing page (#203)
+  landingHeadline: "Organiza o teu jogo em 30 segundos",
+  landingSubtitle: "Partilha um link, junta jogadores, sorteia equipas — feito.",
+  landingFeatureTeams: "Sorteia equipas equilibradas",
+  landingFeaturePayments: "Divide custos com os jogadores",
+  landingFeatureRankings: "Acompanha classificações ELO",
+  landingFeatureNotifications: "Recebe notificações push",
+  landingFeatureReminders: "Lembretes para jogar e pagar",
+  landingOpenSource: "Open source · Grátis para sempre",
 };
 
 export default pt;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,6 @@
 ---
 export const prerender = true;
-import CreateEventForm from "../components/CreateEventForm";
+import { LandingPageWithProviders } from "../components/LandingPage";
 ---
 
 <!doctype html>
@@ -8,14 +8,14 @@ import CreateEventForm from "../components/CreateEventForm";
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Convocados — Criar Jogo</title>
-    <meta name="description" content="Organise your sports game, divide teams, manage players." />
+    <title>Convocados — Organize your game in 30 seconds</title>
+    <meta name="description" content="Share a link, collect players, randomize balanced teams, split costs, and track ELO rankings. Free and open source." />
     <link rel="icon" href="/favicon.ico" />
     <link rel="apple-touch-icon" href="/icons/apple-touch-icon.png" />
     <link rel="manifest" href="/manifest.json" />
     <meta name="theme-color" content="#1b6b4a" />
   </head>
   <body>
-    <CreateEventForm client:only="react" />
+    <LandingPageWithProviders client:only="react" />
   </body>
 </html>


### PR DESCRIPTION
## Changes

### Landing page
- Add hero section alongside the create game form
- Responsive layout: stacked on mobile, side-by-side on desktop
- Feature chips highlighting key capabilities
- Tighter vertical spacing for mobile

### Move "Claim as me" to Rankings page

#### Web app
- Remove claim player state, handlers, and dialog from EventPage
- Remove claim player props from PlayerList and EventDialogs
- Add claim player UI and logic to RankingsPage with merged rows (rated players + unclaimed players without ratings)
- HowToReg icon button per unclaimed row when authenticated user has no linked player
- Confirmation dialog before claiming
- Update e2e test to navigate to `/events/{id}/rankings` for claim flow

#### Android app
- Remove claim button from EventDetailScreen PlayerRow
- Rewrite RankingsScreen properly:
  - Move user profile fetch into RankingsViewModel via `MutableStateFlow<UserProfile?>` (was broken with reflection hack and direct API call in composable)
  - Add `refreshing` state for pull-to-refresh support
  - HowToReg icon button (24dp, Primary tint) per unclaimed row
  - `canClaim` computed from ViewModel user state, not composable-level hacks
  - Uses `collectAsStateWithLifecycle` consistently

### Testing
- Typecheck passes
- All 1401 tests pass
- e2e claim player test updated