### PR TITLE
fix: MVP candidates always from teamsSnapshot, not current roster

### DIFF
--- a/src/components/HistoryPage.tsx
+++ b/src/components/HistoryPage.tsx
@@ -1055,11 +1055,6 @@ function HistoryCardFull({
             <MvpVotingCard
               eventId={eventId}
               historyId={entry.id}
-              participants={(() => {
-                // Only show players who participated in this specific game
-                const gamePlayerNames = new Set(teams.flatMap((t) => t.players.map((p) => p.name.toLowerCase())));
-                return eventPlayers.filter((p) => gamePlayerNames.has(p.name.toLowerCase()));
-              })()}
             />
           </Box>
         )}

--- a/src/components/MvpVotingCard.tsx
+++ b/src/components/MvpVotingCard.tsx
@@ -25,12 +25,10 @@ interface MvpData {
 interface Props {
   eventId: string;
   historyId: string;
-  /** All player names from the teamsSnapshot — used as vote candidates */
-  participants: { id: string; name: string }[];
   compact?: boolean;
 }
 
-export function MvpVotingCard({ eventId, historyId, participants, compact }: Props) {
+export function MvpVotingCard({ eventId, historyId, compact }: Props) {
   const t = useT();
   const theme = useTheme();
   const { data: session } = useSession();
@@ -81,7 +79,7 @@ export function MvpVotingCard({ eventId, historyId, participants, compact }: Pro
 
   const { mvp, isVotingOpen, hasVoted } = data;
   const canVote = isVotingOpen && isAuthenticated && hasVoted === false;
-  const voteCandidates = participants.length > 0 ? participants : (data.participants ?? []);
+  const voteCandidates = data.participants ?? [];
 
   // Show MVP result badge (voting closed with votes, or already voted and results available)
   if (mvp && mvp.length > 0 && (!canVote || !isVotingOpen)) {

--- a/src/components/PostGameBanner.tsx
+++ b/src/components/PostGameBanner.tsx
@@ -52,17 +52,13 @@ export function PostGameBanner({ eventId, canEdit, onScrollToScore, onScrollToPa
   const [paymentsDirty, setPaymentsDirty] = useState(false);
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
-  const [eventPlayers, setEventPlayers] = useState<{ id: string; name: string }[]>([]);
 
   const onStatusChangeRef = useRef(onStatusChange);
   onStatusChangeRef.current = onStatusChange;
 
   const fetchStatus = useCallback(async () => {
     try {
-      const [statusRes, eventRes] = await Promise.all([
-        fetch(`/api/events/${eventId}/post-game-status`),
-        eventPlayers.length === 0 ? fetch(`/api/events/${eventId}`) : null,
-      ]);
+      const statusRes = await fetch(`/api/events/${eventId}/post-game-status`);
       if (statusRes.ok) {
         const data = await statusRes.json();
         setStatus(data);
@@ -71,12 +67,8 @@ export function PostGameBanner({ eventId, canEdit, onScrollToScore, onScrollToPa
           setEditablePayments(data.paymentsSnapshot);
         }
       }
-      if (eventRes?.ok) {
-        const ev = await eventRes.json();
-        setEventPlayers((ev.players ?? []).map((p: any) => ({ id: p.id, name: p.name })));
-      }
     } catch { /* ignore */ }
-  }, [eventId, paymentsDirty, eventPlayers.length]);
+  }, [eventId, paymentsDirty]);
 
   useEffect(() => {
     fetchStatus();
@@ -330,7 +322,6 @@ export function PostGameBanner({ eventId, canEdit, onScrollToScore, onScrollToPa
                 <MvpVotingCard
                   eventId={eventId}
                   historyId={status.latestHistoryId}
-                  participants={eventPlayers}
                   compact
                 />
               </Box>

--- a/src/test/mvp-vote.test.ts
+++ b/src/test/mvp-vote.test.ts
@@ -665,3 +665,75 @@ describe("POST mvp-vote (name-based)", () => {
     expect(body.error).toMatch(/not found/i);
   });
 });
+
+// ─── GET /api/events/[id]/history/[historyId]/mvp — candidates source ────────
+
+describe("GET mvp — candidates from teamsSnapshot", () => {
+  it("returns all players from teamsSnapshot including anonymous (no Player record)", async () => {
+    const user = await seedUser("Alice");
+    mockAuth(user.id, "Alice");
+    const event = await seedEvent();
+    await seedPlayer(event.id, "Alice", user.id);
+    // "AnonPlayer" has no Player record — only exists in teamsSnapshot
+    const history = await seedHistory(event.id, {
+      teamsSnapshot: JSON.stringify([
+        { team: "Ninjas", players: [{ name: "Alice", order: 0 }, { name: "AnonPlayer", order: 1 }] },
+        { team: "Gunas", players: [{ name: "Bob", order: 0 }] },
+      ]),
+    });
+
+    const res = await getMvp(getCtx({ id: event.id, historyId: history.id }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const names = body.participants.map((p: { name: string }) => p.name);
+    expect(names).toContain("AnonPlayer");
+    expect(names).toContain("Alice");
+    expect(names).toContain("Bob");
+    // AnonPlayer should have a name-based ID
+    const anon = body.participants.find((p: { name: string }) => p.name === "AnonPlayer");
+    expect(anon.id).toBe("name:AnonPlayer");
+  });
+
+  it("returns players who left the event after the game", async () => {
+    const user = await seedUser("Alice");
+    mockAuth(user.id, "Alice");
+    const event = await seedEvent();
+    await seedPlayer(event.id, "Alice", user.id);
+    // "LeftPlayer" was in the game but has since been removed from event
+    const history = await seedHistory(event.id, {
+      teamsSnapshot: JSON.stringify([
+        { team: "Ninjas", players: [{ name: "Alice", order: 0 }, { name: "LeftPlayer", order: 1 }] },
+        { team: "Gunas", players: [{ name: "Bob", order: 0 }] },
+      ]),
+    });
+    // LeftPlayer has no Player record (removed from event)
+
+    const res = await getMvp(getCtx({ id: event.id, historyId: history.id }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const names = body.participants.map((p: { name: string }) => p.name);
+    expect(names).toContain("LeftPlayer");
+  });
+
+  it("allows voting for anonymous players by name-based ID", async () => {
+    const user = await seedUser("Alice");
+    mockAuth(user.id, "Alice");
+    const event = await seedEvent();
+    await seedPlayer(event.id, "Alice", user.id);
+    const history = await seedHistory(event.id, {
+      teamsSnapshot: JSON.stringify([
+        { team: "Ninjas", players: [{ name: "Alice", order: 0 }] },
+        { team: "Gunas", players: [{ name: "AnonPlayer", order: 0 }] },
+      ]),
+    });
+
+    const res = await castMvpVote(postCtx(
+      { id: event.id, historyId: history.id },
+      { votedForPlayerId: "name:AnonPlayer" },
+    ));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.vote.votedForName).toBe("AnonPlayer");
+  });
+});


### PR DESCRIPTION
Closes #340

## Problem

`MvpVotingCard` prioritized the `participants` prop (current event player list) over the API response. This caused:
- Players who left after the game to be missing from MVP candidates
- Anonymous players (no Player record) only appearing via fallback
- Wrong candidate list shown before recurrence reset

## Fix

- Removed `participants` prop from `MvpVotingCard` — always uses `data.participants` from the `GET /api/events/:id/history/:historyId/mvp` endpoint
- Removed `eventPlayers` state and extra fetch from `PostGameBanner` (no longer needed)
- Updated `HistoryPage` to remove the prop

The API endpoint already correctly resolves candidates from `teamsSnapshot`, including anonymous players (with `name:` prefix IDs).

## Tests

- Added 3 new API tests confirming anonymous players, removed players, and name-based voting all work
- All 1086 tests pass (2 pre-existing failures unrelated)