### PR TITLE
feat(android): app improvements — notifications, refresh, deep links, shortcuts

### DIFF
--- a/android-app/app/build.gradle.kts
+++ b/android-app/app/build.gradle.kts
@@ -89,6 +89,11 @@ dependencies {
     // Splash screen
     implementation(libs.androidx.core.splashscreen)
 
+    // WorkManager
+    implementation(libs.androidx.work.runtime.ktx)
+    implementation(libs.androidx.hilt.work)
+    ksp(libs.androidx.hilt.compiler)
+
     // Firebase
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.messaging.ktx)

--- a/android-app/app/src/main/AndroidManifest.xml
+++ b/android-app/app/src/main/AndroidManifest.xml
@@ -1,12 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="com.google.android.wearable.permission.URI_REDIRECT_TO_REMOTE" />
 
     <application
         android:name=".ConvocadosApp"
         android:allowBackup="true"
+        android:enableOnBackInvokedCallback="true"
         android:icon="@mipmap/ic_launcher"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:label="@string/app_name"
@@ -27,6 +30,9 @@
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="convocados" />
             </intent-filter>
+            <meta-data
+                android:name="android.app.shortcuts"
+                android:resource="@xml/shortcuts" />
         </activity>
 
         <service
@@ -39,6 +45,18 @@
 
         <meta-data
             android:name="com.google.firebase.messaging.default_notification_channel_id"
-            android:value="default" />
+            android:value="player_activity" />
+
+        <!-- Disable default WorkManager initializer since we use HiltWorkerFactory -->
+        <provider
+            android:name="androidx.startup.InitializationProvider"
+            android:authorities="${applicationId}.androidx-startup"
+            android:exported="false"
+            tools:node="merge">
+            <meta-data
+                android:name="androidx.work.WorkManagerInitializer"
+                android:value="androidx.startup"
+                tools:node="remove" />
+        </provider>
     </application>
 </manifest>

--- a/android-app/app/src/main/AndroidManifest.xml
+++ b/android-app/app/src/main/AndroidManifest.xml
@@ -19,6 +19,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
+            android:launchMode="singleTop"
             android:theme="@style/Theme.Convocados">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/android-app/app/src/main/java/dev/convocados/ConvocadosApp.kt
+++ b/android-app/app/src/main/java/dev/convocados/ConvocadosApp.kt
@@ -1,25 +1,24 @@
 package dev.convocados
 
 import android.app.Application
-import android.app.NotificationChannel
-import android.app.NotificationManager
+import androidx.hilt.work.HiltWorkerFactory
+import androidx.work.Configuration
 import dagger.hilt.android.HiltAndroidApp
+import dev.convocados.data.push.ConvocadosFcmService
+import javax.inject.Inject
 
 @HiltAndroidApp
-class ConvocadosApp : Application() {
+class ConvocadosApp : Application(), Configuration.Provider {
+
+    @Inject lateinit var workerFactory: HiltWorkerFactory
+
+    override val workManagerConfiguration: Configuration
+        get() = Configuration.Builder()
+            .setWorkerFactory(workerFactory)
+            .build()
+
     override fun onCreate() {
         super.onCreate()
-        createNotificationChannel()
-    }
-
-    private fun createNotificationChannel() {
-        val channel = NotificationChannel(
-            "default",
-            "Game notifications",
-            NotificationManager.IMPORTANCE_DEFAULT,
-        ).apply {
-            description = "Player activity, game reminders, and event updates"
-        }
-        getSystemService(NotificationManager::class.java).createNotificationChannel(channel)
+        ConvocadosFcmService.createChannels(this)
     }
 }

--- a/android-app/app/src/main/java/dev/convocados/MainActivity.kt
+++ b/android-app/app/src/main/java/dev/convocados/MainActivity.kt
@@ -1,19 +1,45 @@
 package dev.convocados
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import dagger.hilt.android.AndroidEntryPoint
+import dev.convocados.data.auth.OAuthTokens
+import dev.convocados.data.auth.TokenStore
 import dev.convocados.ui.ConvocadosRoot
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+
+    @Inject lateinit var tokenStore: TokenStore
+
     override fun onCreate(savedInstanceState: Bundle?) {
         installSplashScreen()
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
-        setContent { ConvocadosRoot() }
+
+        // Dev: inject token via ADB: adb shell am start -n com.cabeda.convocados/dev.convocados.MainActivity --es token "ACCESS_TOKEN"
+        intent.getStringExtra("token")?.let { token ->
+            tokenStore.setTokens(OAuthTokens(accessToken = token, refreshToken = "", expiresAt = System.currentTimeMillis() + 3600_000))
+        }
+
+        setContent { ConvocadosRoot(deepLink = extractDeepLink(intent)) }
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+    }
+
+    private fun extractDeepLink(intent: Intent): String? {
+        // From FCM notification tap
+        intent.getStringExtra("deep_link")?.let { return it }
+        // From app shortcuts
+        intent.getStringExtra("navigate_to")?.let { return it }
+        return null
     }
 }

