### PR TITLE
feat: restrict MVP voting to players who played in the game

### DIFF
--- a/src/pages/api/events/[id]/history/[historyId]/mvp-vote.ts
+++ b/src/pages/api/events/[id]/history/[historyId]/mvp-vote.ts
@@ -57,30 +57,21 @@ export const POST: APIRoute = async ({ params, request }) => {
     return Response.json({ error: "Voting is closed — the 7-day window has expired." }, { status: 400 });
   }
 
-  // Find the voter's player record in this event
-  const voterPlayer = await prisma.player.findFirst({
-    where: { eventId: params.id, userId },
-  });
+  // Only players who actually played in this game (appear in teamsSnapshot) can vote.
+  let voterName: string | undefined;
+  let voterPlayerId: string | undefined;
 
-  // Also check teamsSnapshot for name-based participation
-  let voterName = voterPlayer?.name;
-  let voterPlayerId = voterPlayer?.id;
-
-  if (!voterPlayer) {
-    // Check if user's name appears in the teamsSnapshot (Player records may be gone after reset)
-    const userName = session.user?.name;
-    if (userName && history.teamsSnapshot) {
-      const teams = JSON.parse(history.teamsSnapshot) as Array<{ team: string; players: Array<{ name: string }> }>;
-      const allPlayers = teams.flatMap((t) => t.players);
-      const match = allPlayers.find((p) => p.name.toLowerCase() === userName.toLowerCase());
-      if (match) {
-        const playerByName = await prisma.player.findFirst({
-          where: { eventId: params.id, name: match.name },
-        });
-        // Use Player record if it exists, otherwise fall back to name-based ID
-        voterName = match.name;
-        voterPlayerId = playerByName?.id ?? `name:${match.name}`;
-      }
+  if (history.teamsSnapshot && session.user?.name) {
+    const teams = JSON.parse(history.teamsSnapshot) as Array<{ team: string; players: Array<{ name: string }> }>;
+    const allPlayers = teams.flatMap((t) => t.players);
+    const match = allPlayers.find((p) => p.name.toLowerCase() === session.user!.name!.toLowerCase());
+    if (match) {
+      voterName = match.name;
+      // Try to find the Player record for this user (may exist if they signed up)
+      const voterPlayer = await prisma.player.findFirst({
+        where: { eventId: params.id, userId },
+      });
+      voterPlayerId = voterPlayer?.id ?? `name:${match.name}`;
     }
   }
 

--- a/src/pages/api/events/[id]/history/[historyId]/mvp.ts
+++ b/src/pages/api/events/[id]/history/[historyId]/mvp.ts
@@ -60,40 +60,55 @@ export const GET: APIRoute = async ({ params, request }) => {
   let hasVoted: boolean | null = null;
   const session = await getSession(request);
   if (session?.user?.id) {
-    // First try: find player linked by userId
-    let playerIds: string[];
-    const userPlayers = await prisma.player.findMany({
-      where: { eventId: params.id, userId: session.user.id },
-      select: { id: true },
-    });
-    playerIds = userPlayers.map((p) => p.id);
+    // Only participants (players in teamsSnapshot) can have hasVoted !== null
+    let isParticipant = false;
+    let playerIds: string[] = [];
 
-    // Fallback: match by name in teamsSnapshot (same logic as mvp-vote.ts)
-    if (playerIds.length === 0 && session.user.name && history.teamsSnapshot) {
+    if (history.teamsSnapshot && session.user.name) {
       const teams = JSON.parse(history.teamsSnapshot) as Array<{ team: string; players: Array<{ name: string }> }>;
       const allSnapshotPlayers = teams.flatMap((t) => t.players);
       const nameMatch = allSnapshotPlayers.find(
-        (p) => p.name.toLowerCase() === (session.user?.name ?? "").toLowerCase(),
+        (p) => p.name.toLowerCase() === session.user!.name!.toLowerCase(),
       );
       if (nameMatch) {
-        const playerByName = await prisma.player.findFirst({
-          where: { eventId: params.id, name: nameMatch.name },
+        isParticipant = true;
+        const userPlayers = await prisma.player.findMany({
+          where: { eventId: params.id, userId: session.user.id },
           select: { id: true },
         });
-        if (playerByName) playerIds = [playerByName.id];
+        playerIds = userPlayers.map((p) => p.id);
+
+        if (playerIds.length === 0) {
+          const playerByName = await prisma.player.findFirst({
+            where: { eventId: params.id, name: nameMatch.name },
+            select: { id: true },
+          });
+          if (playerByName) playerIds = [playerByName.id];
+        }
       }
     }
 
-    if (playerIds.length > 0) {
-      const existingVote = await prisma.mvpVote.findFirst({
-        where: {
-          gameHistoryId: history.id,
-          voterPlayerId: { in: playerIds },
-        },
-      });
-      hasVoted = !!existingVote;
+    if (isParticipant) {
+      if (playerIds.length > 0) {
+        const existingVote = await prisma.mvpVote.findFirst({
+          where: {
+            gameHistoryId: history.id,
+            voterPlayerId: { in: playerIds },
+          },
+        });
+        hasVoted = !!existingVote;
+      } else {
+        // Participant with no Player record — check name-based vote
+        const existingVote = await prisma.mvpVote.findFirst({
+          where: {
+            gameHistoryId: history.id,
+            voterPlayerId: `name:${session.user.name}`,
+          },
+        });
+        hasVoted = !!existingVote;
+      }
     } else {
-      hasVoted = false;
+      hasVoted = null;
     }
   }
 

--- a/src/test/mvp-vote.test.ts
+++ b/src/test/mvp-vote.test.ts
@@ -218,6 +218,24 @@ describe("POST mvp-vote", () => {
     expect(res.status).toBe(403);
   });
 
+  it("rejects admin who did not play in the game", async () => {
+    const admin = await seedUser("Admin");
+    mockAuth(admin.id, "Admin");
+    const event = await seedEvent();
+    // Admin has a Player record for the event but is NOT in the teamsSnapshot
+    await seedPlayer(event.id, "Admin", admin.id);
+    const bob = await seedPlayer(event.id, "Bob");
+    const history = await seedHistory(event.id);
+
+    const res = await castMvpVote(postCtx(
+      { id: event.id, historyId: history.id },
+      { votedForPlayerId: bob.id },
+    ));
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toMatch(/participant/i);
+  });
+
   it("rejects vote after newer game exists", async () => {
     const user = await seedUser("Alice");
     mockAuth(user.id, "Alice");
@@ -533,14 +551,26 @@ describe("GET mvp", () => {
     expect(body.hasVoted).toBeNull();
   });
 
-  it("returns hasVoted=false when no player match", async () => {
+  it("returns hasVoted=null when user did not play in the game", async () => {
     const user = await seedUser("Unknown");
     mockAuth(user.id, "Unknown");
     const event = await seedEvent();
     const history = await seedHistory(event.id);
     const res = await getMvp(getCtx({ id: event.id, historyId: history.id }));
     const body = await res.json();
-    expect(body.hasVoted).toBe(false);
+    expect(body.hasVoted).toBeNull();
+  });
+
+  it("returns hasVoted=null for admin who did not play", async () => {
+    const admin = await seedUser("Admin");
+    mockAuth(admin.id, "Admin");
+    const event = await seedEvent();
+    // Admin has a Player record for the event but is NOT in the teamsSnapshot
+    await seedPlayer(event.id, "Admin", admin.id);
+    const history = await seedHistory(event.id);
+    const res = await getMvp(getCtx({ id: event.id, historyId: history.id }));
+    const body = await res.json();
+    expect(body.hasVoted).toBeNull();
   });
 
   it("returns empty participants when teamsSnapshot is missing", async () => {


### PR DESCRIPTION
## Summary
Restricts MVP voting so that **only players whose names appear in the game's `teamsSnapshot` can vote**. Admins and event owners who did not play in that specific game are now blocked.

## Changes
- **POST `/api/events/[id]/history/[historyId]/mvp-vote`**: Voter eligibility now always checks the `teamsSnapshot` first. Even if a user has a `Player` record for the event, they are rejected with 403 unless their name appears in that game's snapshot.
- **GET `/api/events/[id]/history/[historyId]/mvp`**: Returns `hasVoted: null` for non-participants, preventing the voting UI from rendering for admins/owners who didn't play.
- **Tests**: Added regression tests for admin rejection and `hasVoted=null` cases.

## Checklist
- [x] All tests pass (1,644 tests)
- [x] Type checking passes
- [x] Coverage maintained