### PR TITLE
feat: show MVP awards in rankings table

### DIFF
--- a/src/components/RankingsPage.tsx
+++ b/src/components/RankingsPage.tsx
@@ -23,6 +23,7 @@ interface PlayerRating {
   wins: number;
   draws: number;
   losses: number;
+  mvpAwards: number;
 }
 
 interface EventPlayer {
@@ -39,6 +40,7 @@ interface TableRowData {
   wins: number;
   draws: number;
   losses: number;
+  mvpAwards: number;
   playerId: string | null;
   userId: string | null;
 }
@@ -232,6 +234,7 @@ export default function RankingsPage({ eventId }: { eventId: string }) {
         wins: r.wins,
         draws: r.draws,
         losses: r.losses,
+        mvpAwards: r.mvpAwards ?? 0,
         playerId: p?.id ?? null,
         userId: p?.userId ?? null,
       });
@@ -248,6 +251,7 @@ export default function RankingsPage({ eventId }: { eventId: string }) {
           wins: 0,
           draws: 0,
           losses: 0,
+          mvpAwards: 0,
           playerId: p.id,
           userId: p.userId,
         });
@@ -326,6 +330,7 @@ export default function RankingsPage({ eventId }: { eventId: string }) {
                         <TableCell align="center" sx={{ fontWeight: 700, color: "success.main" }}>{t("wins")}</TableCell>
                         <TableCell align="center" sx={{ fontWeight: 700, color: "text.secondary" }}>{t("draws")}</TableCell>
                         <TableCell align="center" sx={{ fontWeight: 700, color: "error.main" }}>{t("losses")}</TableCell>
+                        <TableCell align="center" sx={{ fontWeight: 700, color: "warning.main" }}>🏆</TableCell>
                         {showActionsCol && <TableCell sx={{ width: 110 }} />}
                       </TableRow>
                     </TableHead>
@@ -397,6 +402,11 @@ export default function RankingsPage({ eventId }: { eventId: string }) {
                             </TableCell>
                             <TableCell align="center">
                               <Typography variant="body2" color="error.main" fontWeight={600}>{r.losses}</Typography>
+                            </TableCell>
+                            <TableCell align="center">
+                              {r.mvpAwards > 0 && (
+                                <Typography variant="body2" color="warning.main" fontWeight={700}>{r.mvpAwards}</Typography>
+                              )}
                             </TableCell>
                             {showActionsCol && (
                               <TableCell align="right" sx={{ px: 0.5 }}>

--- a/src/pages/api/events/[id]/ratings/index.ts
+++ b/src/pages/api/events/[id]/ratings/index.ts
@@ -21,7 +21,35 @@ export const GET: APIRoute = async ({ params, request }) => {
     ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
   });
 
-  return Response.json(buildPaginatedResponse(ratings, limit));
+  // Compute MVP awards per player for this event
+  const votes = await prisma.mvpVote.findMany({
+    where: { gameHistory: { eventId: params.id } },
+    select: { gameHistoryId: true, votedForName: true },
+  });
+  const mvpCounts = new Map<string, number>();
+  if (votes.length > 0) {
+    // Group votes by game, find winner(s) per game
+    const byGame = new Map<string, Map<string, number>>();
+    for (const v of votes) {
+      let game = byGame.get(v.gameHistoryId);
+      if (!game) { game = new Map(); byGame.set(v.gameHistoryId, game); }
+      game.set(v.votedForName, (game.get(v.votedForName) ?? 0) + 1);
+    }
+    for (const [, tally] of byGame) {
+      const max = Math.max(...tally.values());
+      if (max < 1) continue;
+      for (const [name, count] of tally) {
+        if (count === max) mvpCounts.set(name.toLowerCase(), (mvpCounts.get(name.toLowerCase()) ?? 0) + 1);
+      }
+    }
+  }
+
+  const ratingsWithMvp = ratings.map((r) => ({
+    ...r,
+    mvpAwards: mvpCounts.get(r.name.toLowerCase()) ?? 0,
+  }));
+
+  return Response.json(buildPaginatedResponse(ratingsWithMvp, limit));
 };
 
 /**


### PR DESCRIPTION
## Summary

Adds MVP award counts to the event rankings table, giving players visible recognition for their MVP wins without affecting ELO ratings.

### Changes

**Ratings API** (`/api/events/:id/ratings`):
- Queries all MvpVote records for the event's game history
- Tallies winners per game (player(s) with most votes)
- Returns `mvpAwards` count per player in the response

**Rankings table** (`RankingsPage.tsx`):
- New 🏆 column showing MVP award count
- Only displays the number for players with ≥1 award (keeps it clean)
- Trophy emoji header, warning color for the count

### How it works
For each game in the event's history, the player(s) with the most votes are counted as MVP winners. If there's a tie, all tied players get credit. The count is purely cosmetic — it doesn't affect ELO ratings.

## Files changed (2)
- `src/pages/api/events/[id]/ratings/index.ts` — MVP tally logic
- `src/components/RankingsPage.tsx` — interface + table column