### PR TITLE
feat: scheduler worker for exact-time notifications

### DIFF
--- a/scheduler/.env.example
+++ b/scheduler/.env.example
@@ -1,0 +1,3 @@
+APP_URL=https://convocados.fly.dev
+SCHEDULER_SECRET=your-shared-secret-here
+POLL_INTERVAL_MS=10000

--- a/scheduler/Dockerfile
+++ b/scheduler/Dockerfile
@@ -1,0 +1,16 @@
+# Build stage
+FROM node:22-alpine AS builder
+WORKDIR /app
+COPY package.json tsconfig.json ./
+RUN npm install
+COPY index.ts ./
+RUN npm run build
+
+# Production stage
+FROM node:22-alpine
+WORKDIR /app
+ENV NODE_ENV=production
+COPY package.json ./
+RUN npm install --omit=dev
+COPY --from=builder /app/dist ./dist
+CMD ["node", "dist/index.js"]

--- a/scheduler/README.md
+++ b/scheduler/README.md
@@ -1,0 +1,45 @@
+# Convocados Scheduler Worker
+
+A lightweight polling worker that processes scheduled jobs from the Convocados web app.
+
+## Architecture
+
+```
+┌─────────────────────┐      GET /api/internal/jobs/due      ┌──────────────┐
+│  Scheduler Worker   │  ──────────────────────────────────> │  Web App     │
+│  (this app)         │                                      │  (SQLite)    │
+│                     │  <────────────────────────────────── │              │
+│  - Polls every 10s  │      { jobs: [...] }                 │              │
+│  - Processes jobs   │                                      │              │
+│    sequentially     │  POST /api/internal/jobs/:id/process │              │
+└─────────────────────┘  ──────────────────────────────────> └──────────────┘
+```
+
+## Deployment
+
+1. Set the `SCHEDULER_SECRET` secret (must match the web app's `SCHEDULER_SECRET`):
+   ```bash
+   fly secrets set SCHEDULER_SECRET=your-secret -a convocados-scheduler
+   ```
+
+2. Deploy:
+   ```bash
+   fly deploy
+   ```
+
+## Development
+
+```bash
+npm install
+cp .env.example .env
+# Edit .env with your values
+npm run dev
+```
+
+## Environment Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `APP_URL` | Yes | `https://convocados.fly.dev` | Web app base URL |
+| `SCHEDULER_SECRET` | Yes | — | Shared secret for internal API auth |
+| `POLL_INTERVAL_MS` | No | `10000` | Polling interval in milliseconds |

--- a/scheduler/fly.toml
+++ b/scheduler/fly.toml
@@ -1,0 +1,14 @@
+app = "convocados-scheduler"
+primary_region = "cdg"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[env]
+  APP_URL = "https://convocados.fly.dev"
+  POLL_INTERVAL_MS = "10000"
+
+[[vm]]
+  memory = "128mb"
+  cpu_kind = "shared"
+  cpus = 1

--- a/scheduler/index.ts
+++ b/scheduler/index.ts
@@ -1,0 +1,93 @@
+/**
+ * Convocados Scheduler Worker
+ *
+ * A lightweight polling worker that runs as a separate Fly machine.
+ * It polls the web app's internal API for due scheduled jobs and
+ * processes them one at a time.
+ *
+ * Environment variables:
+ *   APP_URL          - Web app base URL (e.g. https://convocados.fly.dev)
+ *   SCHEDULER_SECRET - Shared secret for internal API auth
+ *   POLL_INTERVAL_MS - Polling interval in ms (default: 10000)
+ */
+
+import { setTimeout } from "node:timers/promises";
+
+const APP_URL = process.env.APP_URL ?? "https://convocados.fly.dev";
+const SCHEDULER_SECRET = process.env.SCHEDULER_SECRET;
+const POLL_INTERVAL_MS = parseInt(process.env.POLL_INTERVAL_MS ?? "10000", 10);
+
+interface Job {
+  id: string;
+  eventId: string | null;
+  type: string;
+  runAt: string;
+}
+
+async function fetchDueJobs(): Promise<Job[]> {
+  const res = await fetch(`${APP_URL}/api/internal/jobs/due`, {
+    headers: {
+      authorization: `Bearer ${SCHEDULER_SECRET}`,
+    },
+  });
+
+  if (!res.ok) {
+    throw new Error(`Failed to fetch due jobs: ${res.status} ${res.statusText}`);
+  }
+
+  const body = (await res.json()) as { jobs: Job[] };
+  return body.jobs ?? [];
+}
+
+async function processJob(jobId: string): Promise<void> {
+  const res = await fetch(`${APP_URL}/api/internal/jobs/${jobId}/process`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${SCHEDULER_SECRET}`,
+    },
+  });
+
+  if (!res.ok) {
+    throw new Error(`Failed to process job ${jobId}: ${res.status} ${res.statusText}`);
+  }
+}
+
+async function runLoop() {
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const start = Date.now();
+    try {
+      const jobs = await fetchDueJobs();
+      if (jobs.length > 0) {
+        console.log(`[scheduler] Found ${jobs.length} due job(s)`);
+      }
+
+      for (const job of jobs) {
+        try {
+          await processJob(job.id);
+          console.log(`[scheduler] Processed job ${job.id} (${job.type})`);
+        } catch (err) {
+          console.error(`[scheduler] Failed to process job ${job.id}:`, err);
+        }
+      }
+    } catch (err) {
+      console.error("[scheduler] Polling error:", err);
+    }
+
+    const elapsed = Date.now() - start;
+    const sleep = Math.max(0, POLL_INTERVAL_MS - elapsed);
+    await setTimeout(sleep);
+  }
+}
+
+// Validate config before starting
+if (!SCHEDULER_SECRET) {
+  console.error("[scheduler] SCHEDULER_SECRET is required");
+  process.exit(1);
+}
+
+console.log(`[scheduler] Starting — polling ${APP_URL}/api/internal/jobs/due every ${POLL_INTERVAL_MS}ms`);
+runLoop().catch((err) => {
+  console.error("[scheduler] Fatal error:", err);
+  process.exit(1);
+});

--- a/scheduler/package.json
+++ b/scheduler/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "convocados-scheduler",
+  "version": "1.0.0",
+  "description": "Lightweight scheduler worker for Convocados",
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "tsx index.ts"
+  },
+  "dependencies": {
+    "p-retry": "^6.2.1"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.5.0"
+  }
+}

--- a/scheduler/tsconfig.json
+++ b/scheduler/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

Deploys a lightweight scheduler worker as a separate Fly machine to enable exact-time notification delivery.

## Architecture

- **Web app** (`feat/wear-email-login-score-visibility`): exposes `GET /api/internal/jobs/due` and `POST /api/internal/jobs/:id/process` endpoints protected by `SCHEDULER_SECRET`
- **Scheduler worker** (this PR): polls the web app every 10s and processes due jobs sequentially

## Deployment

1. Merge the web app PR first (includes `ScheduledJob` table + internal API)
2. Deploy the scheduler worker:
   ```bash
   cd scheduler
   fly secrets set SCHEDULER_SECRET=your-secret
   fly deploy
   ```

## Cost

- 128MB shared CPU machine on Fly.io ≈ $1.94/month

## What this replaces

The existing external cron service that hits `/api/cron/reminders` periodically. The new system:
- Schedules reminders at event creation time (exact timestamps)
- Processes them at the exact scheduled time
- Supports arbitrary future notification times