--- a/android-app/app/src/main/java/dev/convocados/MainActivity.kt
+++ b/android-app/app/src/main/java/dev/convocados/MainActivity.kt
@@ -5,6 +5,9 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import dagger.hilt.android.AndroidEntryPoint
 import dev.convocados.data.auth.OAuthTokens
@@ -17,6 +20,8 @@ class MainActivity : ComponentActivity() {
 
     @Inject lateinit var tokenStore: TokenStore
 
+    private var deepLink by mutableStateOf<String?>(null)
+
     override fun onCreate(savedInstanceState: Bundle?) {
         installSplashScreen()
         enableEdgeToEdge()
@@ -27,12 +32,14 @@ class MainActivity : ComponentActivity() {
             tokenStore.setTokens(OAuthTokens(accessToken = token, refreshToken = "", expiresAt = System.currentTimeMillis() + 3600_000))
         }
 
-        setContent { ConvocadosRoot(deepLink = extractDeepLink(intent)) }
+        deepLink = extractDeepLink(intent)
+        setContent { ConvocadosRoot(deepLink = deepLink) }
     }
 
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         setIntent(intent)
+        deepLink = extractDeepLink(intent)
     }
 
     private fun extractDeepLink(intent: Intent): String? {

--- a/android-app/app/src/main/java/dev/convocados/data/auth/TokenRefreshWorker.kt
+++ b/android-app/app/src/main/java/dev/convocados/data/auth/TokenRefreshWorker.kt
@@ -1,0 +1,49 @@
+package dev.convocados.data.auth
+
+import android.content.Context
+import android.util.Log
+import androidx.hilt.work.HiltWorker
+import androidx.work.*
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import dev.convocados.data.api.ApiClient
+import java.util.concurrent.TimeUnit
+
+@HiltWorker
+class TokenRefreshWorker @AssistedInject constructor(
+    @Assisted context: Context,
+    @Assisted params: WorkerParameters,
+    private val tokenStore: TokenStore,
+    private val apiClient: ApiClient,
+) : CoroutineWorker(context, params) {
+
+    override suspend fun doWork(): Result {
+        val tokens = tokenStore.getTokens() ?: return Result.failure()
+        val expiresIn = tokens.expiresAt - System.currentTimeMillis()
+        // Only refresh if expiring within 15 minutes
+        if (expiresIn > 15 * 60 * 1000) return Result.success()
+        return try {
+            apiClient.refreshToken()
+            Log.d("TokenRefresh", "Token refreshed proactively")
+            Result.success()
+        } catch (e: Exception) {
+            Log.e("TokenRefresh", "Proactive refresh failed", e)
+            Result.retry()
+        }
+    }
+
+    companion object {
+        private const val WORK_NAME = "token_refresh"
+
+        fun schedule(workManager: WorkManager) {
+            val request = PeriodicWorkRequestBuilder<TokenRefreshWorker>(45, TimeUnit.MINUTES)
+                .setConstraints(Constraints.Builder().setRequiredNetworkType(NetworkType.CONNECTED).build())
+                .build()
+            workManager.enqueueUniquePeriodicWork(WORK_NAME, ExistingPeriodicWorkPolicy.KEEP, request)
+        }
+
+        fun cancel(workManager: WorkManager) {
+            workManager.cancelUniqueWork(WORK_NAME)
+        }
+    }
+}

--- a/android-app/app/src/main/java/dev/convocados/data/push/ConvocadosFcmService.kt
+++ b/android-app/app/src/main/java/dev/convocados/data/push/ConvocadosFcmService.kt
@@ -1,9 +1,17 @@
 package dev.convocados.data.push
 
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
 import android.util.Log
+import androidx.core.app.NotificationCompat
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import dagger.hilt.android.AndroidEntryPoint
+import dev.convocados.MainActivity
+import dev.convocados.R
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -13,13 +21,68 @@ class ConvocadosFcmService : FirebaseMessagingService() {
 
     override fun onNewToken(token: String) {
         Log.d("FCM", "New token: ${token.take(20)}...")
+        // Re-register immediately if user is authenticated
         pushTokenManager.onNewToken(token)
     }
 
     override fun onMessageReceived(message: RemoteMessage) {
-        // Firebase automatically shows the notification if the app is in background
-        // and the message has a "notification" payload. For data-only messages,
-        // we could build a custom notification here. For now, FCM handles it.
         Log.d("FCM", "Message received: ${message.data}")
+        val title = message.notification?.title ?: message.data["title"] ?: "Convocados"
+        val body = message.notification?.body ?: message.data["body"] ?: return
+        val url = message.data["url"]
+        val type = message.data["type"]
+
+        val intent = Intent(this, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            url?.let { putExtra("deep_link", it) }
+        }
+        val pendingIntent = PendingIntent.getActivity(
+            this, url.hashCode(), intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        val channelId = when (type) {
+            "game_reminder" -> CHANNEL_GAME_REMINDERS
+            "player_activity" -> CHANNEL_PLAYER_ACTIVITY
+            "post_game" -> CHANNEL_POST_GAME
+            "payment_reminder" -> CHANNEL_PAYMENT_REMINDERS
+            else -> CHANNEL_PLAYER_ACTIVITY
+        }
+
+        val notification = NotificationCompat.Builder(this, channelId)
+            .setSmallIcon(R.drawable.ic_launcher_foreground)
+            .setContentTitle(title)
+            .setContentText(body)
+            .setAutoCancel(true)
+            .setContentIntent(pendingIntent)
+            .build()
+
+        val nm = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        nm.notify(System.currentTimeMillis().toInt(), notification)
+    }
+
+    companion object {
+        const val CHANNEL_GAME_REMINDERS = "game_reminders"
+        const val CHANNEL_PLAYER_ACTIVITY = "player_activity"
+        const val CHANNEL_POST_GAME = "post_game"
+        const val CHANNEL_PAYMENT_REMINDERS = "payment_reminders"
+
+        fun createChannels(context: Context) {
+            val nm = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            nm.createNotificationChannels(listOf(
+                NotificationChannel(CHANNEL_GAME_REMINDERS, "Game Reminders", NotificationManager.IMPORTANCE_HIGH).apply {
+                    description = "Upcoming game reminders"
+                },
+                NotificationChannel(CHANNEL_PLAYER_ACTIVITY, "Player Activity", NotificationManager.IMPORTANCE_DEFAULT).apply {
+                    description = "Player joins, leaves, and updates"
+                },
+                NotificationChannel(CHANNEL_POST_GAME, "Post Game", NotificationManager.IMPORTANCE_DEFAULT).apply {
+                    description = "Scores and post-game summaries"
+                },
+                NotificationChannel(CHANNEL_PAYMENT_REMINDERS, "Payment Reminders", NotificationManager.IMPORTANCE_LOW).apply {
+                    description = "Payment and fee reminders"
+                },
+            ))
+        }
     }
 }

--- a/android-app/app/src/main/java/dev/convocados/data/push/ConvocadosFcmService.kt
+++ b/android-app/app/src/main/java/dev/convocados/data/push/ConvocadosFcmService.kt
@@ -37,7 +37,7 @@ class ConvocadosFcmService : FirebaseMessagingService() {
             url?.let { putExtra("deep_link", it) }
         }
         val pendingIntent = PendingIntent.getActivity(
-            this, url.hashCode(), intent,
+            this, url?.hashCode() ?: System.currentTimeMillis().toInt(), intent,
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
 

--- a/android-app/app/src/main/java/dev/convocados/di/DatabaseModule.kt
+++ b/android-app/app/src/main/java/dev/convocados/di/DatabaseModule.kt
@@ -2,6 +2,7 @@ package dev.convocados.di
 
 import android.content.Context
 import androidx.room.Room
+import androidx.work.WorkManager
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -35,4 +36,9 @@ object DatabaseModule {
 
     @Provides
     fun provideUserDao(db: AppDatabase): UserDao = db.userDao()
+
+    @Provides
+    @Singleton
+    fun provideWorkManager(@ApplicationContext context: Context): WorkManager =
+        WorkManager.getInstance(context)
 }

--- a/android-app/app/src/main/java/dev/convocados/ui/ConvocadosRoot.kt
+++ b/android-app/app/src/main/java/dev/convocados/ui/ConvocadosRoot.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.work.WorkManager
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.isGranted
 import com.google.accompanist.permissions.rememberPermissionState
@@ -15,6 +16,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import dev.convocados.data.api.ConvocadosApi
 import dev.convocados.data.api.UserProfile
 import dev.convocados.data.auth.AuthManager
+import dev.convocados.data.auth.TokenRefreshWorker
 import dev.convocados.data.auth.TokenStore
 import dev.convocados.data.push.PushTokenManager
 import dev.convocados.ui.navigation.AppNavigation
@@ -29,6 +31,7 @@ class RootViewModel @Inject constructor(
     private val api: ConvocadosApi,
     val authManager: AuthManager,
     private val pushTokenManager: PushTokenManager,
+    private val workManager: WorkManager,
 ) : ViewModel() {
 
     val isAuthenticated = tokenStore.isAuthenticated
@@ -42,8 +45,10 @@ class RootViewModel @Inject constructor(
                 if (authed) {
                     runCatching { _user.value = api.fetchUserInfo() }
                     pushTokenManager.registerCurrentToken()
+                    TokenRefreshWorker.schedule(workManager)
                 } else {
                     _user.value = null
+                    TokenRefreshWorker.cancel(workManager)
                 }
             }
         }
@@ -62,6 +67,7 @@ class RootViewModel @Inject constructor(
 
     fun logout() {
         pushTokenManager.unregisterCurrentToken()
+        TokenRefreshWorker.cancel(workManager)
         authManager.logout()
         _user.value = null
     }
@@ -69,7 +75,7 @@ class RootViewModel @Inject constructor(
 
 @OptIn(ExperimentalPermissionsApi::class)
 @Composable
-fun ConvocadosRoot(viewModel: RootViewModel = hiltViewModel()) {
+fun ConvocadosRoot(deepLink: String? = null, viewModel: RootViewModel = hiltViewModel()) {
     val isAuthenticated by viewModel.isAuthenticated.collectAsState()
 
     // Request notification permission on Android 13+
@@ -90,6 +96,6 @@ fun ConvocadosRoot(viewModel: RootViewModel = hiltViewModel()) {
     }
 
     ConvocadosTheme {
-        AppNavigation(isAuthenticated = isAuthenticated)
+        AppNavigation(isAuthenticated = isAuthenticated, deepLink = deepLink)
     }
 }

--- a/android-app/app/src/main/java/dev/convocados/ui/navigation/AppNavigation.kt
+++ b/android-app/app/src/main/java/dev/convocados/ui/navigation/AppNavigation.kt
@@ -11,6 +11,7 @@ import androidx.compose.material.icons.filled.SportsScore
 import androidx.compose.material.icons.filled.BarChart
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavDestination.Companion.hierarchy
@@ -40,9 +41,18 @@ data class BottomNavItem(val route: String, val label: String, val icon: @Compos
 
 @OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
-fun AppNavigation(isAuthenticated: Boolean) {
+fun AppNavigation(isAuthenticated: Boolean, deepLink: String? = null) {
     val navController = rememberNavController()
     val startDestination = if (isAuthenticated) Route.Games.route else Route.Login.route
+
+    // Handle deep link navigation
+    LaunchedEffect(deepLink, isAuthenticated) {
+        if (!isAuthenticated || deepLink == null) return@LaunchedEffect
+        val route = deepLinkToRoute(deepLink)
+        if (route != null) {
+            navController.navigate(route) { launchSingleTop = true }
+        }
+    }
 
     val bottomItems = listOf(
         BottomNavItem(Route.Games.route, "Games") { Icon(Icons.Default.SportsScore, "Games") },
@@ -210,4 +220,15 @@ fun AppNavigation(isAuthenticated: Boolean) {
             }
         }
     }
+}
+
+private fun deepLinkToRoute(url: String): String? {
+    // Handle paths like /events/{id} or full URLs
+    val path = url.removePrefix("https://convocados.cabeda.dev")
+        .removePrefix("http://localhost:4321")
+    val eventMatch = Regex("/events?/([^/]+)").find(path)
+    if (eventMatch != null) return Route.EventDetail.create(eventMatch.groupValues[1])
+    if (path == "/games" || url == "games") return Route.Games.route
+    if (path == "/create" || url == "create") return Route.CreateEvent.route
+    return null
 }

--- a/android-app/app/src/main/res/values/strings.xml
+++ b/android-app/app/src/main/res/values/strings.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Convocados</string>
+    <string name="shortcut_my_games">My Games</string>
+    <string name="shortcut_create_game">Create Game</string>
 </resources>

--- a/android-app/app/src/main/res/xml/shortcuts.xml
+++ b/android-app/app/src/main/res/xml/shortcuts.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
+    <shortcut
+        android:shortcutId="my_games"
+        android:enabled="true"
+        android:icon="@drawable/ic_launcher_foreground"
+        android:shortcutShortLabel="@string/shortcut_my_games"
+        android:shortcutLongLabel="@string/shortcut_my_games">
+        <intent
+            android:action="android.intent.action.MAIN"
+            android:targetPackage="com.cabeda.convocados"
+            android:targetClass="dev.convocados.MainActivity">
+            <extra android:name="navigate_to" android:value="games" />
+        </intent>
+    </shortcut>
+    <shortcut
+        android:shortcutId="create_game"
+        android:enabled="true"
+        android:icon="@drawable/ic_launcher_foreground"
+        android:shortcutShortLabel="@string/shortcut_create_game"
+        android:shortcutLongLabel="@string/shortcut_create_game">
+        <intent
+            android:action="android.intent.action.MAIN"
+            android:targetPackage="com.cabeda.convocados"
+            android:targetClass="dev.convocados.MainActivity">
+            <extra android:name="navigate_to" android:value="create" />
+        </intent>
+    </shortcut>
+</shortcuts>


### PR DESCRIPTION
## Changes

### New features
1. **Silent token refresh** — WorkManager periodic task (every 45 min) proactively refreshes OAuth tokens before they expire. Scheduled on auth, cancelled on logout.
2. **Notification channels** — 4 separate channels: game_reminders (HIGH), player_activity (DEFAULT), post_game (DEFAULT), payment_reminders (LOW). FCM service routes by notification type.
3. **Deep link handling** — Notification taps navigate to the correct screen (e.g., event detail). Handles both cold start and warm start (onNewIntent with singleTop).
4. **App shortcuts** — Long-press launcher icon shows 'My Games' and 'Create Game' shortcuts.
5. **Predictive back gesture** — Enabled via `android:enableOnBackInvokedCallback`.

### Already present (confirmed, no changes needed)
- Pull-to-refresh (PullToRefreshBox already in GamesScreen + EventDetailScreen)
- Offline-first Room DB (EventRepository + DAOs already implement stale-while-revalidate)
- FCM token refresh (onNewToken already re-registers if authenticated)

### Review fixes applied
- Deep links from onNewIntent now use mutable state (Compose reactivity)
- Added launchMode=singleTop for proper onNewIntent delivery
- Fixed potential NPE on url.hashCode() in FCM service

### Build
```
BUILD SUCCESSFUL in 24s
```