### PR TITLE
fix: schedule reminder jobs after recurring event reset

### DIFF
--- a/src/pages/api/events/[id]/index.ts
+++ b/src/pages/api/events/[id]/index.ts
@@ -5,6 +5,7 @@ import { fireWebhooks } from "../../../../lib/webhook.server";
 import { autoPriorityEnroll } from "../../../../lib/priority.server";
 import { getSession, checkEventAdmin } from "../../../../lib/auth.helpers.server";
 import { checkAccess } from "../../../../lib/eventAccess";
+import { cancelEventJobs, scheduleEventReminders } from "../../../../lib/scheduler.server";
 
 export const GET: APIRoute = async ({ params, request }) => {
   const event = await prisma.event.findUnique({
@@ -123,6 +124,11 @@ export const GET: APIRoute = async ({ params, request }) => {
 
         // Auto-enroll priority players for the new occurrence (non-blocking)
         autoPriorityEnroll(event.id).catch(() => {});
+
+        // Schedule reminder jobs for the new occurrence (non-blocking)
+        cancelEventJobs(event.id)
+          .then(() => scheduleEventReminders(event.id, newDateTime, event.durationMinutes))
+          .catch(() => {});
       }
 
       const fresh = await prisma.event.findUnique({


### PR DESCRIPTION
## Problem

When a recurring event advances to its next occurrence (lazy recurrence reset), the old reminder jobs were already processed but no new jobs were created for the new date. This left the scheduler queue permanently empty for recurring events, meaning no 24h/2h/1h reminders or post-game notifications were sent.

## Root Cause

The recurrence reset logic in GET /api/events/[id] updates the event dateTime and fires webhooks/priority enrollment, but never called scheduleEventReminders() to create new scheduled jobs for the new occurrence.

## Fix

Added cancelEventJobs() + scheduleEventReminders() after the recurrence reset, matching the same pattern used in the datetime update endpoint (PATCH /api/events/[id]/datetime).

## Testing

- Integration tests pass (17/17)
- Manually backfilled jobs for the upcoming June 1 event on production
- Typecheck passes with no new errors