### PR TITLE
feat: make convocados.cabeda.dev the canonical domain

### DIFF
--- a/android-app/app/src/main/java/dev/convocados/data/auth/TokenStore.kt
+++ b/android-app/app/src/main/java/dev/convocados/data/auth/TokenStore.kt
@@ -79,6 +79,6 @@ class TokenStore @Inject constructor(@ApplicationContext context: Context) {
     }
 
     companion object {
-        const val DEFAULT_SERVER_URL = "https://convocados.fly.dev"
+        const val DEFAULT_SERVER_URL = "https://convocados.cabeda.dev"
     }
 }

--- a/android-app/app/src/main/java/dev/convocados/ui/screen/login/LoginScreen.kt
+++ b/android-app/app/src/main/java/dev/convocados/ui/screen/login/LoginScreen.kt
@@ -70,7 +70,7 @@ fun LoginScreen(
                 OutlinedTextField(
                     value = serverUrl,
                     onValueChange = { serverUrl = it },
-                    placeholder = { Text("https://convocados.fly.dev") },
+                    placeholder = { Text("https://convocados.cabeda.dev") },
                     modifier = Modifier.fillMaxWidth(),
                     singleLine = true,
                     colors = OutlinedTextFieldDefaults.colors(

--- a/android-app/app/src/main/java/dev/convocados/ui/screen/profile/ProfileScreen.kt
+++ b/android-app/app/src/main/java/dev/convocados/ui/screen/profile/ProfileScreen.kt
@@ -120,7 +120,7 @@ fun ProfileScreen(
                 Column(Modifier.padding(12.dp)) {
                     OutlinedTextField(
                         value = serverUrl, onValueChange = { serverUrl = it },
-                        placeholder = { Text("https://convocados.fly.dev") },
+                        placeholder = { Text("https://convocados.cabeda.dev") },
                         modifier = Modifier.fillMaxWidth(), singleLine = true,
                     )
                     Row(Modifier.fillMaxWidth().padding(top = 8.dp), horizontalArrangement = Arrangement.End) {

--- a/android-app/wear/src/androidTest/java/dev/convocados/wear/data/auth/WearTokenStoreTest.kt
+++ b/android-app/wear/src/androidTest/java/dev/convocados/wear/data/auth/WearTokenStoreTest.kt
@@ -76,7 +76,7 @@ class WearTokenStoreTest {
 
     @Test
     fun getServerUrl_returns_default_when_not_set() {
-        assertEquals("https://convocados.fly.dev", store.getServerUrl())
+        assertEquals("https://convocados.cabeda.dev", store.getServerUrl())
     }
 
     @Test
@@ -90,8 +90,8 @@ class WearTokenStoreTest {
         store.setServerUrl("http://10.0.2.2:4321")
         assertEquals("http://10.0.2.2:4321", store.getServerUrl())
 
-        store.setServerUrl("https://convocados.fly.dev")
-        assertEquals("https://convocados.fly.dev", store.getServerUrl())
+        store.setServerUrl("https://convocados.cabeda.dev")
+        assertEquals("https://convocados.cabeda.dev", store.getServerUrl())
     }
 
     @Test

--- a/android-app/wear/src/main/java/dev/convocados/wear/data/auth/WearTokenStore.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/data/auth/WearTokenStore.kt
@@ -76,6 +76,6 @@ class WearTokenStore @Inject constructor(@ApplicationContext context: Context) {
     }
 
     companion object {
-        const val DEFAULT_SERVER_URL = "https://convocados.fly.dev"
+        const val DEFAULT_SERVER_URL = "https://convocados.cabeda.dev"
     }
 }

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/auth/AuthScreen.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/auth/AuthScreen.kt
@@ -306,7 +306,7 @@ private fun BackendSelector(viewModel: AuthViewModel) {
             Spacer(modifier = Modifier.height(8.dp))
             Button(
                 onClick = {
-                    val newUrl = if (isLocal) "https://convocados.fly.dev" else "http://10.0.2.2:4321"
+                    val newUrl = if (isLocal) "https://convocados.cabeda.dev" else "http://10.0.2.2:4321"
                     serverUrl = newUrl
                     viewModel.setServerUrl(newUrl)
                 },

--- a/android-app/wear/src/test/java/dev/convocados/wear/ui/screen/auth/AuthViewModelTest.kt
+++ b/android-app/wear/src/test/java/dev/convocados/wear/ui/screen/auth/AuthViewModelTest.kt
@@ -31,7 +31,7 @@ class AuthViewModelTest {
     fun setup() {
         Dispatchers.setMain(testDispatcher)
         every { tokenStore.isAuthenticated } returns isAuthenticatedFlow
-        every { tokenStore.getServerUrl() } returns "https://convocados.fly.dev"
+        every { tokenStore.getServerUrl() } returns "https://convocados.cabeda.dev"
         viewModel = AuthViewModel(tokenStore, googleSignIn, apiClient)
     }
 

--- a/fly.toml
+++ b/fly.toml
@@ -7,7 +7,7 @@ primary_region = "cdg"
   HOST = "0.0.0.0"
   PORT = "3000"
   NODE_ENV = "production"
-  BETTER_AUTH_URL = "https://convocados.fly.dev"
+  BETTER_AUTH_URL = "https://convocados.cabeda.dev"
   EMAIL_FROM = "Convocados <noreply@cabeda.dev>"
 
 [http_service]

--- a/scheduler/fly.toml
+++ b/scheduler/fly.toml
@@ -5,7 +5,7 @@ primary_region = "cdg"
   dockerfile = "Dockerfile"
 
 [env]
-  APP_URL = "https://convocados.fly.dev"
+  APP_URL = "https://convocados.cabeda.dev"
   POLL_INTERVAL_MS = "10000"
 
 [[vm]]

--- a/src/lib/auth.server.ts
+++ b/src/lib/auth.server.ts
@@ -127,6 +127,8 @@ export const auth = betterAuth({
   },
   trustedOrigins: [
     baseUrl,
+    // Keep old fly.dev domain as trusted for backwards compatibility
+    "https://convocados.fly.dev",
     // Allow local network access for mobile app development
     ...(process.env.TRUSTED_ORIGINS?.split(",").map((s) => s.trim()).filter(Boolean) ?? []),
   ],

--- a/src/lib/email.server.ts
+++ b/src/lib/email.server.ts
@@ -23,7 +23,7 @@ export function _resetResendClient() {
 const EMAIL_FROM = import.meta.env.EMAIL_FROM ?? process.env.EMAIL_FROM ?? "Convocados <noreply@cabeda.dev>";
 
 function getAppUrl(): string {
-  return import.meta.env.BETTER_AUTH_URL ?? process.env.BETTER_AUTH_URL ?? "https://convocados.fly.dev";
+  return import.meta.env.BETTER_AUTH_URL ?? process.env.BETTER_AUTH_URL ?? "https://convocados.cabeda.dev";
 }
 
 function emailTemplate({ heading, body, buttonText, buttonUrl, footnote }: {
@@ -80,7 +80,7 @@ function emailTemplate({ heading, body, buttonText, buttonUrl, footnote }: {
           <!-- Footer -->
           <tr>
             <td style="padding: 20px 32px; border-top: 1px solid #e8ece9; text-align: center;">
-              <a href="${getAppUrl()}" style="font-size: 12px; color: #8a9b92; text-decoration: none;">convocados.fly.dev</a>
+              <a href="${getAppUrl()}" style="font-size: 12px; color: #8a9b92; text-decoration: none;">convocados.cabeda.dev</a>
             </td>
           </tr>
         </table>

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -27,7 +27,7 @@ export const openApiSpec = {
     license: { name: "MIT" },
   },
   servers: [
-    { url: "https://convocados.fly.dev", description: "Production" },
+    { url: "https://convocados.cabeda.dev", description: "Production" },
     { url: "http://localhost:4321", description: "Local development" },
   ],
   paths: {

--- a/src/lib/push.server.ts
+++ b/src/lib/push.server.ts
@@ -31,7 +31,7 @@ async function init() {
   const webpush = await getWebPush();
   const publicKey = import.meta.env.VAPID_PUBLIC_KEY ?? process.env.VAPID_PUBLIC_KEY ?? "";
   const privateKey = import.meta.env.VAPID_PRIVATE_KEY ?? process.env.VAPID_PRIVATE_KEY ?? "";
-  webpush.setVapidDetails("mailto:admin@convocados.fly.dev", publicKey, privateKey);
+  webpush.setVapidDetails("mailto:admin@cabeda.dev", publicKey, privateKey);
 }
 
 // ── FCM (Firebase Cloud Messaging) ────────────────────────────────────────────

--- a/src/lib/scheduler.server.ts
+++ b/src/lib/scheduler.server.ts
@@ -6,7 +6,7 @@ import { getNotificationPrefs, wantsEmailReminder } from "./notificationPrefs.se
 
 const log = createLogger("scheduler");
 
-const APP_URL = import.meta.env.BETTER_AUTH_URL ?? process.env.BETTER_AUTH_URL ?? "https://convocados.fly.dev";
+const APP_URL = import.meta.env.BETTER_AUTH_URL ?? process.env.BETTER_AUTH_URL ?? "https://convocados.cabeda.dev";
 
 /** Reminder offsets in milliseconds */
 const REMINDER_OFFSETS = {

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -33,7 +33,7 @@ export function generateEventJsonLd(event: EventJsonLdInput): string {
     organizer: {
       "@type": "Organization",
       name: "Convocados",
-      url: "https://convocados.fly.dev",
+      url: "https://convocados.cabeda.dev",
     },
   });
 }

--- a/src/pages/api/cron/reminders.ts
+++ b/src/pages/api/cron/reminders.ts
@@ -14,7 +14,7 @@ import pLimit from "p-limit";
 const log = createLogger("cron");
 
 const CRON_SECRET = import.meta.env.CRON_SECRET ?? process.env.CRON_SECRET;
-const APP_URL = import.meta.env.BETTER_AUTH_URL ?? process.env.BETTER_AUTH_URL ?? "https://convocados.fly.dev";
+const APP_URL = import.meta.env.BETTER_AUTH_URL ?? process.env.BETTER_AUTH_URL ?? "https://convocados.cabeda.dev";
 
 /** Max concurrent outbound email sends to avoid overwhelming the SMTP provider */
 const EMAIL_CONCURRENCY = 10;

--- a/src/pages/api/events/[id]/admins.ts
+++ b/src/pages/api/events/[id]/admins.ts
@@ -10,7 +10,7 @@ import { createLogger } from "../../../../lib/logger.server";
 const log = createLogger("event-admins");
 
 function getAppUrl(): string {
-  return import.meta.env.BETTER_AUTH_URL ?? process.env.BETTER_AUTH_URL ?? "https://convocados.fly.dev";
+  return import.meta.env.BETTER_AUTH_URL ?? process.env.BETTER_AUTH_URL ?? "https://convocados.cabeda.dev";
 }
 
 /** GET — List admins for an event (owner only). */

--- a/src/pages/api/events/[id]/calendar.ics.ts
+++ b/src/pages/api/events/[id]/calendar.ics.ts
@@ -28,7 +28,7 @@ export const GET: APIRoute = async ({ params, request }) => {
     return new Response("Event not found", { status: 404 });
   }
 
-  const host = request.headers.get("x-forwarded-host") ?? request.headers.get("host") ?? "convocados.fly.dev";
+  const host = request.headers.get("x-forwarded-host") ?? request.headers.get("host") ?? "convocados.cabeda.dev";
   const proto = request.headers.get("x-forwarded-proto") ?? "https";
 
   const calendarEvents = [

--- a/src/pages/api/events/[id]/calendar.ts
+++ b/src/pages/api/events/[id]/calendar.ts
@@ -7,7 +7,7 @@ export const GET: APIRoute = async ({ params, request }) => {
   const event = await prisma.event.findUnique({ where: { id: params.id } });
   if (!event) return new Response("Not found", { status: 404 });
 
-  const host = request.headers.get("x-forwarded-host") ?? request.headers.get("host") ?? "convocados.fly.dev";
+  const host = request.headers.get("x-forwarded-host") ?? request.headers.get("host") ?? "convocados.cabeda.dev";
   const proto = request.headers.get("x-forwarded-proto") ?? "https";
   const url = `${proto}://${host}/events/${event.id}`;
 

--- a/src/pages/api/events/[id]/players.ts
+++ b/src/pages/api/events/[id]/players.ts
@@ -195,7 +195,7 @@ export const POST: APIRoute = async ({ params, request }) => {
   if (limited) return limited;
 
   const eventId = params.id ?? "";
-  const host = request.headers.get("x-forwarded-host") ?? request.headers.get("host") ?? "convocados.fly.dev";
+  const host = request.headers.get("x-forwarded-host") ?? request.headers.get("host") ?? "convocados.cabeda.dev";
   const proto = request.headers.get("x-forwarded-proto") ?? "https";
   const origin = `${proto}://${host}`;
   const session = await getSession(request);
@@ -332,7 +332,7 @@ export const DELETE: APIRoute = async ({ params, request }) => {
   if (limited) return limited;
 
   const eventId = params.id ?? "";
-  const host = request.headers.get("x-forwarded-host") ?? request.headers.get("host") ?? "convocados.fly.dev";
+  const host = request.headers.get("x-forwarded-host") ?? request.headers.get("host") ?? "convocados.cabeda.dev";
   const proto = request.headers.get("x-forwarded-proto") ?? "https";
   const origin = `${proto}://${host}`;
   const { playerId } = await request.json();

--- a/src/pages/api/users/[id]/calendar.ics.ts
+++ b/src/pages/api/users/[id]/calendar.ics.ts
@@ -49,7 +49,7 @@ export const GET: APIRoute = async ({ params, request }) => {
   // Sort by date
   allEvents.sort((a, b) => a.dateTime.getTime() - b.dateTime.getTime());
 
-  const host = request.headers.get("x-forwarded-host") ?? request.headers.get("host") ?? "convocados.fly.dev";
+  const host = request.headers.get("x-forwarded-host") ?? request.headers.get("host") ?? "convocados.cabeda.dev";
   const proto = request.headers.get("x-forwarded-proto") ?? "https";
 
   const calendarEvents = allEvents.map((e) => ({

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -2,7 +2,7 @@ import type { APIRoute } from "astro";
 import { prisma } from "../lib/db.server";
 
 export const GET: APIRoute = async ({ request }) => {
-  const host = request.headers.get("x-forwarded-host") ?? request.headers.get("host") ?? "convocados.fly.dev";
+  const host = request.headers.get("x-forwarded-host") ?? request.headers.get("host") ?? "convocados.cabeda.dev";
   const proto = request.headers.get("x-forwarded-proto") ?? "https";
   const base = `${proto}://${host}`;
 


### PR DESCRIPTION
## Summary

Makes `https://convocados.cabeda.dev` the canonical domain for the application, replacing `convocados.fly.dev` as the primary URL.

## Changes

- **fly.toml**: `BETTER_AUTH_URL` → `https://convocados.cabeda.dev`
- **scheduler/fly.toml**: `APP_URL` → `https://convocados.cabeda.dev`
- **auth.server.ts**: Added `https://convocados.fly.dev` to `trustedOrigins` for backwards compatibility
- **All hardcoded fallbacks**: Updated across email, scheduler, cron, openapi, seo, push, calendar, sitemap
- **Android app + Wear OS**: Default server URL updated in TokenStore, login/profile placeholders, and tests

## Impact

- Users accessing via `convocados.fly.dev` will still reach the app (same Fly machine)
- Auth requests from `convocados.fly.dev` are still trusted (in trustedOrigins)
- **Users will need to re-login once** — session cookies are domain-scoped and won't transfer
- OAuth tokens with `iss: convocados.fly.dev` will no longer validate — mobile app users need to re-authenticate

## Prerequisites

Ensure `convocados.cabeda.dev` is configured as a custom domain on the Fly app (`fly certs add convocados.cabeda.dev`).