### PR TITLE
feat(wear): standalone Google sign-in on Wear OS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ android-app/build/
 android-app/local.properties
 android-app/wear/local.properties
 android-app/app/google-services.json
+android-app/wear/google-oauth-android-client.json
 android-app/gradle/gradle-daemon-jvm.properties
 android-app/wear/build
 android-app/wear/.gradle

--- a/android-app/wear/src/main/java/dev/convocados/wear/data/api/WearApiClient.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/data/api/WearApiClient.kt
@@ -12,6 +12,9 @@ import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.serialization.kotlinx.json.*
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonObject
 import java.security.SecureRandom
 import java.security.cert.X509Certificate
 import javax.inject.Inject
@@ -135,20 +138,60 @@ class WearApiClient @Inject constructor(private val tokenStore: WearTokenStore) 
     }
 
     /**
-     * Exchange a Google ID token for Convocados OAuth tokens (unauthenticated).
-     * Uses better-auth's built-in social sign-in callback endpoint, which is
-     * already configured with GOOGLE_CLIENT_ID / GOOGLE_CLIENT_SECRET on the backend.
+     * Exchange a Google ID token for Convocados OAuth tokens (standalone, no phone).
+     *
+     * 1. Signs in to better-auth using the Google ID token (built-in social
+     *    sign-in with ID token) to obtain a session cookie.
+     * 2. Exchanges that session for OAuth access/refresh tokens via the
+     *    mobile-callback flow (same as the email path).
      */
     suspend fun exchangeGoogleToken(idToken: String): OAuthTokenResponse {
-        val response = client.post("$baseUrl/api/auth/callback/google") {
+        val signInResponse = client.post("$baseUrl/api/auth/sign-in/social") {
             contentType(ContentType.Application.Json)
-            setBody(mapOf("idToken" to idToken, "callbackURL" to "/"))
+            setBody(buildJsonObject {
+                put("provider", "google")
+                putJsonObject("idToken") { put("token", idToken) }
+            })
         }
-        if (!response.status.isSuccess()) {
-            val errorBody = runCatching { response.bodyAsText() }.getOrDefault("")
-            throw ApiException(response.status.value, "Google token exchange failed: $errorBody")
+        if (!signInResponse.status.isSuccess()) {
+            val errorBody = runCatching { signInResponse.bodyAsText() }.getOrDefault("")
+            throw ApiException(signInResponse.status.value, "Google sign-in failed: $errorBody")
         }
-        return response.body()
+
+        val cookies = signInResponse.headers.getAll("Set-Cookie")
+            ?.joinToString("; ") { it.substringBefore(";") }
+            ?: throw ApiException(401, "No session cookie returned")
+
+        return exchangeSessionForTokens(cookies)
+    }
+
+    /**
+     * Given a better-auth session cookie, run the mobile-callback flow to get
+     * OAuth access/refresh tokens for the mobile-app client.
+     */
+    private suspend fun exchangeSessionForTokens(cookies: String): OAuthTokenResponse {
+        // GET mobile-callback to get a one-time code (redirect carries it)
+        val callbackResponse = client.get("$baseUrl/api/auth/mobile-callback") {
+            header("Cookie", cookies)
+            parameter("redirect_uri", "convocados://auth")
+        }
+
+        val redirectLocation = callbackResponse.headers["Location"]
+            ?: throw ApiException(400, "No redirect from mobile-callback")
+
+        val code = redirectLocation.substringAfter("code=").substringBefore("&")
+        if (code.isBlank()) throw ApiException(400, "No code in redirect: $redirectLocation")
+
+        // Exchange the one-time code for OAuth tokens
+        val tokenResponse = client.post("$baseUrl/api/auth/mobile-callback") {
+            contentType(ContentType.Application.Json)
+            setBody(mapOf("code" to code))
+        }
+        if (!tokenResponse.status.isSuccess()) {
+            val errorBody = runCatching { tokenResponse.bodyAsText() }.getOrDefault("")
+            throw ApiException(tokenResponse.status.value, "Token exchange failed: $errorBody")
+        }
+        return tokenResponse.body()
     }
 
     /**
@@ -171,28 +214,7 @@ class WearApiClient @Inject constructor(private val tokenStore: WearTokenStore) 
             ?.joinToString("; ") { it.substringBefore(";") }
             ?: throw ApiException(401, "No session cookie returned")
 
-        // Step 2: GET mobile-callback to get a one-time code
-        val callbackResponse = client.get("$baseUrl/api/auth/mobile-callback") {
-            header("Cookie", cookies)
-            parameter("redirect_uri", "convocados://auth")
-        }
-
-        val redirectLocation = callbackResponse.headers["Location"]
-            ?: throw ApiException(400, "No redirect from mobile-callback")
-
-        val code = redirectLocation.substringAfter("code=").substringBefore("&")
-        if (code.isBlank()) throw ApiException(400, "No code in redirect: $redirectLocation")
-
-        // Step 3: Exchange code for OAuth tokens
-        val tokenResponse = client.post("$baseUrl/api/auth/mobile-callback") {
-            contentType(ContentType.Application.Json)
-            setBody(mapOf("code" to code))
-        }
-        if (!tokenResponse.status.isSuccess()) {
-            val errorBody = runCatching { tokenResponse.bodyAsText() }.getOrDefault("")
-            throw ApiException(tokenResponse.status.value, "Token exchange failed: $errorBody")
-        }
-        return tokenResponse.body()
+        return exchangeSessionForTokens(cookies)
     }
 }
 

--- a/android-app/wear/src/main/java/dev/convocados/wear/data/auth/WearGoogleSignIn.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/data/auth/WearGoogleSignIn.kt
@@ -1,31 +1,34 @@
 package dev.convocados.wear.data.auth
 
 import android.content.Context
+import android.content.Intent
 import android.util.Log
-import androidx.credentials.CredentialManager
-import androidx.credentials.CustomCredential
-import androidx.credentials.GetCredentialRequest
-import androidx.credentials.GetCredentialResponse
-import com.google.android.libraries.identity.googleid.GetGoogleIdOption
-import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
+import com.google.android.gms.auth.api.signin.GoogleSignIn
+import com.google.android.gms.auth.api.signin.GoogleSignInClient
+import com.google.android.gms.auth.api.signin.GoogleSignInOptions
+import com.google.android.gms.tasks.Task
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dev.convocados.wear.BuildConfig
 import dev.convocados.wear.data.api.WearApiClient
+import kotlinx.coroutines.suspendCancellableCoroutine
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 
 /**
- * Handles Google Sign-In directly on the Wear OS device.
- * Uses Credential Manager + Google Identity Services to get an ID token,
- * then exchanges it with the Convocados backend via better-auth's
- * existing social sign-in endpoint.
+ * Standalone Google Sign-In on Wear OS using the legacy Google Sign-In API
+ * (GoogleSignInClient).
  *
- * The SERVER_CLIENT_ID must match the GOOGLE_CLIENT_ID env var configured
- * on the backend (see .env.example). This is the *web* client ID from
- * Google Cloud Console, NOT the Android client ID.
+ * Credential Manager's Google provider is NOT supported on Wear OS
+ * ("Google Identity Services do not support this Android Credential Manager
+ * API on Wear OS"), so we use this GMS API instead. It reads the Google
+ * account already configured on the device, so it works on standalone / LTE
+ * watches with no paired phone.
  *
- * This is the primary login method — prominent and seamless on the watch.
- * The Data Layer sync from the phone app is a secondary/fallback path.
+ * requestIdToken uses the server (web) client ID — which must match the
+ * GOOGLE_CLIENT_ID env var on the backend — so better-auth can verify the
+ * ID token via /api/auth/sign-in/social.
  */
 @Singleton
 class WearGoogleSignIn @Inject constructor(
@@ -33,65 +36,68 @@ class WearGoogleSignIn @Inject constructor(
     private val apiClient: WearApiClient,
     private val tokenStore: WearTokenStore,
 ) {
-    private val credentialManager = CredentialManager.create(context)
-
-    /**
-     * Build the credential request for Google Sign-In.
-     * Uses the server (web) client ID so the backend can verify the ID token.
-     */
-    fun buildCredentialRequest(): GetCredentialRequest {
+    fun getClient(): GoogleSignInClient {
         val clientId = BuildConfig.GOOGLE_SERVER_CLIENT_ID
         require(clientId.isNotBlank()) {
             "GOOGLE_SERVER_CLIENT_ID is empty. Add it to android-app/local.properties"
         }
-
-        val googleIdOption = GetGoogleIdOption.Builder()
-            .setFilterByAuthorizedAccounts(false)
-            .setServerClientId(clientId)
-            .setAutoSelectEnabled(true)
+        val gso = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
+            .requestIdToken(clientId)
+            .requestEmail()
             .build()
-
-        return GetCredentialRequest.Builder()
-            .addCredentialOption(googleIdOption)
-            .build()
+        return GoogleSignIn.getClient(context, gso)
     }
 
-    /**
-     * Process the credential response from Google Sign-In.
-     * Extracts the ID token and exchanges it with the backend using
-     * better-auth's social sign-in callback endpoint.
-     */
-    suspend fun handleSignInResult(result: GetCredentialResponse): Boolean {
-        val credential = result.credential
+    /** Intent that launches the on-device account picker (interactive). */
+    fun getSignInIntent(): Intent = getClient().signInIntent
 
-        if (credential is CustomCredential &&
-            credential.type == GoogleIdTokenCredential.TYPE_GOOGLE_ID_TOKEN_CREDENTIAL
-        ) {
-            val googleIdToken = GoogleIdTokenCredential.createFrom(credential.data)
-            val idToken = googleIdToken.idToken
+    /** Silently sign in using the existing on-device Google account (no UI). */
+    suspend fun trySilentSignIn(): Boolean = try {
+        val account = getClient().silentSignIn().await()
+        exchange(account.idToken)
+    } catch (e: Exception) {
+        Log.d("WearGoogleSignIn", "Silent sign-in unavailable: ${e.message}")
+        false
+    }
 
-            return try {
-                val tokenResponse = apiClient.exchangeGoogleToken(idToken)
-                tokenStore.setTokens(
-                    OAuthTokens(
-                        accessToken = tokenResponse.accessToken,
-                        refreshToken = tokenResponse.refreshToken ?: "",
-                        expiresAt = System.currentTimeMillis() + tokenResponse.expiresIn * 1000,
-                    )
-                )
-                Log.d("WearGoogleSignIn", "Google Sign-In successful")
-                true
-            } catch (e: Exception) {
-                Log.e("WearGoogleSignIn", "Token exchange failed", e)
-                false
-            }
+    /** Handle the result Intent returned from the interactive sign-in flow. */
+    suspend fun handleSignInResult(data: Intent?): Boolean = try {
+        val account = GoogleSignIn.getSignedInAccountFromIntent(data).await()
+        exchange(account.idToken)
+    } catch (e: Exception) {
+        Log.e("WearGoogleSignIn", "Sign-in failed", e)
+        false
+    }
+
+    private suspend fun exchange(idToken: String?): Boolean {
+        if (idToken.isNullOrBlank()) {
+            Log.e("WearGoogleSignIn", "No ID token returned from Google")
+            return false
         }
-
-        Log.w("WearGoogleSignIn", "Unexpected credential type: ${credential.javaClass.name}")
-        return false
+        return try {
+            val tokenResponse = apiClient.exchangeGoogleToken(idToken)
+            tokenStore.setTokens(
+                OAuthTokens(
+                    accessToken = tokenResponse.accessToken,
+                    refreshToken = tokenResponse.refreshToken ?: "",
+                    expiresAt = System.currentTimeMillis() + tokenResponse.expiresIn * 1000,
+                )
+            )
+            Log.d("WearGoogleSignIn", "Google Sign-In successful")
+            true
+        } catch (e: Exception) {
+            Log.e("WearGoogleSignIn", "Token exchange failed", e)
+            false
+        }
     }
 
     suspend fun loginWithEmail(email: String, password: String): dev.convocados.wear.data.api.OAuthTokenResponse {
         return apiClient.loginWithEmail(email, password)
     }
+}
+
+private suspend fun <T> Task<T>.await(): T = suspendCancellableCoroutine { cont ->
+    addOnSuccessListener { cont.resume(it) }
+    addOnFailureListener { cont.resumeWithException(it) }
+    addOnCanceledListener { cont.cancel() }
 }

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/auth/AuthScreen.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/auth/AuthScreen.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -14,7 +13,6 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.credentials.CredentialManager
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.wear.compose.material3.*
 import androidx.wear.input.RemoteInputIntentHelper
@@ -25,7 +23,6 @@ import com.google.android.horologist.compose.layout.rememberColumnState
 import dev.convocados.wear.BuildConfig
 import dev.convocados.wear.R
 import dev.convocados.wear.ui.theme.TextMuted
-import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalHorologistApi::class)
 @Composable
@@ -35,8 +32,6 @@ fun AuthScreen(
 ) {
     val isAuthenticated by viewModel.isAuthenticated.collectAsState()
     val uiState by viewModel.uiState.collectAsState()
-    val context = LocalContext.current
-    val scope = rememberCoroutineScope()
     val columnState = rememberColumnState()
 
     LaunchedEffect(isAuthenticated) {
@@ -175,22 +170,16 @@ fun AuthScreen(
                 item { Spacer(modifier = Modifier.height(8.dp)) }
 
                 item {
+                    val googleLauncher = rememberLauncherForActivityResult(
+                        ActivityResultContracts.StartActivityForResult()
+                    ) { result ->
+                        viewModel.handleGoogleSignInResult(result.data)
+                    }
                     if (uiState.isSigningIn) {
                         CircularProgressIndicator(modifier = Modifier.size(24.dp))
                     } else {
                         Button(
-                            onClick = {
-                                scope.launch {
-                                    try {
-                                        val credentialManager = CredentialManager.create(context)
-                                        val request = viewModel.getGoogleSignInRequest()
-                                        val result = credentialManager.getCredential(context, request)
-                                        viewModel.handleGoogleSignInResult(result)
-                                    } catch (e: Exception) {
-                                        viewModel.handleGoogleSignInError(e)
-                                    }
-                                }
-                            },
+                            onClick = { googleLauncher.launch(viewModel.getSignInIntent()) },
                             modifier = Modifier.fillMaxWidth(),
                             label = { Text(stringResource(R.string.sign_in_google)) }
                         )

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/auth/AuthViewModel.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/auth/AuthViewModel.kt
@@ -1,8 +1,6 @@
 package dev.convocados.wear.ui.screen.auth
 
-import androidx.credentials.GetCredentialRequest
-import androidx.credentials.exceptions.GetCredentialCancellationException
-import androidx.credentials.exceptions.NoCredentialException
+import android.content.Intent
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -36,6 +34,11 @@ class AuthViewModel @Inject constructor(
 
     private val _uiState = MutableStateFlow(AuthUiState())
     val uiState: StateFlow<AuthUiState> = _uiState.asStateFlow()
+
+    init {
+        // Zero-tap login on watches that already have a Google account.
+        trySilentSignIn()
+    }
 
     fun onEmailChanged(email: String) {
         _uiState.update { it.copy(email = email) }
@@ -76,14 +79,24 @@ class AuthViewModel @Inject constructor(
         }
     }
 
-    /** Returns the credential request to launch from the Activity. */
-    fun getGoogleSignInRequest(): GetCredentialRequest = googleSignIn.buildCredentialRequest()
+    /** Returns the intent that launches the on-device Google account picker. */
+    fun getSignInIntent(): Intent = googleSignIn.getSignInIntent()
 
-    /** Called after the Activity receives the credential response. */
-    fun handleGoogleSignInResult(result: androidx.credentials.GetCredentialResponse) {
+    /** Try a zero-tap silent sign-in using the existing on-device Google account. */
+    fun trySilentSignIn() {
+        if (isAuthenticated.value) return
+        viewModelScope.launch {
+            _uiState.update { it.copy(isSigningIn = true) }
+            val success = googleSignIn.trySilentSignIn()
+            _uiState.update { it.copy(isSigningIn = false) }
+        }
+    }
+
+    /** Called with the result Intent from the interactive sign-in flow. */
+    fun handleGoogleSignInResult(data: Intent?) {
         viewModelScope.launch {
             _uiState.update { it.copy(isSigningIn = true, error = null) }
-            val success = googleSignIn.handleSignInResult(result)
+            val success = googleSignIn.handleSignInResult(data)
             _uiState.update {
                 it.copy(
                     isSigningIn = false,
@@ -91,15 +104,6 @@ class AuthViewModel @Inject constructor(
                 )
             }
         }
-    }
-
-    fun handleGoogleSignInError(e: Exception) {
-        val message = when (e) {
-            is GetCredentialCancellationException -> null // User cancelled, no error
-            is NoCredentialException -> "No Google account found"
-            else -> "Sign-in failed: ${e.message}"
-        }
-        _uiState.update { it.copy(isSigningIn = false, error = message) }
     }
 
     fun signOut() {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -41,12 +41,28 @@ const SECURITY_HEADERS: Record<string, string> = {
 };
 
 function addSecurityHeaders(response: Response): Response {
-  for (const [key, value] of Object.entries(SECURITY_HEADERS)) {
-    if (!response.headers.has(key)) {
-      response.headers.set(key, value);
+  try {
+    for (const [key, value] of Object.entries(SECURITY_HEADERS)) {
+      if (!response.headers.has(key)) {
+        response.headers.set(key, value);
+      }
     }
+    return response;
+  } catch {
+    // Responses created via Response.redirect() have immutable headers,
+    // so set() throws. Rebuild with a mutable copy (preserves status + Location).
+    const headers = new Headers(response.headers);
+    for (const [key, value] of Object.entries(SECURITY_HEADERS)) {
+      if (!headers.has(key)) {
+        headers.set(key, value);
+      }
+    }
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    });
   }
-  return response;
 }
 
 export const onRequest = defineMiddleware(async (context, next) => {

--- a/src/test/middleware.test.ts
+++ b/src/test/middleware.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from "vitest";
+
+// defineMiddleware is just an identity wrapper at runtime.
+vi.mock("astro:middleware", () => ({
+  defineMiddleware: (fn: unknown) => fn,
+}));
+
+import { onRequest } from "~/middleware";
+
+type Handler = (ctx: unknown, next: () => Promise<Response>) => Promise<Response>;
+const run = onRequest as unknown as Handler;
+
+function ctx(method: string, urlStr: string) {
+  return { request: new Request(urlStr, { method }), url: new URL(urlStr) };
+}
+
+describe("security middleware", () => {
+  it("adds security headers to a normal response", async () => {
+    const res = await run(ctx("GET", "https://convocados.cabeda.dev/"), async () =>
+      new Response("ok", { status: 200 }),
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
+  });
+
+  it("does not throw on redirect responses with immutable headers", async () => {
+    const res = await run(
+      ctx("GET", "https://convocados.cabeda.dev/api/auth/mobile-callback"),
+      async () => Response.redirect("https://convocados.cabeda.dev/auth/signin", 302),
+    );
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe("https://convocados.cabeda.dev/auth/signin");
+    expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
+  });
+});


### PR DESCRIPTION
## Summary
Enables **standalone Google sign-in directly on the Wear OS watch** — no paired phone required, so it works on LTE watches. The watch reads the Google account already configured on the device.

## Why
Credential Manager's Google provider is **not supported on Wear OS** (`Google Identity Services do not support this Android Credential Manager API on Wear OS`). Switched to the legacy `GoogleSignInClient`, which is the supported path on Wear OS and reads the on-device account.

## Changes
**Wear app**
- `WearGoogleSignIn`: `GoogleSignInClient` with `requestIdToken(webClientId)` + `requestEmail()`; silent sign-in (zero-tap) and interactive picker fallback.
- `AuthViewModel` / `AuthScreen`: intent-based sign-in via `ActivityResultContracts.StartActivityForResult`, auto silent sign-in on startup.
- `WearApiClient.exchangeGoogleToken`: now `POST /api/auth/sign-in/social` (Google ID token) → session cookie → reuses the shared `mobile-callback` token exchange (also used by email login). Fixed a mixed-type map serialization crash by using `buildJsonObject`.

**Backend**
- `src/middleware.ts`: `addSecurityHeaders` crashed with `TypeError: immutable` when setting headers on `Response.redirect()` responses (immutable headers), returning a bare 500 — this broke the `mobile-callback` redirect flow (and any redirect). Now rebuilds the response with a mutable header copy when `set()` throws.
- Added `src/test/middleware.test.ts` covering normal + redirect responses.

## Config required (Google Cloud)
`requestIdToken` needs an **Android OAuth 2.0 client** in the same GCP project as the web client (`convocados-490518`), registered with package `com.cabeda.convocados.wear` and the signing SHA-1. Currently only the **release** SHA-1 is registered, so use **release** builds; add the debug SHA-1 as a second Android client to test debug builds.

## Testing
- Verified end-to-end on a physical Galaxy Watch4: Google sign-in → authenticated Games screen. ✅
- `npm run typecheck`, `npm run lint` (0 errors), full suite (1668 tests) pass.
- Backend middleware fix already deployed to prod (`mobile-callback` now returns 302 instead of 500).

## Notes
- The middleware fix is required for this flow but also fixes a latent bug affecting all redirect responses.