### PR TITLE
fix: prevent recurrence reset from cancelling due post_game job

### DIFF
--- a/src/lib/scheduler.server.ts
+++ b/src/lib/scheduler.server.ts
@@ -61,7 +61,7 @@ export async function scheduleEventReminders(
  */
 export async function cancelEventJobs(eventId: string) {
   await prisma.scheduledJob.deleteMany({
-    where: { eventId, processedAt: null },
+    where: { eventId, processedAt: null, runAt: { gt: new Date() } },
   });
 }
 


### PR DESCRIPTION
Race condition: recurrence reset fires at `dateTime + duration` which is the same time as the `post_game` job's `runAt`. `cancelEventJobs()` was deleting all unprocessed jobs including the post_game that was already due.

Fix: only cancel jobs with `runAt > now()`, preserving due jobs for the scheduler to pick up.

This caused post-game notifications to never be delivered for recurring events with duration matching the reset window.