### PR TITLE
fix: post-game lock, MVP voting after reset, score roller wheel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ android-app/local.properties
 android-app/wear/local.properties
 android-app/app/google-services.json
 android-app/gradle/gradle-daemon-jvm.properties
+android-app/wear/build
+android-app/wear/.gradle
+android-app/wear/.idea

--- a/src/components/MvpVotingCard.tsx
+++ b/src/components/MvpVotingCard.tsx
@@ -19,6 +19,7 @@ interface MvpData {
   isVotingOpen: boolean;
   hasVoted: boolean | null;
   totalVotes: number;
+  participants?: { id: string; name: string }[];
 }
 
 interface Props {
@@ -79,6 +80,7 @@ export function MvpVotingCard({ eventId, historyId, participants, compact }: Pro
 
   const { mvp, isVotingOpen, hasVoted } = data;
   const canVote = isVotingOpen && isAuthenticated && hasVoted === false;
+  const voteCandidates = participants.length > 0 ? participants : (data.participants ?? []);
 
   // Show MVP result badge (voting closed with votes, or already voted and results available)
   if (mvp && mvp.length > 0 && (!canVote || !isVotingOpen)) {
@@ -121,7 +123,7 @@ export function MvpVotingCard({ eventId, historyId, participants, compact }: Pro
             </Typography>
           </Box>
           <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.75 }}>
-            {participants.map((p) => (
+            {voteCandidates.map((p) => (
               <Chip
                 key={p.id}
                 data-testid={`mvp-vote-chip-${p.name}`}

--- a/src/components/PostGameBanner.tsx
+++ b/src/components/PostGameBanner.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback, useRef } from "react";
 import {
   Paper, Typography, Stack, Box, Button, alpha, useTheme,
-  LinearProgress, Chip,
+  LinearProgress, Chip, Alert,
 } from "@mui/material";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import RadioButtonUncheckedIcon from "@mui/icons-material/RadioButtonUnchecked";
@@ -50,6 +50,7 @@ export function PostGameBanner({ eventId, canEdit, onScrollToScore, onScrollToPa
   const [editablePayments, setEditablePayments] = useState<PaymentEntry[]>([]);
   const [paymentsDirty, setPaymentsDirty] = useState(false);
   const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
   const [eventPlayers, setEventPlayers] = useState<{ id: string; name: string }[]>([]);
 
   const onStatusChangeRef = useRef(onStatusChange);
@@ -114,14 +115,19 @@ export function PostGameBanner({ eventId, canEdit, onScrollToScore, onScrollToPa
   const handleSavePayments = async () => {
     if (!status.latestHistoryId) return;
     setSaving(true);
+    setSaveError(null);
     try {
-      await fetch(`/api/events/${eventId}/history/${status.latestHistoryId}`, {
+      const res = await fetch(`/api/events/${eventId}/history/${status.latestHistoryId}`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ paymentsSnapshot: editablePayments }),
       });
-      setPaymentsDirty(false);
-      fetchStatus();
+      if (!res.ok) {
+        setSaveError(res.status === 403 ? t("postGamePaymentsLocked") : t("somethingWentWrong"));
+      } else {
+        setPaymentsDirty(false);
+        fetchStatus();
+      }
     } catch { /* ignore */ }
     setSaving(false);
   };
@@ -297,12 +303,17 @@ export function PostGameBanner({ eventId, canEdit, onScrollToScore, onScrollToPa
                       </Button>
                     </Box>
                   )}
+                  {saveError && (
+                    <Alert severity="warning" sx={{ mt: 1, borderRadius: 2 }} onClose={() => setSaveError(null)}>
+                      {saveError}
+                    </Alert>
+                  )}
                 </Box>
               )}
             </Box>
 
             {/* MVP voting task */}
-            {status.latestHistoryId && status.hasScore && eventPlayers.length > 0 && (
+            {status.latestHistoryId && status.hasScore && (
               <Box sx={{
                 p: 1.5,
                 borderRadius: 2,

--- a/src/components/event/ScoreRoller.tsx
+++ b/src/components/event/ScoreRoller.tsx
@@ -120,6 +120,18 @@ export function ScoreRoller({ value, onChange, teamName, min = 0, max = 20 }: Sc
     }, 80);
   }, [snapToNearest]);
 
+  // Block mouse wheel / trackpad scroll from changing the score.
+  // On non-touch devices the score should only change via click-and-drag.
+  useEffect(() => {
+    const el = listRef.current;
+    if (!el) return;
+    const blockWheel = (e: WheelEvent) => {
+      e.preventDefault();
+    };
+    el.addEventListener("wheel", blockWheel, { passive: false });
+    return () => el.removeEventListener("wheel", blockWheel);
+  }, []);
+
   useEffect(() => {
     return () => {
       if (rafId.current) cancelAnimationFrame(rafId.current);

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -783,6 +783,7 @@ const de: TranslationKeys = {
   postGameNotification: "Spiel vorbei! Ergebnis eintragen, Zahlungen abschließen und MVP von {title} wählen",
   postGamePaymentsLabel: "Zahlungen für dieses Spiel",
   upcomingGamePaymentsLabel: "Zahlungen für das nächste Spiel",
+  postGamePaymentsLocked: "Zahlungen können nicht gespeichert werden — das Ergebnis ist gesperrt. Entsperre es im Verlauf, um fortzufahren.",
 
   adminDeleteUser: "Benutzer löschen",
   adminDeleteUserConfirm: "Sind Sie sicher, dass Sie diesen Benutzer dauerhaft löschen möchten? Diese Aktion kann nicht rückgängig gemacht werden.",

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -838,6 +838,7 @@ const en = {
   postGameNotification: "Game over! Add the score, settle payments, and vote for the MVP of {title}",
   postGamePaymentsLabel: "Payments for this game",
   upcomingGamePaymentsLabel: "Payments for the upcoming game",
+  postGamePaymentsLocked: "Payments can't be saved — the result is locked. Unlock it from History to continue.",
 
   // Admin role notifications
   adminRoleAddedSubject: "You're now an admin for {title}",

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -783,6 +783,7 @@ const es: TranslationKeys = {
   postGameNotification: "Partido terminado! Añade el resultado, cierra los pagos y vota al MVP de {title}",
   postGamePaymentsLabel: "Pagos de este partido",
   upcomingGamePaymentsLabel: "Pagos del próximo partido",
+  postGamePaymentsLocked: "No se pueden guardar los pagos — el resultado está bloqueado. Desbloquéalo desde el Historial para continuar.",
 
   adminDeleteUser: "Eliminar usuario",
   adminDeleteUserConfirm: "¿Estás seguro de que quieres eliminar permanentemente este usuario? Esta acción no se puede deshacer.",

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -783,6 +783,7 @@ const fr: TranslationKeys = {
   postGameNotification: "Match terminé ! Ajoutez le score, réglez les paiements et votez pour le MVP de {title}",
   postGamePaymentsLabel: "Paiements de ce match",
   upcomingGamePaymentsLabel: "Paiements du prochain match",
+  postGamePaymentsLocked: "Impossible d'enregistrer les paiements — le résultat est verrouillé. Déverrouillez-le depuis l'Historique pour continuer.",
 
   adminDeleteUser: "Supprimer l'utilisateur",
   adminDeleteUserConfirm: "Êtes-vous sûr de vouloir supprimer définitivement cet utilisateur ? Cette action est irréversible.",

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -783,6 +783,7 @@ const it: TranslationKeys = {
   postGameNotification: "Partita finita! Aggiungi il risultato, chiudi i pagamenti e vota il MVP di {title}",
   postGamePaymentsLabel: "Pagamenti di questa partita",
   upcomingGamePaymentsLabel: "Pagamenti della prossima partita",
+  postGamePaymentsLocked: "Impossibile salvare i pagamenti — il risultato è bloccato. Sbloccalo dalla Cronologia per continuare.",
 
   adminDeleteUser: "Elimina utente",
   adminDeleteUserConfirm: "Sei sicuro di voler eliminare definitivamente questo utente? Questa azione non può essere annullata.",

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -830,6 +830,7 @@ const pt: TranslationKeys = {
   postGameNotification: "Jogo terminado! Adiciona o resultado, fecha os pagamentos e vota no MVP de {title}",
   postGamePaymentsLabel: "Pagamentos deste jogo",
   upcomingGamePaymentsLabel: "Pagamentos do próximo jogo",
+  postGamePaymentsLocked: "Não é possível guardar os pagamentos — o resultado está bloqueado. Desbloqueia-o no Histórico para continuar.",
   adminDeleteUser: "Eliminar utilizador",
   adminDeleteUserConfirm: "Tem a certeza que quer eliminar permanentemente este utilizador? Esta ação não pode ser desfeita.",
   adminDeleteUserError: "Não foi possível eliminar o utilizador.",

--- a/src/pages/api/events/[id]/history/[historyId]/mvp-vote.ts
+++ b/src/pages/api/events/[id]/history/[historyId]/mvp-vote.ts
@@ -33,7 +33,7 @@ export const POST: APIRoute = async ({ params, request }) => {
   }
 
   // Check voting window: game must have ended
-  const gameEndTime = new Date(event.dateTime.getTime() + (event.durationMinutes ?? 60) * 60_000);
+  const gameEndTime = new Date(history.dateTime.getTime() + (event.durationMinutes ?? 60) * 60_000);
   if (gameEndTime > new Date()) {
     return Response.json({ error: "Voting is not open yet — game has not ended." }, { status: 400 });
   }
@@ -67,21 +67,19 @@ export const POST: APIRoute = async ({ params, request }) => {
   let voterPlayerId = voterPlayer?.id;
 
   if (!voterPlayer) {
-    // Check if user's name appears in the teamsSnapshot
+    // Check if user's name appears in the teamsSnapshot (Player records may be gone after reset)
     const userName = session.user?.name;
     if (userName && history.teamsSnapshot) {
       const teams = JSON.parse(history.teamsSnapshot) as Array<{ team: string; players: Array<{ name: string }> }>;
       const allPlayers = teams.flatMap((t) => t.players);
       const match = allPlayers.find((p) => p.name.toLowerCase() === userName.toLowerCase());
       if (match) {
-        // Find the player record by name
         const playerByName = await prisma.player.findFirst({
           where: { eventId: params.id, name: match.name },
         });
-        if (playerByName) {
-          voterName = playerByName.name;
-          voterPlayerId = playerByName.id;
-        }
+        // Use Player record if it exists, otherwise fall back to name-based ID
+        voterName = match.name;
+        voterPlayerId = playerByName?.id ?? `name:${match.name}`;
       }
     }
   }
@@ -92,22 +90,48 @@ export const POST: APIRoute = async ({ params, request }) => {
 
   // Parse body
   const body = await request.json();
-  const { votedForPlayerId } = body;
-  if (!votedForPlayerId) {
-    return Response.json({ error: "votedForPlayerId is required." }, { status: 400 });
+  const { votedForPlayerId, votedForName: votedForNameBody } = body;
+  if (!votedForPlayerId && !votedForNameBody) {
+    return Response.json({ error: "votedForPlayerId or votedForName is required." }, { status: 400 });
   }
 
-  // Validate target player exists in this event
-  const targetPlayer = await prisma.player.findFirst({
-    where: { id: votedForPlayerId, eventId: params.id },
-  });
-  if (!targetPlayer) {
-    return Response.json({ error: "Target player not found in this event." }, { status: 400 });
-  }
+  // Resolve target player — by ID first, then by name in teamsSnapshot
+  let targetPlayerId: string;
+  let targetPlayerName: string;
 
-  // Prevent self-vote: check by userId or by playerId
-  if (targetPlayer.userId === userId || targetPlayer.id === voterPlayerId) {
-    return Response.json({ error: "You cannot vote for yourself." }, { status: 400 });
+  if (votedForPlayerId && !votedForPlayerId.startsWith("name:")) {
+    const targetPlayer = await prisma.player.findFirst({
+      where: { id: votedForPlayerId, eventId: params.id },
+    });
+    if (!targetPlayer) {
+      return Response.json({ error: "Target player not found in this event." }, { status: 400 });
+    }
+    targetPlayerId = targetPlayer.id;
+    targetPlayerName = targetPlayer.name;
+
+    // Prevent self-vote: check by userId or by playerId
+    if (targetPlayer.userId === userId || targetPlayer.id === voterPlayerId) {
+      return Response.json({ error: "You cannot vote for yourself." }, { status: 400 });
+    }
+  } else {
+    // Name-based voting (Player records may have been deleted after recurrence reset)
+    const nameToVoteFor = votedForNameBody || (votedForPlayerId?.startsWith("name:") ? votedForPlayerId.slice(5) : null);
+    if (!nameToVoteFor || !history.teamsSnapshot) {
+      return Response.json({ error: "Target player not found." }, { status: 400 });
+    }
+    const teams = JSON.parse(history.teamsSnapshot) as Array<{ team: string; players: Array<{ name: string }> }>;
+    const allNames = teams.flatMap((t) => t.players.map((p) => p.name));
+    const match = allNames.find((n) => n.toLowerCase() === nameToVoteFor.toLowerCase());
+    if (!match) {
+      return Response.json({ error: "Target player not found in this game." }, { status: 400 });
+    }
+    targetPlayerId = `name:${match}`;
+    targetPlayerName = match;
+
+    // Prevent self-vote by name
+    if (voterName && match.toLowerCase() === voterName.toLowerCase()) {
+      return Response.json({ error: "You cannot vote for yourself." }, { status: 400 });
+    }
   }
 
   // Create vote (unique constraint prevents duplicates)
@@ -116,14 +140,14 @@ export const POST: APIRoute = async ({ params, request }) => {
       data: {
         gameHistoryId: history.id,
         voterPlayerId,
-        voterName,
-        votedForPlayerId: targetPlayer.id,
-        votedForName: targetPlayer.name,
+        voterName: voterName as string,
+        votedForPlayerId: targetPlayerId,
+        votedForName: targetPlayerName,
       },
     });
     return Response.json({ ok: true, vote: { id: vote.id, votedForName: vote.votedForName } });
-  } catch (err: any) {
-    if (err?.code === "P2002") {
+  } catch (err) {
+    if (err && typeof err === "object" && "code" in err && (err as { code: string }).code === "P2002") {
       return Response.json({ error: "You have already voted for this game." }, { status: 409 });
     }
     throw err;

--- a/src/pages/api/events/[id]/history/[historyId]/mvp.ts
+++ b/src/pages/api/events/[id]/history/[historyId]/mvp.ts
@@ -13,7 +13,7 @@ export const GET: APIRoute = async ({ params, request }) => {
   if (!history) return Response.json({ error: "Game not found." }, { status: 404 });
 
   // Compute isVotingOpen
-  const gameEndTime = new Date(event.dateTime.getTime() + (event.durationMinutes ?? 60) * 60_000);
+  const gameEndTime = new Date(history.dateTime.getTime() + (event.durationMinutes ?? 60) * 60_000);
   const gameEnded = gameEndTime <= new Date();
   const daysSinceCreation = (Date.now() - history.createdAt.getTime()) / 86400_000;
   const withinWindow = daysSinceCreation <= MVP_VOTING_WINDOW_DAYS;
@@ -73,7 +73,7 @@ export const GET: APIRoute = async ({ params, request }) => {
       const teams = JSON.parse(history.teamsSnapshot) as Array<{ team: string; players: Array<{ name: string }> }>;
       const allSnapshotPlayers = teams.flatMap((t) => t.players);
       const nameMatch = allSnapshotPlayers.find(
-        (p) => p.name.toLowerCase() === (session.user!.name ?? "").toLowerCase(),
+        (p) => p.name.toLowerCase() === (session.user?.name ?? "").toLowerCase(),
       );
       if (nameMatch) {
         const playerByName = await prisma.player.findFirst({
@@ -97,6 +97,30 @@ export const GET: APIRoute = async ({ params, request }) => {
     }
   }
 
+  // Extract participants from teamsSnapshot for the voting UI
+  let participants: Array<{ id: string; name: string }> = [];
+  if (history.teamsSnapshot) {
+    try {
+      const teams = JSON.parse(history.teamsSnapshot) as Array<{ team: string; players: Array<{ name: string }> }>;
+      const names = teams.flatMap((t) => t.players.map((p) => p.name));
+      // Try to resolve Player IDs; fall back to name-based IDs
+      const players = await prisma.player.findMany({
+        where: { eventId: params.id, name: { in: names } },
+        select: { id: true, name: true },
+      });
+      const byName = new Map(players.map((p) => [p.name.toLowerCase(), p]));
+      const seen = new Set<string>();
+      participants = names.reduce<Array<{ id: string; name: string }>>((acc, n) => {
+        const key = n.toLowerCase();
+        if (seen.has(key)) return acc;
+        seen.add(key);
+        const match = byName.get(key);
+        acc.push(match ? { id: match.id, name: match.name } : { id: `name:${n}`, name: n });
+        return acc;
+      }, []);
+    } catch { /* ignore */ }
+  }
+
   return Response.json({
     mvp,
     votes: votes.map((v: { voterName: string; votedForName: string }) => ({
@@ -106,5 +130,6 @@ export const GET: APIRoute = async ({ params, request }) => {
     isVotingOpen,
     hasVoted,
     totalVotes: votes.length,
+    participants,
   });
 };

--- a/src/pages/api/events/[id]/index.ts
+++ b/src/pages/api/events/[id]/index.ts
@@ -66,7 +66,7 @@ export const GET: APIRoute = async ({ params, request }) => {
       });
 
       if (claimed.count === 1) {
-        const editableUntil = new Date(event.dateTime.getTime() + 7 * 24 * 60 * 60 * 1000);
+        const editableUntil = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
         const teamsSnapshot = event.teamResults.length > 0
           ? JSON.stringify(event.teamResults.map((tr) => ({
               team: tr.name,

--- a/src/test/api.test.ts
+++ b/src/test/api.test.ts
@@ -225,6 +225,33 @@ describe("GET /api/events/[id]", () => {
     const actualResetAt = new Date(body.nextResetAt);
     expect(actualResetAt.getTime()).toBe(expectedResetAt.getTime());
   });
+
+  it("creates history entry with editableUntil based on now, not old dateTime", async () => {
+    const oldDateTime = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000); // 7 days ago
+    const event = await prisma.event.create({
+      data: {
+        title: "Weekly Game", location: "Pitch",
+        dateTime: oldDateTime,
+        teamOneName: "A", teamTwoName: "B",
+        isRecurring: true,
+        recurrenceRule: JSON.stringify({ freq: "weekly", interval: 1 }),
+        nextResetAt: new Date(Date.now() - 3600_000),
+      },
+    });
+    const res = await getEvent(ctx({ id: event.id }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.wasReset).toBe(true);
+
+    const history = await prisma.gameHistory.findFirst({ where: { eventId: event.id } });
+    expect(history).toBeTruthy();
+    // editableUntil should be ~7 days from now, not 7 days from oldDateTime (which would be ~now)
+    const sevenDaysFromNow = Date.now() + 7 * 24 * 60 * 60 * 1000;
+    const editableUntil = history?.editableUntil.getTime() ?? 0;
+    expect(editableUntil).toBeGreaterThan(Date.now() + 6 * 24 * 60 * 60 * 1000);
+    expect(editableUntil).toBeLessThanOrEqual(sevenDaysFromNow + 5000);
+    expect(editableUntil > Date.now()).toBe(true);
+  });
 });
 
 // ─── POST /api/events/[id]/players ──────────────────────────────────────────

--- a/src/test/auth-api.test.ts
+++ b/src/test/auth-api.test.ts
@@ -1012,6 +1012,19 @@ describe("PATCH /api/events/[id]/history/[historyId]", () => {
     expect(res.status).toBe(403);
   });
 
+  it("returns 403 when owner tries to edit paymentsSnapshot on locked entry", async () => {
+    const owner = await seedUser();
+    mockAuth(owner.id);
+    const id = await seedEvent({ ownerId: owner.id });
+    const history = await seedHistory(id, { editableUntil: new Date(Date.now() - 1000) });
+    const res = await patchHistory(patchCtx({ id, historyId: history.id }, {
+      paymentsSnapshot: [{ playerName: "Alice", amount: 10, status: "paid" }],
+    }));
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toContain("no longer be edited");
+  });
+
   it("updates teamsSnapshot", async () => {
     const owner = await seedUser();
     mockAuth(owner.id);

--- a/src/test/mvp-vote.test.ts
+++ b/src/test/mvp-vote.test.ts
@@ -348,4 +348,102 @@ describe("GET mvp", () => {
     const body = await res.json();
     expect(body.isVotingOpen).toBe(false);
   });
+
+  it("returns isVotingOpen=true after recurrence reset (event.dateTime is future, history.dateTime is past)", async () => {
+    // After recurrence reset: event.dateTime advances to next week, but history.dateTime is the old game time
+    const event = await seedEvent({ dateTime: new Date(Date.now() + 7 * 86400_000) });
+    const history = await seedHistory(event.id, {
+      dateTime: new Date(Date.now() - 3600_000), // game was 1h ago
+    });
+
+    const res = await getMvp(getCtx({ id: event.id, historyId: history.id }));
+    const body = await res.json();
+    expect(body.isVotingOpen).toBe(true);
+  });
+
+  it("returns participants from teamsSnapshot", async () => {
+    const event = await seedEvent();
+    const history = await seedHistory(event.id);
+
+    const res = await getMvp(getCtx({ id: event.id, historyId: history.id }));
+    const body = await res.json();
+    expect(body.participants).toBeDefined();
+    expect(body.participants.map((p: any) => p.name).sort()).toEqual(["Alice", "Bob", "Charlie", "Dave"]);
+  });
+});
+
+describe("POST mvp-vote (name-based)", () => {
+  it("accepts name-based vote when Player records are gone (post-reset)", async () => {
+    const user = await seedUser("Alice");
+    mockAuth(user.id, "Alice");
+    // Event dateTime is in the future (post-reset), but history is from the past game
+    const event = await seedEvent({ dateTime: new Date(Date.now() + 7 * 86400_000) });
+    // Create player record for voter (Alice) — she re-enrolled for next game
+    await seedPlayer(event.id, "Alice", user.id);
+    const history = await seedHistory(event.id, {
+      dateTime: new Date(Date.now() - 3600_000),
+    });
+
+    // Vote for Bob by name (no Player record for Bob after reset)
+    const res = await castMvpVote(postCtx(
+      { id: event.id, historyId: history.id },
+      { votedForPlayerId: "name:Bob" },
+    ));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.vote.votedForName).toBe("Bob");
+  });
+
+  it("rejects name-based self-vote", async () => {
+    const user = await seedUser("Alice");
+    mockAuth(user.id, "Alice");
+    const event = await seedEvent({ dateTime: new Date(Date.now() + 7 * 86400_000) });
+    await seedPlayer(event.id, "Alice", user.id);
+    const history = await seedHistory(event.id, {
+      dateTime: new Date(Date.now() - 3600_000),
+    });
+
+    const res = await castMvpVote(postCtx(
+      { id: event.id, historyId: history.id },
+      { votedForPlayerId: "name:Alice" },
+    ));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/yourself/i);
+  });
+
+  it("allows vote when voter has no Player record (fully name-based after reset)", async () => {
+    const user = await seedUser("Alice");
+    mockAuth(user.id, "Alice");
+    const event = await seedEvent({ dateTime: new Date(Date.now() + 7 * 86400_000) });
+    // No Player records at all — both voter and target resolved by name
+    const history = await seedHistory(event.id, {
+      dateTime: new Date(Date.now() - 3600_000),
+    });
+
+    const res = await castMvpVote(postCtx(
+      { id: event.id, historyId: history.id },
+      { votedForPlayerId: "name:Bob" },
+    ));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.vote.votedForName).toBe("Bob");
+  });
+
+  it("rejects name-based vote for unknown player", async () => {
+    const user = await seedUser("Alice");
+    mockAuth(user.id, "Alice");
+    const event = await seedEvent({ dateTime: new Date(Date.now() + 7 * 86400_000) });
+    const history = await seedHistory(event.id, {
+      dateTime: new Date(Date.now() - 3600_000),
+    });
+
+    const res = await castMvpVote(postCtx(
+      { id: event.id, historyId: history.id },
+      { votedForPlayerId: "name:Unknown" },
+    ));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/not found/i);
+  });
 });


### PR DESCRIPTION
## Summary

Three post-game UX fixes and one desktop interaction fix.

### 1. Game history locks prematurely on recurring events
**Root cause:** Recurrence reset calculated `editableUntil` as `event.dateTime + 7 days` (the old game time). For weekly games, this meant the entry locked right when the next game started — before the owner could finish post-game tasks.

**Fix:** Use `Date.now() + 7 days`, consistent with all other history creation paths.

### 2. MVP voting broken after recurrence reset
**Root cause:** The MVP endpoints used `event.dateTime` to check if the game ended. After reset, `event.dateTime` advances to the next game (future), so `isVotingOpen` was always `false`.

**Fix:**
- Use `history.dateTime` instead of `event.dateTime` for the game-ended check
- MVP GET now returns `participants` from the history's teamsSnapshot
- MVP vote accepts name-based voting (`name:PlayerName`) when Player records are deleted after reset
- `MvpVotingCard` uses API-provided participants as fallback
- PostGameBanner shows MVP section even when event players list is empty

### 3. PostGameBanner silently fails when saving payments on locked entry
**Fix:** Show a dismissible warning Alert when the PATCH returns non-ok (e.g. 403 locked).

### 4. ScoreRoller changes score on trackpad scroll
**Fix:** Block `wheel` events on the score roller. Score changes only via click-and-drag on desktop.

## Testing
- 1420 tests pass (4 new), typecheck clean
- New tests: recurrence reset editableUntil, locked payment PATCH 403, MVP voting after reset, name-based MVP voting

## Files changed (15)
- `src/pages/api/events/[id]/index.ts` — editableUntil fix
- `src/pages/api/events/[id]/history/[historyId]/mvp.ts` — gameEnded fix + participants response
- `src/pages/api/events/[id]/history/[historyId]/mvp-vote.ts` — gameEnded fix + name-based voting
- `src/components/MvpVotingCard.tsx` — API participants fallback
- `src/components/PostGameBanner.tsx` — payment lock warning + MVP gate fix
- `src/components/event/ScoreRoller.tsx` — block wheel events
- `src/lib/i18n/{en,pt,es,fr,de,it}.ts` — `postGamePaymentsLocked` key
- `src/test/{api,auth-api,mvp-vote}.test.ts` — new tests