### PR TITLE
feat: allow participants to edit teams in game history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ android-app/local.properties
 android-app/wear/local.properties
 android-app/app/google-services.json
 android-app/gradle/gradle-daemon-jvm.properties
+android-app/wear/build
+android-app/wear/.gradle
+android-app/wear/.idea

--- a/src/components/HistoryPage.tsx
+++ b/src/components/HistoryPage.tsx
@@ -424,7 +424,8 @@ function HistoryCardFull({
 
   // Gate editing on both time-based editability AND authentication
   // Score: owner/admin or participant can edit
-  // Teams/payments: only owner/admin can edit
+  // Teams: owner/admin or participant can edit
+  // Payments: only owner/admin can edit
   const isParticipantInGame = (() => {
     if (isOwner) return true;
     if (!userName) return false;
@@ -433,7 +434,8 @@ function HistoryCardFull({
     return allNames.includes(userName.toLowerCase());
   })();
   const canEditScore = entry.editable && isAuthenticated && isParticipantInGame;
-  const canEditTeams = entry.editable && isAuthenticated && isOwner;
+  const canEditTeams = entry.editable && isAuthenticated && (isOwner || isParticipantInGame);
+  const canEditPayments = entry.editable && isAuthenticated && isOwner;
 
   const [unlocking, setUnlocking] = useState(false);
   const handleToggleLock = async () => {
@@ -993,7 +995,7 @@ function HistoryCardFull({
               title={t("historyPayments")}
               icon={<PaymentIcon fontSize="small" sx={{ color: "text.secondary" }} />}
               action={
-                canEditTeams && paymentsDirty ? (
+                canEditPayments && paymentsDirty ? (
                   <Button variant="contained" size="small" disableElevation startIcon={<SaveIcon />}
                     onClick={handleSavePayments} disabled={saving}
                     sx={{ borderRadius: 2, textTransform: "none", fontWeight: 600 }}>
@@ -1008,7 +1010,7 @@ function HistoryCardFull({
                 border: `1px solid ${alpha(theme.palette.divider, 0.08)}`,
               }}>
                 <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.75 }}>
-                  {(canEditTeams ? editablePayments : payments).map((p, idx) => {
+                  {(canEditPayments ? editablePayments : payments).map((p, idx) => {
                     const isPaid = p.status === "paid";
                     const chipColor = isPaid ? "success" : "warning";
                     return (
@@ -1018,11 +1020,11 @@ function HistoryCardFull({
                         variant={isPaid ? "filled" : "outlined"}
                         color={chipColor}
                         label={`${p.playerName}  ${p.amount.toFixed(2)}`}
-                        onClick={canEditTeams ? () => cyclePaymentStatus(idx) : undefined}
+                        onClick={canEditPayments ? () => cyclePaymentStatus(idx) : undefined}
                         sx={{
                           borderRadius: 2,
                           fontWeight: isPaid ? 600 : 400,
-                          ...(canEditTeams ? { cursor: "pointer" } : {}),
+                          ...(canEditPayments ? { cursor: "pointer" } : {}),
                         }}
                       />
                     );

--- a/src/pages/api/events/[id]/history/[historyId].ts
+++ b/src/pages/api/events/[id]/history/[historyId].ts
@@ -112,10 +112,15 @@ export const PATCH: APIRoute = async ({ params, request }) => {
     return Response.json({ error: "Only the event owner or a participant can edit this." }, { status: 403 });
   }
 
-  // Restrict team and payment edits to owner/admin only
-  if (body.teamsSnapshot !== undefined || body.paymentsSnapshot !== undefined) {
+  // Restrict team edits to owner/admin/participant; payment edits to owner/admin only
+  if (body.paymentsSnapshot !== undefined) {
     if (!isOwner && !isAdmin) {
-      return Response.json({ error: "Only the event owner or admin can edit teams and payments." }, { status: 403 });
+      return Response.json({ error: "Only the event owner or admin can edit payments." }, { status: 403 });
+    }
+  }
+  if (body.teamsSnapshot !== undefined) {
+    if (!isOwner && !isAdmin && !isParticipant) {
+      return Response.json({ error: "Only the event owner, admin, or a participant can edit teams." }, { status: 403 });
     }
   }
 

--- a/src/test/auth-api.test.ts
+++ b/src/test/auth-api.test.ts
@@ -808,7 +808,7 @@ describe("PATCH /api/events/[id]/history/[historyId]", () => {
     expect(body.scoreOne).toBe(3);
   });
 
-  it("returns 403 when participant tries to edit teams", async () => {
+  it("allows participant to edit teams", async () => {
     const owner = await seedUser();
     const participant = await seedUser({ name: "Alice" });
     mockAuth(participant.id, "Alice");
@@ -823,9 +823,9 @@ describe("PATCH /api/events/[id]/history/[historyId]", () => {
       { team: "B", players: [{ name: "Bob", order: 0 }] },
     ];
     const res = await patchHistory(patchCtx({ id, historyId: history.id }, { teamsSnapshot: newTeams }));
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.error).toContain("owner or admin");
+    expect(body.teamsSnapshot).toBeDefined();
   });
 
   it("returns 403 when participant tries to edit payments", async () => {
@@ -842,6 +842,8 @@ describe("PATCH /api/events/[id]/history/[historyId]", () => {
       paymentsSnapshot: [{ playerName: "Alice", amount: 10, status: "paid" }],
     }));
     expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toContain("owner or admin");
   });
 
   it("allows owner to edit teams", async () => {


### PR DESCRIPTION
## Summary

Closes #308

Previously only the event owner or admin could edit team assignments in past games (history page). Now any authenticated player who participated in the game can also move players between teams via drag-and-drop.

## Changes

- **API** (`src/pages/api/events/[id]/history/[historyId].ts`): Relaxed the team edit restriction to allow participants (not just owner/admin). Payment editing remains owner/admin only.
- **Frontend** (`src/components/HistoryPage.tsx`): Added `canEditPayments` permission separate from `canEditTeams`. Participants now see the drag-and-drop team editing UI.
- **Tests** (`src/test/auth-api.test.ts`): Updated test to verify participants can now edit teams, while still being blocked from editing payments.

## What was tested

- Full test suite passes (1422 tests)
- Type checking passes
- Verified participant can edit teams (200 response)
- Verified participant is still blocked from editing payments (403 response)
- Verified non-participant is still blocked from editing teams (403 response)