### PR TITLE
fix: Android notifications + session persistence

### DIFF
--- a/android-app/app/src/main/java/dev/convocados/ui/ConvocadosRoot.kt
+++ b/android-app/app/src/main/java/dev/convocados/ui/ConvocadosRoot.kt
@@ -1,11 +1,16 @@
 package dev.convocados.ui
 
+import android.Manifest
 import android.content.Intent
+import android.os.Build
 import androidx.compose.runtime.*
 import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.google.accompanist.permissions.ExperimentalPermissionsApi
+import com.google.accompanist.permissions.isGranted
+import com.google.accompanist.permissions.rememberPermissionState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dev.convocados.data.api.ConvocadosApi
 import dev.convocados.data.api.UserProfile
@@ -62,9 +67,20 @@ class RootViewModel @Inject constructor(
     }
 }
 
+@OptIn(ExperimentalPermissionsApi::class)
 @Composable
 fun ConvocadosRoot(viewModel: RootViewModel = hiltViewModel()) {
     val isAuthenticated by viewModel.isAuthenticated.collectAsState()
+
+    // Request notification permission on Android 13+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        val permissionState = rememberPermissionState(Manifest.permission.POST_NOTIFICATIONS)
+        LaunchedEffect(Unit) {
+            if (!permissionState.status.isGranted) {
+                permissionState.launchPermissionRequest()
+            }
+        }
+    }
 
     // Handle deep link intent
     val context = LocalContext.current

--- a/src/lib/auth.server.ts
+++ b/src/lib/auth.server.ts
@@ -102,7 +102,7 @@ export const auth = betterAuth({
       allowPlainCodeChallengeMethod: false,
       allowDynamicClientRegistration: true,
       accessTokenExpiresIn: 3600, // 1 hour
-      refreshTokenExpiresIn: 604800, // 7 days
+      refreshTokenExpiresIn: 15552000, // 180 days
       codeExpiresIn: 600, // 10 minutes
       scopes: OAUTH_SCOPES,
       defaultScope: "openid",


### PR DESCRIPTION
**Android notifications not received:**
The app never requested `POST_NOTIFICATIONS` permission on launch (only on the notification settings screen). Most users never navigated there, so notifications were silently blocked by the OS. Now requests permission on first app launch.

**Frequent re-authentication:**
OAuth refresh token lifetime was 7 days. After a week without opening the app, users had to sign in again. Increased to 180 days to match industry standards (GitHub, Google don't require frequent re-auth for mobile apps).