### PR TITLE
fix: refresh mvp state after 409 duplicate vote

### DIFF
--- a/src/components/MvpVotingCard.tsx
+++ b/src/components/MvpVotingCard.tsx
@@ -66,6 +66,7 @@ export function MvpVotingCard({ eventId, historyId, participants, compact }: Pro
         setSnack({ msg: t("mvpSelfVoteError"), severity: "error" });
       } else if (res.status === 409) {
         setSnack({ msg: t("mvpAlreadyVoted"), severity: "error" });
+        fetchMvp();
       } else {
         setSnack({ msg: body.error || "Error", severity: "error" });
       }

--- a/src/test/mvp-vote.test.ts
+++ b/src/test/mvp-vote.test.ts
@@ -170,6 +170,39 @@ describe("POST mvp-vote", () => {
     expect(res.status).toBe(409);
   });
 
+  it("sets hasVoted=true after voting via GET mvp endpoint", async () => {
+    const user = await seedUser("Alice");
+    mockAuth(user.id, "Alice");
+    const event = await seedEvent();
+    await seedPlayer(event.id, "Alice", user.id);
+    const bob = await seedPlayer(event.id, "Bob");
+    const history = await seedHistory(event.id);
+
+    await castMvpVote(postCtx(
+      { id: event.id, historyId: history.id },
+      { votedForPlayerId: bob.id },
+    ));
+
+    const mvpRes = await getMvp(getCtx({ id: event.id, historyId: history.id }));
+    const mvpBody = await mvpRes.json();
+    expect(mvpBody.hasVoted).toBe(true);
+    expect(mvpBody.totalVotes).toBe(1);
+  });
+
+  it("get mvp shows hasVoted=false before voting", async () => {
+    const user = await seedUser("Alice");
+    mockAuth(user.id, "Alice");
+    const event = await seedEvent();
+    await seedPlayer(event.id, "Alice", user.id);
+    await seedPlayer(event.id, "Bob");
+    const history = await seedHistory(event.id);
+
+    const res = await getMvp(getCtx({ id: event.id, historyId: history.id }));
+    const body = await res.json();
+    expect(body.hasVoted).toBe(false);
+    expect(body.totalVotes).toBe(0);
+  });
+
   it("rejects non-participant", async () => {
     const user = await seedUser("Outsider");
     mockAuth(user.id, "Outsider");


### PR DESCRIPTION
## Summary
- After casting a vote, if the server returns 409 (duplicate vote), the component now calls `fetchMvp()` to refresh the state and correctly show the "already voted" UI instead of leaving the voting UI active.

## Changes
- **MvpVotingCard.tsx:69** — Added `fetchMvp()` call on 409 response
- **mvp-vote.test.ts** — Added two new tests:
  - `sets hasVoted=true after voting via GET mvp endpoint`
  - `get mvp shows hasVoted=false before voting`