### PR TITLE
feat: add lint to pre-push hook, hide MVP in post-game banner when disabled

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ After cloning, install the git hooks to catch CI failures before they reach the 
 ```bash
 npm run setup-hooks
 ```
-This installs a pre-push hook that runs `typecheck` and `vitest --coverage` before every push.
+This installs a pre-push hook that runs `lint`, `typecheck` and `vitest --coverage` before every push.
 
 ### Branch Naming
 ```
@@ -289,6 +289,7 @@ export function MyComponent() {
 ## Reviewing Checklist
 
 Before submitting a PR:
+- [ ] Lint passes (`npm run lint -- --max-warnings 521`)
 - [ ] All tests pass (`npm run test`)
 - [ ] Type checking passes (`npm run typecheck`)
 - [ ] i18n strings added to all 6 locales

--- a/scripts/pre-push.sh
+++ b/scripts/pre-push.sh
@@ -4,6 +4,14 @@
 
 echo "Running pre-push checks..."
 
+# Lint
+echo "→ Linting..."
+npx eslint src/ --max-warnings 521
+if [ $? -ne 0 ]; then
+  echo "✗ Lint failed. Push aborted."
+  exit 1
+fi
+
 # Type check
 echo "→ Type checking..."
 npm run typecheck

--- a/src/components/PostGameBanner.tsx
+++ b/src/components/PostGameBanner.tsx
@@ -32,6 +32,7 @@ export interface PostGameStatus {
   costCurrency: string | null;
   costAmount: number | null;
   hasPendingPastPayments: boolean;
+  mvpEnabled: boolean;
 }
 
 interface Props {
@@ -313,7 +314,7 @@ export function PostGameBanner({ eventId, canEdit, onScrollToScore, onScrollToPa
             </Box>
 
             {/* MVP voting task */}
-            {status.latestHistoryId && status.hasScore && (
+            {status.mvpEnabled && status.latestHistoryId && status.hasScore && (
               <Box sx={{
                 p: 1.5,
                 borderRadius: 2,

--- a/src/pages/api/events/[id]/post-game-status.ts
+++ b/src/pages/api/events/[id]/post-game-status.ts
@@ -17,7 +17,7 @@ import { getSession } from "../../../../lib/auth.helpers.server";
 export const GET: APIRoute = async ({ params, request }) => {
   const event = await prisma.event.findUnique({
     where: { id: params.id },
-    select: { id: true, dateTime: true, durationMinutes: true, ownerId: true },
+    select: { id: true, dateTime: true, durationMinutes: true, ownerId: true, mvpEnabled: true },
   });
 
   if (!event) return Response.json({ error: "Not found." }, { status: 404 });
@@ -147,6 +147,6 @@ export const GET: APIRoute = async ({ params, request }) => {
   return Response.json({
     gameEnded, hasScore, hasCost, allPaid, allComplete, isParticipant,
     latestHistoryId, paymentsSnapshot, costCurrency, costAmount,
-    hasPendingPastPayments,
+    hasPendingPastPayments, mvpEnabled: event.mvpEnabled,
   });
 };


### PR DESCRIPTION
## Summary

Two small improvements:

### 1. Lint added to pre-push hook
The pre-push hook now runs `eslint src/ --max-warnings 521` before typecheck and tests, matching the CI pipeline. This catches lint regressions locally before they reach CI.

Also updated AGENTS.md reviewing checklist to include lint as the first check.

### 2. MVP voting respects event setting in post-game banner
The post-game banner now checks the event's `mvpEnabled` setting. When MVP voting is disabled for an event, the MVP section is completely hidden from the post-game checklist.

Changes:
- `post-game-status` API now returns `mvpEnabled` field
- `PostGameBanner` conditionally renders MVP section based on `status.mvpEnabled`

## Files changed (4)
- `scripts/pre-push.sh` — lint step added
- `AGENTS.md` — lint in workflow docs and checklist
- `src/pages/api/events/[id]/post-game-status.ts` — select + return mvpEnabled
- `src/components/PostGameBanner.tsx` — interface + conditional render