### PR TITLE
feat(wear): one-tap score tracking for the current game

### DIFF
--- a/android-app/wear/src/main/AndroidManifest.xml
+++ b/android-app/wear/src/main/AndroidManifest.xml
@@ -4,6 +4,8 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.VIBRATE" />
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
 
     <uses-feature android:name="android.hardware.type.watch" />
 
@@ -60,5 +62,9 @@
                     android:scheme="wear" />
             </intent-filter>
         </service>
+
+        <receiver
+            android:name=".data.alarm.GameAlarmReceiver"
+            android:exported="false" />
     </application>
 </manifest>

--- a/android-app/wear/src/main/java/dev/convocados/wear/data/alarm/GameAlarmReceiver.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/data/alarm/GameAlarmReceiver.kt
@@ -1,0 +1,38 @@
+package dev.convocados.wear.data.alarm
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.os.VibrationEffect
+import android.os.Vibrator
+import android.os.VibratorManager
+
+/** Vibrates the watch when a scheduled game alarm fires. Pulse count distinguishes alarms. */
+class GameAlarmReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action != ACTION) return
+        val pulses = intent.getIntExtra(EXTRA_PULSES, 1).coerceIn(1, 3)
+        vibrator(context).vibrate(VibrationEffect.createWaveform(patternFor(pulses), -1))
+    }
+
+    private fun vibrator(context: Context): Vibrator =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            (context.getSystemService(Context.VIBRATOR_MANAGER_SERVICE) as VibratorManager).defaultVibrator
+        } else {
+            @Suppress("DEPRECATION")
+            context.getSystemService(Context.VIBRATOR_SERVICE) as Vibrator
+        }
+
+    private fun patternFor(pulses: Int): LongArray = when (pulses) {
+        2 -> longArrayOf(0, 250, 180, 250)
+        3 -> longArrayOf(0, 200, 150, 200, 150, 200)
+        else -> longArrayOf(0, 450)
+    }
+
+    companion object {
+        const val ACTION = "dev.convocados.wear.GAME_ALARM"
+        const val EXTRA_PULSES = "pulses"
+    }
+}

--- a/android-app/wear/src/main/java/dev/convocados/wear/data/alarm/GameAlarmScheduler.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/data/alarm/GameAlarmScheduler.kt
@@ -1,0 +1,71 @@
+package dev.convocados.wear.data.alarm
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Schedules per-event game alarms as exact [AlarmManager] alarms that fire even
+ * in Doze. Falls back to inexact ([AlarmManager.setAndAllowWhileIdle]) when the
+ * exact-alarm permission is unavailable. Alarms survive the app being killed
+ * (they're cancelled explicitly when the user leaves the game).
+ */
+@Singleton
+class GameAlarmScheduler @Inject constructor(
+    @ApplicationContext private val context: Context,
+) {
+    private val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+
+    fun canScheduleExact(): Boolean =
+        Build.VERSION.SDK_INT < Build.VERSION_CODES.S || alarmManager.canScheduleExactAlarms()
+
+    /** Cancel any previously-scheduled alarms for the event and schedule [fires]. */
+    fun reschedule(eventId: String, fires: List<AlarmFire>) {
+        cancelAll(eventId)
+        val base = baseCode(eventId)
+        fires.take(MAX_ALARMS).forEachIndexed { i, fire ->
+            val pi = pendingIntent(eventId, base + i, fire.pulses, create = true) ?: return@forEachIndexed
+            try {
+                if (canScheduleExact()) {
+                    alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, fire.triggerAtMs, pi)
+                } else {
+                    alarmManager.setAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, fire.triggerAtMs, pi)
+                }
+            } catch (_: SecurityException) {
+                alarmManager.setAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, fire.triggerAtMs, pi)
+            }
+        }
+    }
+
+    fun cancelAll(eventId: String) {
+        val base = baseCode(eventId)
+        for (i in 0 until MAX_ALARMS) {
+            pendingIntent(eventId, base + i, 0, create = false)?.let {
+                alarmManager.cancel(it)
+                it.cancel()
+            }
+        }
+    }
+
+    private fun pendingIntent(eventId: String, code: Int, pulses: Int, create: Boolean): PendingIntent? {
+        val intent = Intent(context, GameAlarmReceiver::class.java).apply {
+            action = GameAlarmReceiver.ACTION
+            putExtra(GameAlarmReceiver.EXTRA_PULSES, pulses)
+        }
+        val flags = (if (create) PendingIntent.FLAG_UPDATE_CURRENT else PendingIntent.FLAG_NO_CREATE) or
+            PendingIntent.FLAG_IMMUTABLE
+        return PendingIntent.getBroadcast(context, code, intent, flags)
+    }
+
+    /** Deterministic, collision-spaced request-code base per event. */
+    private fun baseCode(eventId: String): Int = (eventId.hashCode() and 0x1FFFF) * MAX_ALARMS
+
+    companion object {
+        const val MAX_ALARMS = 64
+    }
+}

--- a/android-app/wear/src/main/java/dev/convocados/wear/data/alarm/GameSettings.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/data/alarm/GameSettings.kt
@@ -1,0 +1,68 @@
+package dev.convocados.wear.data.alarm
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+enum class AlarmType { SINGLE, RECURRING }
+
+/**
+ * A game alarm, relative to kickoff.
+ * - SINGLE: vibrates once at [minute] minutes after kickoff.
+ * - RECURRING: vibrates every [minute] minutes after kickoff (minute = interval).
+ *
+ * [pulses] (1..3) selects the vibration pattern so different alarms feel distinct.
+ */
+@Serializable
+data class GameAlarm(
+    val id: String,
+    val type: AlarmType,
+    val minute: Int,
+    val pulses: Int = 1,
+    val enabled: Boolean = true,
+)
+
+/** Per-event, device-local game settings (kickoff override + alarms). */
+@Serializable
+data class GameSettings(
+    val kickoffEpochMs: Long? = null,
+    val alarms: List<GameAlarm> = emptyList(),
+)
+
+/** A single scheduled vibration. */
+data class AlarmFire(val triggerAtMs: Long, val pulses: Int)
+
+/**
+ * Expands the enabled alarms into concrete future fire times within the game
+ * window (kickoff .. kickoff + [durationMinutes]). Pure and side-effect free:
+ * deterministic for a given (kickoff, alarms, duration, now). Only times strictly
+ * after [nowMs] and at/below the game end are returned, sorted ascending.
+ */
+fun computeAlarmTimes(
+    kickoffMs: Long,
+    alarms: List<GameAlarm>,
+    durationMinutes: Int,
+    nowMs: Long,
+): List<AlarmFire> {
+    val endMs = kickoffMs + durationMinutes * 60_000L
+    val fires = mutableListOf<AlarmFire>()
+    for (alarm in alarms) {
+        if (!alarm.enabled || alarm.minute <= 0) continue
+        val pulses = alarm.pulses.coerceIn(1, 3)
+        when (alarm.type) {
+            AlarmType.SINGLE -> {
+                val t = kickoffMs + alarm.minute * 60_000L
+                if (t in (nowMs + 1)..endMs) fires += AlarmFire(t, pulses)
+            }
+            AlarmType.RECURRING -> {
+                var k = 1
+                while (true) {
+                    val t = kickoffMs + k.toLong() * alarm.minute * 60_000L
+                    if (t > endMs) break
+                    if (t > nowMs) fires += AlarmFire(t, pulses)
+                    k++
+                }
+            }
+        }
+    }
+    return fires.sortedBy { it.triggerAtMs }
+}

--- a/android-app/wear/src/main/java/dev/convocados/wear/data/alarm/GameSettingsStore.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/data/alarm/GameSettingsStore.kt
@@ -1,0 +1,47 @@
+package dev.convocados.wear.data.alarm
+
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Device-local, per-event game settings (kickoff override + alarms), backed by
+ * SharedPreferences and exposed as a reactive [StateFlow] so the score screen
+ * reacts to changes made on the settings screen.
+ */
+@Singleton
+class GameSettingsStore @Inject constructor(
+    @ApplicationContext context: Context,
+) {
+    private val prefs = context.getSharedPreferences("game_settings", Context.MODE_PRIVATE)
+    private val json = Json { ignoreUnknownKeys = true }
+    private val flows = mutableMapOf<String, MutableStateFlow<GameSettings>>()
+
+    fun settings(eventId: String): StateFlow<GameSettings> = flowFor(eventId)
+
+    fun current(eventId: String): GameSettings = flowFor(eventId).value
+
+    /** Atomically transform and persist this event's settings. */
+    @Synchronized
+    fun update(eventId: String, transform: (GameSettings) -> GameSettings): GameSettings {
+        val flow = flowFor(eventId)
+        val updated = transform(flow.value)
+        flow.value = updated
+        prefs.edit().putString(eventId, json.encodeToString(updated)).apply()
+        return updated
+    }
+
+    @Synchronized
+    private fun flowFor(eventId: String): MutableStateFlow<GameSettings> =
+        flows.getOrPut(eventId) { MutableStateFlow(load(eventId)) }
+
+    private fun load(eventId: String): GameSettings =
+        prefs.getString(eventId, null)
+            ?.let { runCatching { json.decodeFromString<GameSettings>(it) }.getOrNull() }
+            ?: GameSettings()
+}

--- a/android-app/wear/src/main/java/dev/convocados/wear/data/api/WearApiClient.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/data/api/WearApiClient.kt
@@ -123,6 +123,15 @@ class WearApiClient @Inject constructor(private val tokenStore: WearTokenStore) 
         patch("/api/events/$eventId/teams", request)
 
     /**
+     * Start score tracking for an event: auto-creates today's game-history
+     * record (requires teams to be assigned). Idempotent — returns the
+     * existing record if one already exists for today.
+     */
+    suspend fun startWatchGame(eventId: String) {
+        authenticatedRequest(HttpMethod.Post, "/api/watch/events", mapOf("eventId" to eventId))
+    }
+
+    /**
      * Exchange email/password for Convocados OAuth tokens.
      */
     suspend fun loginWithEmail(email: String, password: String): OAuthTokenResponse {

--- a/android-app/wear/src/main/java/dev/convocados/wear/data/repository/WearGameRepository.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/data/repository/WearGameRepository.kt
@@ -44,8 +44,7 @@ class WearGameRepository @Inject constructor(
     }
 
     /** Refresh history for a specific event. */
-    suspend fun refreshHistory(eventId: String): Result<Unit> = try {
-        val history = client.get<dev.convocados.wear.data.api.PaginatedHistory>("/api/events/$eventId/history")
+    suspend fun refreshHistory(eventId: String): Result<Unit> = try {        val history = client.get<dev.convocados.wear.data.api.PaginatedHistory>("/api/events/$eventId/history")
         historyDao.refreshHistory(
             eventId,
             history.data.map { it.toHistoryEntity(eventId) }
@@ -59,6 +58,19 @@ class WearGameRepository @Inject constructor(
     /** Get the latest history entry for a game (from cache). */
     suspend fun getLatestHistory(eventId: String): WearHistoryEntity? =
         historyDao.getLatestHistory(eventId)
+
+    /**
+     * Start score tracking for an event (creates today's history record if
+     * teams are assigned), then refresh the local history cache.
+     */
+    suspend fun startGame(eventId: String): Result<Unit> = try {
+        client.startWatchGame(eventId)
+        refreshHistory(eventId)
+        Result.success(Unit)
+    } catch (e: Exception) {
+        Log.w("WearGameRepo", "Failed to start game $eventId", e)
+        Result.failure(e)
+    }
 
     /** Get a cached game by ID. */
     suspend fun getGame(eventId: String): WearGameEntity? = gameDao.getGame(eventId)

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/navigation/WearNavigation.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/navigation/WearNavigation.kt
@@ -67,7 +67,6 @@ fun WearNavigation(tokenStore: WearTokenStore) {
                     onTeams = {
                         navController.navigate(WearRoutes.teams(eventId))
                     },
-                    onDone = { navController.popBackStack() },
                 )
             }
 

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/navigation/WearNavigation.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/navigation/WearNavigation.kt
@@ -77,6 +77,17 @@ fun WearNavigation(tokenStore: WearTokenStore) {
                     eventId = eventId,
                     viewModel = viewModel,
                     onDone = { navController.popBackStack() },
+                    onSettings = { navController.navigate(WearRoutes.settings(eventId)) },
+                )
+            }
+
+            composable(WearRoutes.SETTINGS) { backStackEntry ->
+                val eventId = backStackEntry.arguments?.getString("eventId") ?: return@composable
+                val viewModel: dev.convocados.wear.ui.screen.settings.GameSettingsViewModel = hiltViewModel()
+                dev.convocados.wear.ui.screen.settings.GameSettingsScreen(
+                    eventId = eventId,
+                    viewModel = viewModel,
+                    onBack = { navController.popBackStack() },
                 )
             }
         }

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/navigation/WearRoutes.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/navigation/WearRoutes.kt
@@ -6,7 +6,9 @@ object WearRoutes {
     const val GAMES = "games"
     const val SCORE = "score/{eventId}"
     const val TEAMS = "teams/{eventId}"
+    const val SETTINGS = "settings/{eventId}"
 
     fun score(eventId: String) = "score/$eventId"
     fun teams(eventId: String) = "teams/$eventId"
+    fun settings(eventId: String) = "settings/$eventId"
 }

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/score/ScoreScreen.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/score/ScoreScreen.kt
@@ -1,7 +1,6 @@
 package dev.convocados.wear.ui.screen.score
 
 import android.view.HapticFeedbackConstants
-import android.view.View
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
@@ -22,6 +21,8 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -32,6 +33,7 @@ import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.compose.layout.ScreenScaffold
 import com.google.android.horologist.compose.layout.rememberColumnState
 import dev.convocados.wear.R
+import dev.convocados.wear.ui.theme.Warning
 import dev.convocados.wear.util.gameProgressFraction
 import dev.convocados.wear.util.parseInstant
 import kotlinx.coroutines.delay
@@ -44,7 +46,6 @@ fun ScoreScreen(
     eventId: String,
     viewModel: ScoreViewModel,
     onTeams: () -> Unit = {},
-    onDone: () -> Unit = {},
 ) {
     LaunchedEffect(eventId) { viewModel.load(eventId) }
 
@@ -138,6 +139,15 @@ private fun ScoreEditor(
     onTeams: () -> Unit,
     readOnly: Boolean = false,
 ) {
+    // Single 1s ticker drives both the edge progress and the clock.
+    var now by remember { mutableStateOf(Instant.now()) }
+    LaunchedEffect(Unit) {
+        while (true) {
+            now = Instant.now()
+            delay(1000)
+        }
+    }
+
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -179,18 +189,44 @@ private fun ScoreEditor(
             )
         }
 
+        // Non-interactive overlays (no pointerInput, so taps fall through to the tiles).
         state.game?.let { game ->
-            // Non-interactive overlays: no pointerInput, so taps fall through to the tiles.
-            GameProgressBar(
-                dateTime = game.dateTime,
-                sport = game.sport,
+            GameEdgeProgress(
+                progress = gameProgressFraction(game.dateTime, game.sport),
                 modifier = Modifier.fillMaxSize(),
             )
-            GameClock(
-                dateTime = game.dateTime,
+            val start = parseInstant(game.dateTime)
+            if (start != null && !now.isBefore(start)) {
+                val s = ChronoUnit.SECONDS.between(start, now).coerceAtLeast(0)
+                GameClock(
+                    text = "%d:%02d".format(s / 60, s % 60),
+                    modifier = Modifier
+                        .align(Alignment.BottomCenter)
+                        .padding(bottom = 4.dp),
+                )
+            }
+        }
+
+        if (!readOnly) {
+            Text(
+                text = stringResource(R.string.teams_hint),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                modifier = Modifier
+                    .align(Alignment.TopCenter)
+                    .padding(top = 14.dp),
+            )
+        }
+
+        if (state.isOfflineQueued) {
+            Text(
+                text = stringResource(R.string.will_sync_online),
+                style = MaterialTheme.typography.labelSmall,
+                color = Warning,
+                textAlign = TextAlign.Center,
                 modifier = Modifier
                     .align(Alignment.BottomCenter)
-                    .padding(bottom = 4.dp),
+                    .padding(bottom = 26.dp),
             )
         }
     }
@@ -220,6 +256,8 @@ private fun TeamScoreButton(
             .background(container)
             .combinedClickable(
                 enabled = enabled,
+                onClickLabel = "Add a point to $teamName",
+                onLongClickLabel = "Remove a point from $teamName",
                 onClick = {
                     view.performHapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
                     onIncrement()
@@ -229,6 +267,7 @@ private fun TeamScoreButton(
                     onDecrement()
                 },
             )
+            .semantics { contentDescription = "$teamName, $score points" }
             .padding(horizontal = 6.dp, vertical = 10.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
@@ -256,16 +295,7 @@ private fun TeamScoreButton(
  *  rounded-rectangle perimeter on rectangular ones), starting at 12 o'clock.
  *  Non-interactive: draws only, so taps fall through to the tiles. */
 @Composable
-private fun GameProgressBar(dateTime: String, sport: String, modifier: Modifier = Modifier) {
-    var progress by remember { mutableFloatStateOf(gameProgressFraction(dateTime, sport)) }
-
-    LaunchedEffect(dateTime, sport) {
-        while (true) {
-            progress = gameProgressFraction(dateTime, sport)
-            delay(1000)
-        }
-    }
-
+private fun GameEdgeProgress(progress: Float, modifier: Modifier = Modifier) {
     if (progress <= 0f) return
 
     val isRound = LocalConfiguration.current.isScreenRound
@@ -306,25 +336,11 @@ private fun GameProgressBar(dateTime: String, sport: String, modifier: Modifier 
     }
 }
 
-/** Lightweight elapsed-time label (m:ss) shown once the game has started. */
+/** Lightweight elapsed-time pill (m:ss). */
 @Composable
-private fun GameClock(dateTime: String, modifier: Modifier = Modifier) {    var elapsedText by remember { mutableStateOf("") }
-
-    LaunchedEffect(dateTime) {
-        while (true) {
-            val start = parseInstant(dateTime)
-            elapsedText = if (start != null && !Instant.now().isBefore(start)) {
-                val s = ChronoUnit.SECONDS.between(start, Instant.now()).coerceAtLeast(0)
-                "%d:%02d".format(s / 60, s % 60)
-            } else ""
-            delay(1000)
-        }
-    }
-
-    if (elapsedText.isEmpty()) return
-
+private fun GameClock(text: String, modifier: Modifier = Modifier) {
     Text(
-        text = elapsedText,
+        text = text,
         style = MaterialTheme.typography.labelMedium,
         color = MaterialTheme.colorScheme.onSurface,
         modifier = modifier

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/score/ScoreScreen.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/score/ScoreScreen.kt
@@ -5,12 +5,14 @@ import android.view.View
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -23,6 +25,7 @@ import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.compose.layout.ScreenScaffold
 import com.google.android.horologist.compose.layout.rememberColumnState
 import dev.convocados.wear.R
+import dev.convocados.wear.util.gameProgressFraction
 import dev.convocados.wear.util.parseInstant
 import kotlinx.coroutines.delay
 import java.time.Instant
@@ -97,6 +100,7 @@ fun ScoreScreen(
                         onDecrementOne = {},
                         onIncrementTwo = {},
                         onDecrementTwo = {},
+                        onTeams = onTeams,
                         readOnly = true,
                     )
                 }
@@ -109,6 +113,7 @@ fun ScoreScreen(
                         onDecrementOne = viewModel::decrementScoreOne,
                         onIncrementTwo = viewModel::incrementScoreTwo,
                         onDecrementTwo = viewModel::decrementScoreTwo,
+                        onTeams = onTeams,
                     )
                 }
             }
@@ -123,9 +128,22 @@ private fun ScoreEditor(
     onDecrementOne: () -> Unit,
     onIncrementTwo: () -> Unit,
     onDecrementTwo: () -> Unit,
+    onTeams: () -> Unit,
     readOnly: Boolean = false,
 ) {
-    Box(modifier = Modifier.fillMaxSize()) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .pointerInput(Unit) {
+                // Swipe up (within the content) opens the Teams screen.
+                val threshold = 64.dp.toPx()
+                var dragY = 0f
+                detectVerticalDragGestures(
+                    onDragStart = { dragY = 0f },
+                    onDragEnd = { if (dragY < -threshold) onTeams() },
+                ) { _, dy -> dragY += dy }
+            },
+    ) {
         Row(
             modifier = Modifier
                 .fillMaxSize()
@@ -155,6 +173,15 @@ private fun ScoreEditor(
         }
 
         state.game?.let { game ->
+            // Non-interactive overlays: no pointerInput, so taps fall through to the tiles.
+            GameProgressBar(
+                dateTime = game.dateTime,
+                sport = game.sport,
+                modifier = Modifier
+                    .align(Alignment.TopCenter)
+                    .padding(top = 10.dp)
+                    .fillMaxWidth(0.55f),
+            )
             GameClock(
                 dateTime = game.dateTime,
                 modifier = Modifier
@@ -221,10 +248,39 @@ private fun TeamScoreButton(
     }
 }
 
+/** Horizontal game-progress bar (fraction of match elapsed). Non-interactive. */
+@Composable
+private fun GameProgressBar(dateTime: String, sport: String, modifier: Modifier = Modifier) {
+    var progress by remember { mutableFloatStateOf(gameProgressFraction(dateTime, sport)) }
+
+    LaunchedEffect(dateTime, sport) {
+        while (true) {
+            progress = gameProgressFraction(dateTime, sport)
+            delay(1000)
+        }
+    }
+
+    if (progress <= 0f) return
+
+    Box(
+        modifier = modifier
+            .height(6.dp)
+            .clip(RoundedCornerShape(50))
+            .background(MaterialTheme.colorScheme.surfaceContainer),
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxHeight()
+                .fillMaxWidth(progress.coerceIn(0f, 1f))
+                .clip(RoundedCornerShape(50))
+                .background(MaterialTheme.colorScheme.primary),
+        )
+    }
+}
+
 /** Lightweight elapsed-time label (m:ss) shown once the game has started. */
 @Composable
-private fun GameClock(dateTime: String, modifier: Modifier = Modifier) {
-    var elapsedText by remember { mutableStateOf("") }
+private fun GameClock(dateTime: String, modifier: Modifier = Modifier) {    var elapsedText by remember { mutableStateOf("") }
 
     LaunchedEffect(dateTime) {
         while (true) {

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/score/ScoreScreen.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/score/ScoreScreen.kt
@@ -3,10 +3,15 @@ package dev.convocados.wear.ui.screen.score
 import android.view.HapticFeedbackConstants
 import android.view.View
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.StrokeCap
@@ -23,9 +28,6 @@ import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.compose.layout.ScreenScaffold
 import com.google.android.horologist.compose.layout.rememberColumnState
 import dev.convocados.wear.R
-import dev.convocados.wear.ui.theme.Success
-import dev.convocados.wear.ui.theme.TextMuted
-import dev.convocados.wear.ui.theme.Warning
 import dev.convocados.wear.util.gameProgressFraction
 import dev.convocados.wear.util.parseInstant
 import dev.convocados.wear.util.sportDurationMinutes
@@ -63,30 +65,42 @@ fun ScoreScreen(
                         modifier = Modifier.padding(16.dp),
                     ) {
                         Text(
-                            text = stringResource(R.string.no_game_history),
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            text = state.game?.title ?: stringResource(R.string.score_title),
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.primary,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
                         )
-                        Spacer(modifier = Modifier.height(4.dp))
-                        Text(
-                            text = stringResource(R.string.start_from_phone),
-                            style = MaterialTheme.typography.labelSmall,
-                            color = TextMuted,
-                            textAlign = TextAlign.Center,
-                        )
-                        if (state.game != null) {
-                            Spacer(modifier = Modifier.height(8.dp))
-                            CompactButton(onClick = onTeams) {
-                                Text(stringResource(R.string.teams_title))
+                        Spacer(modifier = Modifier.height(8.dp))
+                        if (state.isStarting) {
+                            CircularProgressIndicator(modifier = Modifier.size(24.dp))
+                        } else {
+                            Button(
+                                onClick = { viewModel.startGame() },
+                                modifier = Modifier.fillMaxWidth(),
+                                colors = ButtonDefaults.buttonColors(
+                                    containerColor = MaterialTheme.colorScheme.primary,
+                                    contentColor = MaterialTheme.colorScheme.onPrimary,
+                                ),
+                            ) {
+                                Text(stringResource(R.string.start_scoring))
                             }
                         }
+                        state.error?.let { error ->
+                            Spacer(modifier = Modifier.height(4.dp))
+                            Text(
+                                text = error,
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.error,
+                                textAlign = TextAlign.Center,
+                                maxLines = 2,
+                            )
+                        }
+                        Spacer(modifier = Modifier.height(4.dp))
+                        CompactButton(onClick = onTeams) {
+                            Text(stringResource(R.string.teams_title))
+                        }
                     }
-                }
-                state.saved -> {
-                    SavedConfirmation(
-                        isOfflineQueued = state.isOfflineQueued,
-                        onDone = onDone,
-                    )
                 }
                 state.history?.editable == false -> {
                     ScoreEditor(
@@ -95,8 +109,6 @@ fun ScoreScreen(
                         onDecrementOne = {},
                         onIncrementTwo = {},
                         onDecrementTwo = {},
-                        onSave = {},
-                        onTeams = onTeams,
                         readOnly = true,
                     )
                 }
@@ -109,8 +121,6 @@ fun ScoreScreen(
                         onDecrementOne = viewModel::decrementScoreOne,
                         onIncrementTwo = viewModel::incrementScoreTwo,
                         onDecrementTwo = viewModel::decrementScoreTwo,
-                        onSave = viewModel::saveScore,
-                        onTeams = onTeams,
                     )
                 }
             }
@@ -125,151 +135,90 @@ private fun ScoreEditor(
     onDecrementOne: () -> Unit,
     onIncrementTwo: () -> Unit,
     onDecrementTwo: () -> Unit,
-    onSave: () -> Unit,
-    onTeams: () -> Unit,
     readOnly: Boolean = false,
 ) {
-    Column(
+    Row(
         modifier = Modifier
             .fillMaxSize()
-            .padding(8.dp),
+            .padding(horizontal = 8.dp, vertical = 22.dp),
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        TeamScoreButton(
+            teamName = state.teamOneName,
+            score = state.scoreOne,
+            container = MaterialTheme.colorScheme.primaryContainer,
+            contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+            onIncrement = onIncrementOne,
+            onDecrement = onDecrementOne,
+            enabled = !readOnly,
+            modifier = Modifier.weight(1f),
+        )
+        TeamScoreButton(
+            teamName = state.teamTwoName,
+            score = state.scoreTwo,
+            container = MaterialTheme.colorScheme.tertiaryContainer,
+            contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+            onIncrement = onIncrementTwo,
+            onDecrement = onDecrementTwo,
+            enabled = !readOnly,
+            modifier = Modifier.weight(1f),
+        )
+    }
+}
+
+/**
+ * A full-height team tile: tap to add a point, long-press to subtract one.
+ * The team name stays visible above the score so each side is clearly labelled.
+ */
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun TeamScoreButton(
+    teamName: String,
+    score: Int,
+    container: androidx.compose.ui.graphics.Color,
+    contentColor: androidx.compose.ui.graphics.Color,
+    onIncrement: () -> Unit,
+    onDecrement: () -> Unit,
+    enabled: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val view = LocalView.current
+    Column(
+        modifier = modifier
+            .fillMaxHeight()
+            .clip(RoundedCornerShape(28.dp))
+            .background(container)
+            .combinedClickable(
+                enabled = enabled,
+                onClick = {
+                    view.performHapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
+                    onIncrement()
+                },
+                onLongClick = {
+                    view.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
+                    onDecrement()
+                },
+            )
+            .padding(horizontal = 6.dp, vertical = 10.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
     ) {
         Text(
-            text = state.game?.title ?: stringResource(R.string.score_title),
-            style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.primary,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-        )
-
-        Spacer(modifier = Modifier.height(4.dp))
-
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.Center,
-            modifier = Modifier.fillMaxWidth(),
-        ) {
-            ScoreColumn(
-                teamName = state.teamOneName,
-                score = state.scoreOne,
-                onIncrement = onIncrementOne,
-                onDecrement = onDecrementOne,
-                enabled = !readOnly,
-            )
-
-            Text(
-                text = ":",
-                style = MaterialTheme.typography.displaySmall.copy(
-                    fontSize = 24.sp,
-                    fontWeight = FontWeight.Bold
-                ),
-                color = MaterialTheme.colorScheme.onSurface,
-            )
-
-            ScoreColumn(
-                teamName = state.teamTwoName,
-                score = state.scoreTwo,
-                onIncrement = onIncrementTwo,
-                onDecrement = onDecrementTwo,
-                enabled = !readOnly,
-            )
-        }
-
-        Spacer(modifier = Modifier.height(4.dp))
-
-        if (readOnly) {
-            Text(
-                text = stringResource(R.string.score_read_only),
-                style = MaterialTheme.typography.labelSmall,
-                color = TextMuted,
-            )
-        } else {
-            Button(
-                onClick = onSave,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp),
-                colors = ButtonDefaults.buttonColors(
-                    containerColor = MaterialTheme.colorScheme.primary,
-                    contentColor = MaterialTheme.colorScheme.onPrimary,
-                ),
-            ) {
-                Text(
-                    text = if (state.isSaving) stringResource(R.string.saving) else stringResource(R.string.save),
-                    style = MaterialTheme.typography.labelMedium,
-                )
-            }
-        }
-
-        Spacer(modifier = Modifier.height(4.dp))
-
-        CompactButton(onClick = onTeams) {
-            Text(
-                text = stringResource(R.string.manage_teams),
-                style = MaterialTheme.typography.labelSmall,
-            )
-        }
-    }
-}
-
-@Composable
-private fun ScoreColumn(
-    teamName: String,
-    score: Int,
-    onIncrement: () -> Unit,
-    onDecrement: () -> Unit,
-    enabled: Boolean = true,
-) {
-    val view = LocalView.current
-    val hapticEnabled = enabled
-
-    Column(
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(2.dp),
-    ) {
-        Text(
             text = teamName,
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            style = MaterialTheme.typography.titleSmall,
+            color = contentColor,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.widthIn(max = 60.dp),
+            textAlign = TextAlign.Center,
         )
-
-        IconButton(
-            onClick = {
-                if (hapticEnabled) view.performHapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
-                onIncrement()
-            },
-            modifier = Modifier.size(32.dp),
-            colors = IconButtonDefaults.filledTonalIconButtonColors(),
-            enabled = enabled,
-        ) {
-            Text("+", style = MaterialTheme.typography.labelLarge, fontWeight = FontWeight.Bold)
-        }
-
         Text(
             text = "$score",
-            style = MaterialTheme.typography.displaySmall.copy(
-                fontSize = 28.sp,
-                fontWeight = FontWeight.Bold
+            style = MaterialTheme.typography.displayLarge.copy(
+                fontSize = 44.sp,
+                fontWeight = FontWeight.Bold,
             ),
-            color = MaterialTheme.colorScheme.onSurface,
+            color = contentColor,
         )
-
-        IconButton(
-            onClick = {
-                if (hapticEnabled) view.performHapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
-                onDecrement()
-            },
-            modifier = Modifier.size(32.dp),
-            colors = IconButtonDefaults.filledTonalIconButtonColors(),
-            enabled = enabled,
-        ) {
-            Text("-", style = MaterialTheme.typography.labelLarge, fontWeight = FontWeight.Bold)
-        }
     }
 }
 
@@ -340,47 +289,5 @@ private fun GameTimerArc(dateTime: String, sport: String) {
             style = MaterialTheme.typography.labelSmall,
             color = arcColor,
         )
-    }
-}
-
-@Composable
-private fun SavedConfirmation(
-    isOfflineQueued: Boolean,
-    onDone: () -> Unit,
-) {
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(16.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center,
-    ) {
-        Text(
-            text = stringResource(R.string.score_saved),
-            style = MaterialTheme.typography.titleMedium,
-            color = Success,
-        )
-
-        if (isOfflineQueued) {
-            Spacer(modifier = Modifier.height(4.dp))
-            Text(
-                text = stringResource(R.string.will_sync_online),
-                style = MaterialTheme.typography.labelSmall,
-                color = Warning,
-                textAlign = TextAlign.Center,
-            )
-        }
-
-        Spacer(modifier = Modifier.height(12.dp))
-
-        Button(
-            onClick = onDone,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp),
-            colors = ButtonDefaults.filledTonalButtonColors(),
-        ) {
-            Text(stringResource(R.string.done))
-        }
     }
 }

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/score/ScoreScreen.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/score/ScoreScreen.kt
@@ -2,7 +2,6 @@ package dev.convocados.wear.ui.screen.score
 
 import android.view.HapticFeedbackConstants
 import android.view.View
-import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
@@ -12,10 +11,6 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Size
-import androidx.compose.ui.graphics.StrokeCap
-import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -28,9 +23,7 @@ import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.compose.layout.ScreenScaffold
 import com.google.android.horologist.compose.layout.rememberColumnState
 import dev.convocados.wear.R
-import dev.convocados.wear.util.gameProgressFraction
 import dev.convocados.wear.util.parseInstant
-import dev.convocados.wear.util.sportDurationMinutes
 import kotlinx.coroutines.delay
 import java.time.Instant
 import java.time.temporal.ChronoUnit
@@ -50,11 +43,6 @@ fun ScoreScreen(
 
     ScreenScaffold(scrollState = columnState) {
         Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-            // Game timer arc around the bezel
-            state.game?.let { game ->
-                GameTimerArc(dateTime = game.dateTime, sport = game.sport)
-            }
-
             when {
                 state.isLoading -> {
                     CircularProgressIndicator()
@@ -137,32 +125,43 @@ private fun ScoreEditor(
     onDecrementTwo: () -> Unit,
     readOnly: Boolean = false,
 ) {
-    Row(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(horizontal = 8.dp, vertical = 22.dp),
-        horizontalArrangement = Arrangement.spacedBy(6.dp),
-    ) {
-        TeamScoreButton(
-            teamName = state.teamOneName,
-            score = state.scoreOne,
-            container = MaterialTheme.colorScheme.primaryContainer,
-            contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-            onIncrement = onIncrementOne,
-            onDecrement = onDecrementOne,
-            enabled = !readOnly,
-            modifier = Modifier.weight(1f),
-        )
-        TeamScoreButton(
-            teamName = state.teamTwoName,
-            score = state.scoreTwo,
-            container = MaterialTheme.colorScheme.tertiaryContainer,
-            contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
-            onIncrement = onIncrementTwo,
-            onDecrement = onDecrementTwo,
-            enabled = !readOnly,
-            modifier = Modifier.weight(1f),
-        )
+    Box(modifier = Modifier.fillMaxSize()) {
+        Row(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(2.dp),
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            TeamScoreButton(
+                teamName = state.teamOneName,
+                score = state.scoreOne,
+                container = MaterialTheme.colorScheme.primaryContainer,
+                contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                onIncrement = onIncrementOne,
+                onDecrement = onDecrementOne,
+                enabled = !readOnly,
+                modifier = Modifier.weight(1f),
+            )
+            TeamScoreButton(
+                teamName = state.teamTwoName,
+                score = state.scoreTwo,
+                container = MaterialTheme.colorScheme.tertiaryContainer,
+                contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+                onIncrement = onIncrementTwo,
+                onDecrement = onDecrementTwo,
+                enabled = !readOnly,
+                modifier = Modifier.weight(1f),
+            )
+        }
+
+        state.game?.let { game ->
+            GameClock(
+                dateTime = game.dateTime,
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(bottom = 4.dp),
+            )
+        }
     }
 }
 
@@ -222,72 +221,31 @@ private fun TeamScoreButton(
     }
 }
 
-/**
- * Draws a progress arc around the screen edge showing elapsed game time.
- * Fills clockwise from 12 o'clock. Shows elapsed time text at the top.
- */
+/** Lightweight elapsed-time label (m:ss) shown once the game has started. */
 @Composable
-private fun GameTimerArc(dateTime: String, sport: String) {
-    var progress by remember { mutableFloatStateOf(gameProgressFraction(dateTime, sport)) }
+private fun GameClock(dateTime: String, modifier: Modifier = Modifier) {
     var elapsedText by remember { mutableStateOf("") }
 
-    LaunchedEffect(dateTime, sport) {
+    LaunchedEffect(dateTime) {
         while (true) {
-            progress = gameProgressFraction(dateTime, sport)
             val start = parseInstant(dateTime)
-            if (start != null) {
-                val elapsed = ChronoUnit.SECONDS.between(start, Instant.now()).coerceAtLeast(0)
-                val min = elapsed / 60
-                val sec = elapsed % 60
-                elapsedText = "%d:%02d".format(min, sec)
-            }
+            elapsedText = if (start != null && !Instant.now().isBefore(start)) {
+                val s = ChronoUnit.SECONDS.between(start, Instant.now()).coerceAtLeast(0)
+                "%d:%02d".format(s / 60, s % 60)
+            } else ""
             delay(1000)
         }
     }
 
-    if (progress <= 0f) return
+    if (elapsedText.isEmpty()) return
 
-    val arcColor = MaterialTheme.colorScheme.primary
-    val trackColor = MaterialTheme.colorScheme.surfaceContainer
-
-    Canvas(modifier = Modifier.fillMaxSize()) {
-        val strokeWidth = 6.dp.toPx()
-        val padding = 4.dp.toPx()
-        val arcSize = Size(size.width - padding * 2, size.height - padding * 2)
-        val topLeft = Offset(padding, padding)
-
-        // Background track
-        drawArc(
-            color = trackColor,
-            startAngle = -90f,
-            sweepAngle = 360f,
-            useCenter = false,
-            topLeft = topLeft,
-            size = arcSize,
-            style = Stroke(width = strokeWidth, cap = StrokeCap.Round),
-        )
-
-        // Progress arc
-        drawArc(
-            color = arcColor,
-            startAngle = -90f,
-            sweepAngle = 360f * progress,
-            useCenter = false,
-            topLeft = topLeft,
-            size = arcSize,
-            style = Stroke(width = strokeWidth, cap = StrokeCap.Round),
-        )
-    }
-
-    // Elapsed time at top
-    Box(
-        modifier = Modifier.fillMaxSize().padding(top = 14.dp),
-        contentAlignment = Alignment.TopCenter,
-    ) {
-        Text(
-            text = elapsedText,
-            style = MaterialTheme.typography.labelSmall,
-            color = arcColor,
-        )
-    }
+    Text(
+        text = elapsedText,
+        style = MaterialTheme.typography.labelMedium,
+        color = MaterialTheme.colorScheme.onSurface,
+        modifier = modifier
+            .clip(RoundedCornerShape(50))
+            .background(MaterialTheme.colorScheme.surfaceContainer)
+            .padding(horizontal = 10.dp, vertical = 2.dp),
+    )
 }

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/score/ScoreScreen.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/score/ScoreScreen.kt
@@ -34,11 +34,10 @@ import com.google.android.horologist.compose.layout.ScreenScaffold
 import com.google.android.horologist.compose.layout.rememberColumnState
 import dev.convocados.wear.R
 import dev.convocados.wear.ui.theme.Warning
-import dev.convocados.wear.util.gameProgressFraction
 import dev.convocados.wear.util.parseInstant
+import dev.convocados.wear.util.sportDurationMinutes
 import kotlinx.coroutines.delay
 import java.time.Instant
-import java.time.temporal.ChronoUnit
 
 @OptIn(ExperimentalHorologistApi::class)
 @Composable
@@ -190,28 +189,36 @@ private fun ScoreEditor(
         }
 
         // Non-interactive overlays (no pointerInput, so taps fall through to the tiles).
+        // Non-interactive overlays (no pointerInput, so taps fall through to the tiles).
         state.game?.let { game ->
-            GameEdgeProgress(
-                progress = gameProgressFraction(game.dateTime, game.sport),
-                modifier = Modifier.fillMaxSize(),
-            )
-            val start = parseInstant(game.dateTime)
-            if (start != null && !now.isBefore(start)) {
-                val s = ChronoUnit.SECONDS.between(start, now).coerceAtLeast(0)
-                GameClock(
-                    text = "%d:%02d".format(s / 60, s % 60),
-                    modifier = Modifier
-                        .align(Alignment.BottomCenter)
-                        .padding(bottom = 4.dp),
+            val kickoffMs = state.kickoffEpochMs ?: parseInstant(game.dateTime)?.toEpochMilli()
+            if (kickoffMs != null) {
+                val durationMs = sportDurationMinutes(game.sport) * 60_000L
+                val elapsedMs = now.toEpochMilli() - kickoffMs
+                GameEdgeProgress(
+                    progress = (elapsedMs.toFloat() / durationMs).coerceIn(0f, 1f),
+                    modifier = Modifier.fillMaxSize(),
                 )
+                if (elapsedMs >= 0) {
+                    val s = elapsedMs / 1000
+                    GameClock(
+                        text = "%d:%02d".format(s / 60, s % 60),
+                        modifier = Modifier
+                            .align(Alignment.BottomCenter)
+                            .padding(bottom = 4.dp),
+                    )
+                }
             }
         }
 
         if (!readOnly) {
+            // Show the next-alarm countdown when armed, otherwise the Teams hint.
+            val nextSec = state.nextAlarmAtMs?.let { (it - now.toEpochMilli()) / 1000 }?.takeIf { it > 0 }
             Text(
-                text = stringResource(R.string.teams_hint),
+                text = if (nextSec != null) "⏰ %d:%02d".format(nextSec / 60, nextSec % 60)
+                else stringResource(R.string.teams_hint),
                 style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
                 modifier = Modifier
                     .align(Alignment.TopCenter)
                     .padding(top = 14.dp),

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/score/ScoreScreen.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/score/ScoreScreen.kt
@@ -88,12 +88,6 @@ fun ScoreScreen(
                         onDone = onDone,
                     )
                 }
-                !state.canScore -> {
-                    NotYetScoreScreen(
-                        state = state,
-                        onTeams = onTeams,
-                    )
-                }
                 state.history?.editable == false -> {
                     ScoreEditor(
                         state = state,
@@ -107,6 +101,8 @@ fun ScoreScreen(
                     )
                 }
                 else -> {
+                    // Teams exist and are editable — go straight to score tracking,
+                    // regardless of the game's time window.
                     ScoreEditor(
                         state = state,
                         onIncrementOne = viewModel::incrementScoreOne,
@@ -118,43 +114,6 @@ fun ScoreScreen(
                     )
                 }
             }
-        }
-    }
-}
-
-@Composable
-private fun NotYetScoreScreen(
-    state: ScoreUiState,
-    onTeams: () -> Unit,
-) {
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(16.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center,
-    ) {
-        Text(
-            text = state.game?.title ?: stringResource(R.string.score_title),
-            style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.primary,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-        )
-
-        Spacer(modifier = Modifier.height(8.dp))
-
-        Text(
-            text = stringResource(R.string.score_not_yet),
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            textAlign = TextAlign.Center,
-        )
-
-        Spacer(modifier = Modifier.height(12.dp))
-
-        CompactButton(onClick = onTeams) {
-            Text(stringResource(R.string.manage_teams))
         }
     }
 }

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/score/ScoreScreen.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/score/ScoreScreen.kt
@@ -2,6 +2,7 @@ package dev.convocados.wear.ui.screen.score
 
 import android.view.HapticFeedbackConstants
 import android.view.View
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
@@ -12,7 +13,13 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.PathMeasure
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -177,10 +184,7 @@ private fun ScoreEditor(
             GameProgressBar(
                 dateTime = game.dateTime,
                 sport = game.sport,
-                modifier = Modifier
-                    .align(Alignment.TopCenter)
-                    .padding(top = 10.dp)
-                    .fillMaxWidth(0.55f),
+                modifier = Modifier.fillMaxSize(),
             )
             GameClock(
                 dateTime = game.dateTime,
@@ -248,7 +252,9 @@ private fun TeamScoreButton(
     }
 }
 
-/** Horizontal game-progress bar (fraction of match elapsed). Non-interactive. */
+/** Game-progress indicator that hugs the screen edge (circle on round watches,
+ *  rounded-rectangle perimeter on rectangular ones), starting at 12 o'clock.
+ *  Non-interactive: draws only, so taps fall through to the tiles. */
 @Composable
 private fun GameProgressBar(dateTime: String, sport: String, modifier: Modifier = Modifier) {
     var progress by remember { mutableFloatStateOf(gameProgressFraction(dateTime, sport)) }
@@ -262,19 +268,41 @@ private fun GameProgressBar(dateTime: String, sport: String, modifier: Modifier 
 
     if (progress <= 0f) return
 
-    Box(
-        modifier = modifier
-            .height(6.dp)
-            .clip(RoundedCornerShape(50))
-            .background(MaterialTheme.colorScheme.surfaceContainer),
-    ) {
-        Box(
-            modifier = Modifier
-                .fillMaxHeight()
-                .fillMaxWidth(progress.coerceIn(0f, 1f))
-                .clip(RoundedCornerShape(50))
-                .background(MaterialTheme.colorScheme.primary),
-        )
+    val isRound = LocalConfiguration.current.isScreenRound
+    val fillColor = MaterialTheme.colorScheme.primary
+    val trackColor = MaterialTheme.colorScheme.surfaceContainer
+
+    Canvas(modifier = modifier.fillMaxSize()) {
+        val stroke = 5.dp.toPx()
+        val left = stroke / 2f + 1.dp.toPx()
+        val top = left
+        val right = size.width - left
+        val bottom = size.height - top
+        val w = right - left
+        val h = bottom - top
+        val r = if (isRound) minOf(w, h) / 2f else 28.dp.toPx()
+        val cx = left + w / 2f
+
+        // Perimeter path, clockwise from top-center.
+        val path = Path().apply {
+            moveTo(cx, top)
+            lineTo(right - r, top)
+            arcTo(Rect(right - 2 * r, top, right, top + 2 * r), -90f, 90f, false)
+            lineTo(right, bottom - r)
+            arcTo(Rect(right - 2 * r, bottom - 2 * r, right, bottom), 0f, 90f, false)
+            lineTo(left + r, bottom)
+            arcTo(Rect(left, bottom - 2 * r, left + 2 * r, bottom), 90f, 90f, false)
+            lineTo(left, top + r)
+            arcTo(Rect(left, top, left + 2 * r, top + 2 * r), 180f, 90f, false)
+            close()
+        }
+
+        drawPath(path, trackColor, style = Stroke(width = stroke))
+
+        val measure = PathMeasure().apply { setPath(path, false) }
+        val segment = Path()
+        measure.getSegment(0f, measure.length * progress.coerceIn(0f, 1f), segment, true)
+        drawPath(segment, fillColor, style = Stroke(width = stroke, cap = StrokeCap.Round))
     }
 }
 

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/score/ScoreViewModel.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/score/ScoreViewModel.kt
@@ -12,6 +12,8 @@ import dev.convocados.wear.data.sync.ScoreSyncWorker
 import dev.convocados.wear.util.canScoreGame
 import dev.convocados.wear.util.tickFlow
 import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -26,7 +28,7 @@ data class ScoreUiState(
     val teamTwoName: String = "Team 2",
     val isLoading: Boolean = true,
     val isSaving: Boolean = false,
-    val saved: Boolean = false,
+    val isStarting: Boolean = false,
     val isOfflineQueued: Boolean = false,
     val canScore: Boolean = false,
     val error: String? = null,
@@ -79,29 +81,50 @@ class ScoreViewModel @Inject constructor(
         }
     }
 
+    /** Start tracking the score for this game (creates today's history record). */
+    fun startGame() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isStarting = true, error = null) }
+            val result = repository.startGame(eventId)
+            _uiState.update {
+                it.copy(
+                    isStarting = false,
+                    error = if (result.isSuccess) null else "Assign teams first, then try again",
+                )
+            }
+        }
+    }
+
     fun incrementScoreOne() {
         _uiState.update { it.copy(scoreOne = it.scoreOne + 1) }
+        scheduleSave()
     }
 
     fun decrementScoreOne() {
         _uiState.update { it.copy(scoreOne = maxOf(0, it.scoreOne - 1)) }
+        scheduleSave()
     }
 
     fun incrementScoreTwo() {
         _uiState.update { it.copy(scoreTwo = it.scoreTwo + 1) }
+        scheduleSave()
     }
 
     fun decrementScoreTwo() {
         _uiState.update { it.copy(scoreTwo = maxOf(0, it.scoreTwo - 1)) }
+        scheduleSave()
     }
 
-    fun saveScore() {
-        val state = _uiState.value
-        val historyId = state.history?.id ?: return
+    private var saveJob: Job? = null
 
-        viewModelScope.launch {
-            _uiState.update { it.copy(isSaving = true, error = null) }
-
+    /** Debounce rapid taps into one save; persists locally + remotely (queues if offline). */
+    private fun scheduleSave() {
+        saveJob?.cancel()
+        saveJob = viewModelScope.launch {
+            delay(500)
+            val state = _uiState.value
+            val historyId = state.history?.id ?: return@launch
+            _uiState.update { it.copy(isSaving = true) }
             val result = scoreRepository.submitScore(
                 eventId = eventId,
                 historyId = historyId,
@@ -110,16 +133,8 @@ class ScoreViewModel @Inject constructor(
                 teamOneName = state.teamOneName,
                 teamTwoName = state.teamTwoName,
             )
-
             ScoreSyncWorker.enqueueOneTime(workManager)
-
-            _uiState.update {
-                it.copy(
-                    isSaving = false,
-                    saved = true,
-                    isOfflineQueued = result.isFailure,
-                )
-            }
+            _uiState.update { it.copy(isSaving = false, isOfflineQueued = result.isFailure) }
         }
     }
 }

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/score/ScoreViewModel.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/score/ScoreViewModel.kt
@@ -5,11 +5,16 @@ import androidx.lifecycle.viewModelScope
 import androidx.work.WorkManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dev.convocados.wear.data.api.ApiException
+import dev.convocados.wear.data.alarm.GameAlarmScheduler
+import dev.convocados.wear.data.alarm.GameSettingsStore
+import dev.convocados.wear.data.alarm.computeAlarmTimes
 import dev.convocados.wear.data.local.entity.WearGameEntity
 import dev.convocados.wear.data.local.entity.WearHistoryEntity
 import dev.convocados.wear.data.repository.WearGameRepository
 import dev.convocados.wear.data.repository.WearScoreRepository
 import dev.convocados.wear.data.sync.ScoreSyncWorker
+import dev.convocados.wear.util.parseInstant
+import dev.convocados.wear.util.sportDurationMinutes
 import dev.convocados.wear.util.tickFlow
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
@@ -27,6 +32,8 @@ data class ScoreUiState(
     val isLoading: Boolean = true,
     val isStarting: Boolean = false,
     val isOfflineQueued: Boolean = false,
+    val kickoffEpochMs: Long? = null,
+    val nextAlarmAtMs: Long? = null,
     val error: String? = null,
 )
 
@@ -34,6 +41,8 @@ data class ScoreUiState(
 class ScoreViewModel @Inject constructor(
     private val repository: WearGameRepository,
     private val scoreRepository: WearScoreRepository,
+    private val settingsStore: GameSettingsStore,
+    private val alarmScheduler: GameAlarmScheduler,
     private val workManager: WorkManager,
 ) : ViewModel() {
 
@@ -53,14 +62,21 @@ class ScoreViewModel @Inject constructor(
             _uiState.update { it.copy(isLoading = true) }
 
             val game = repository.getGame(eventId)
+            val scheduledKickoffMs = game?.dateTime?.let { parseInstant(it)?.toEpochMilli() }
+            val durationMinutes = game?.let { sportDurationMinutes(it.sport) } ?: 60
             repository.refreshHistory(eventId)
 
             combine(
                 repository.observeLatestHistory(eventId),
+                settingsStore.settings(eventId),
                 tickProvider(),
-            ) { history, _ ->
-                history
-            }.collect { history ->
+            ) { history, settings, _ ->
+                Triple(history, settings, System.currentTimeMillis())
+            }.collect { (history, settings, now) ->
+                val kickoffMs = settings.kickoffEpochMs ?: scheduledKickoffMs
+                val nextAlarm = kickoffMs?.let {
+                    computeAlarmTimes(it, settings.alarms, durationMinutes, now).firstOrNull()?.triggerAtMs
+                }
                 _uiState.update { state ->
                     state.copy(
                         game = game,
@@ -69,11 +85,18 @@ class ScoreViewModel @Inject constructor(
                         scoreTwo = history?.scoreTwo ?: state.scoreTwo,
                         teamOneName = history?.teamOneName ?: game?.teamOneName ?: "Team 1",
                         teamTwoName = history?.teamTwoName ?: game?.teamTwoName ?: "Team 2",
+                        kickoffEpochMs = kickoffMs,
+                        nextAlarmAtMs = nextAlarm,
                         isLoading = false,
                     )
                 }
             }
         }
+    }
+
+    /** Leaving the game cancels all of its pending alarms. */
+    override fun onCleared() {
+        if (eventId.isNotEmpty()) alarmScheduler.cancelAll(eventId)
     }
 
     /** Start tracking the score for this game (creates today's history record). */

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/score/ScoreViewModel.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/score/ScoreViewModel.kt
@@ -4,16 +4,14 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.work.WorkManager
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dev.convocados.wear.data.api.ApiException
 import dev.convocados.wear.data.local.entity.WearGameEntity
 import dev.convocados.wear.data.local.entity.WearHistoryEntity
 import dev.convocados.wear.data.repository.WearGameRepository
 import dev.convocados.wear.data.repository.WearScoreRepository
 import dev.convocados.wear.data.sync.ScoreSyncWorker
-import dev.convocados.wear.util.canScoreGame
 import dev.convocados.wear.util.tickFlow
 import kotlinx.coroutines.flow.*
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -27,10 +25,8 @@ data class ScoreUiState(
     val teamOneName: String = "Team 1",
     val teamTwoName: String = "Team 2",
     val isLoading: Boolean = true,
-    val isSaving: Boolean = false,
     val isStarting: Boolean = false,
     val isOfflineQueued: Boolean = false,
-    val canScore: Boolean = false,
     val error: String? = null,
 )
 
@@ -73,7 +69,6 @@ class ScoreViewModel @Inject constructor(
                         scoreTwo = history?.scoreTwo ?: state.scoreTwo,
                         teamOneName = history?.teamOneName ?: game?.teamOneName ?: "Team 1",
                         teamTwoName = history?.teamTwoName ?: game?.teamTwoName ?: "Team 2",
-                        canScore = game?.let { canScoreGame(it.dateTime) } ?: false,
                         isLoading = false,
                     )
                 }
@@ -87,54 +82,71 @@ class ScoreViewModel @Inject constructor(
             _uiState.update { it.copy(isStarting = true, error = null) }
             val result = repository.startGame(eventId)
             _uiState.update {
-                it.copy(
-                    isStarting = false,
-                    error = if (result.isSuccess) null else "Assign teams first, then try again",
-                )
+                it.copy(isStarting = false, error = startErrorMessage(result.exceptionOrNull()))
             }
         }
     }
 
     fun incrementScoreOne() {
         _uiState.update { it.copy(scoreOne = it.scoreOne + 1) }
-        scheduleSave()
+        persist()
     }
 
     fun decrementScoreOne() {
         _uiState.update { it.copy(scoreOne = maxOf(0, it.scoreOne - 1)) }
-        scheduleSave()
+        persist()
     }
 
     fun incrementScoreTwo() {
         _uiState.update { it.copy(scoreTwo = it.scoreTwo + 1) }
-        scheduleSave()
+        persist()
     }
 
     fun decrementScoreTwo() {
         _uiState.update { it.copy(scoreTwo = maxOf(0, it.scoreTwo - 1)) }
-        scheduleSave()
+        persist()
     }
 
-    private var saveJob: Job? = null
+    private var saving = false
+    private var pendingSave = false
 
-    /** Debounce rapid taps into one save; persists locally + remotely (queues if offline). */
-    private fun scheduleSave() {
-        saveJob?.cancel()
-        saveJob = viewModelScope.launch {
-            delay(500)
-            val state = _uiState.value
-            val historyId = state.history?.id ?: return@launch
-            _uiState.update { it.copy(isSaving = true) }
-            val result = scoreRepository.submitScore(
-                eventId = eventId,
-                historyId = historyId,
-                scoreOne = state.scoreOne,
-                scoreTwo = state.scoreTwo,
-                teamOneName = state.teamOneName,
-                teamTwoName = state.teamTwoName,
-            )
+    /**
+     * Persist the score on every change. submitScore writes the local DB first
+     * (instant, survives going offline) then pushes to the server, queuing for
+     * sync on failure. Calls are coalesced + serialized so rapid taps always
+     * end on the latest value without overlapping requests.
+     */
+    private fun persist() {
+        if (_uiState.value.history?.id == null) return
+        pendingSave = true
+        if (saving) return
+        saving = true
+        viewModelScope.launch {
+            while (pendingSave) {
+                pendingSave = false
+                val s = _uiState.value
+                val historyId = s.history?.id ?: break
+                val result = scoreRepository.submitScore(
+                    eventId = eventId,
+                    historyId = historyId,
+                    scoreOne = s.scoreOne,
+                    scoreTwo = s.scoreTwo,
+                    teamOneName = s.teamOneName,
+                    teamTwoName = s.teamTwoName,
+                )
+                _uiState.update { it.copy(isOfflineQueued = result.isFailure) }
+            }
             ScoreSyncWorker.enqueueOneTime(workManager)
-            _uiState.update { it.copy(isSaving = false, isOfflineQueued = result.isFailure) }
+            saving = false
         }
     }
+}
+
+/** Maps a startGame failure to a short, user-facing reason. */
+internal fun startErrorMessage(e: Throwable?): String? = when {
+    e == null -> null
+    e is ApiException && e.code == 400 -> "Assign teams first"
+    e is ApiException && e.code == 401 -> "Session expired — sign in again"
+    e is ApiException -> "Couldn't start (${e.code})"
+    else -> "Couldn't start — check connection"
 }

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/settings/GameSettingsScreen.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/settings/GameSettingsScreen.kt
@@ -1,0 +1,182 @@
+package dev.convocados.wear.ui.screen.settings
+
+import android.content.Intent
+import android.os.Build
+import android.provider.Settings
+import androidx.compose.foundation.layout.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.foundation.lazy.items
+import androidx.wear.compose.material3.*
+import com.google.android.horologist.annotations.ExperimentalHorologistApi
+import com.google.android.horologist.compose.layout.ScalingLazyColumn
+import com.google.android.horologist.compose.layout.ScalingLazyColumnDefaults
+import com.google.android.horologist.compose.layout.ScreenScaffold
+import com.google.android.horologist.compose.layout.rememberColumnState
+import dev.convocados.wear.data.alarm.AlarmType
+import dev.convocados.wear.data.alarm.GameAlarm
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+private val timeFormat = DateTimeFormatter.ofPattern("HH:mm")
+
+@OptIn(ExperimentalHorologistApi::class)
+@Composable
+fun GameSettingsScreen(
+    eventId: String,
+    viewModel: GameSettingsViewModel,
+    onBack: () -> Unit = {},
+) {
+    LaunchedEffect(eventId) { viewModel.load(eventId) }
+
+    val state by viewModel.uiState.collectAsState()
+    val context = LocalContext.current
+    val columnState = rememberColumnState(ScalingLazyColumnDefaults.responsive())
+
+    // Pull down at the top to go back to Teams.
+    val pullThreshold = with(LocalDensity.current) { 72.dp.toPx() }
+    var pulled by remember { mutableFloatStateOf(0f) }
+    val pullToBack = remember(onBack) {
+        object : NestedScrollConnection {
+            override fun onPostScroll(consumed: Offset, available: Offset, source: NestedScrollSource): Offset {
+                if (available.y > 0f && !columnState.state.canScrollBackward) {
+                    pulled += available.y
+                    if (pulled >= pullThreshold) { pulled = 0f; onBack() }
+                } else if (available.y < 0f) pulled = 0f
+                return Offset.Zero
+            }
+        }
+    }
+
+    ScreenScaffold(scrollState = columnState) {
+        ScalingLazyColumn(
+            columnState = columnState,
+            modifier = Modifier.fillMaxSize().nestedScroll(pullToBack),
+        ) {
+            item {
+                ListHeader { Text("Game settings", color = MaterialTheme.colorScheme.primary) }
+            }
+
+            // ── Kickoff ─────────────────────────────────────────────
+            item {
+                val time = Instant.ofEpochMilli(state.kickoffEpochMs)
+                    .atZone(ZoneId.systemDefault()).format(timeFormat)
+                Text(
+                    text = "Kickoff $time" + if (state.isKickoffOverridden) " (set)" else "",
+                    style = MaterialTheme.typography.labelMedium,
+                    modifier = Modifier.fillMaxWidth(),
+                    textAlign = TextAlign.Center,
+                )
+            }
+            item {
+                Button(
+                    onClick = { viewModel.kickoffNow() },
+                    modifier = Modifier.fillMaxWidth(),
+                ) { Text("Kick off now") }
+            }
+            item {
+                Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                    CompactButton(onClick = { viewModel.nudgeKickoff(-1) }) { Text("−1m") }
+                    CompactButton(onClick = { viewModel.nudgeKickoff(1) }) { Text("+1m") }
+                    if (state.isKickoffOverridden) {
+                        CompactButton(onClick = { viewModel.resetKickoff() }) { Text("Reset") }
+                    }
+                }
+            }
+
+            // ── Exact-alarm permission fallback ─────────────────────
+            if (!state.canScheduleExact) {
+                item {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Text(
+                            text = "Alarms may be delayed. Allow exact alarms for on-time buzzes.",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.error,
+                            textAlign = TextAlign.Center,
+                        )
+                        CompactButton(onClick = {
+                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                                runCatching {
+                                    context.startActivity(
+                                        Intent(Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM)
+                                            .setData(android.net.Uri.parse("package:${context.packageName}"))
+                                            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+                                    )
+                                }
+                            }
+                        }) { Text("Allow") }
+                    }
+                }
+            }
+
+            // ── Alarms ──────────────────────────────────────────────
+            item {
+                Text(
+                    text = "Vibration alarms",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+
+            items(state.alarms, key = { it.id }) { alarm ->
+                AlarmRow(
+                    alarm = alarm,
+                    onToggle = { viewModel.toggleAlarm(alarm.id) },
+                    onMinus = { viewModel.changeMinute(alarm.id, -1) },
+                    onPlus = { viewModel.changeMinute(alarm.id, 1) },
+                    onRemove = { viewModel.removeAlarm(alarm.id) },
+                )
+            }
+
+            item {
+                Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                    CompactButton(onClick = { viewModel.addRecurring() }) { Text("+ Every") }
+                    CompactButton(onClick = { viewModel.addSingle() }) { Text("+ Once") }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AlarmRow(
+    alarm: GameAlarm,
+    onToggle: () -> Unit,
+    onMinus: () -> Unit,
+    onPlus: () -> Unit,
+    onRemove: () -> Unit,
+) {
+    val label = if (alarm.type == AlarmType.RECURRING) "Every ${alarm.minute}m" else "At ${alarm.minute}m"
+    val dots = "•".repeat(alarm.pulses)
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .semantics { contentDescription = "$label, ${alarm.pulses} pulses, ${if (alarm.enabled) "on" else "off"}" },
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = "$label  $dots",
+            style = MaterialTheme.typography.labelMedium,
+            color = if (alarm.enabled) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Row(horizontalArrangement = Arrangement.spacedBy(4.dp), modifier = Modifier.padding(top = 2.dp)) {
+            CompactButton(onClick = onMinus) { Text("−") }
+            CompactButton(onClick = onPlus) { Text("+") }
+            CompactButton(onClick = onToggle) { Text(if (alarm.enabled) "On" else "Off") }
+            CompactButton(onClick = onRemove) { Text("✕") }
+        }
+    }
+}

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/settings/GameSettingsViewModel.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/settings/GameSettingsViewModel.kt
@@ -1,0 +1,105 @@
+package dev.convocados.wear.ui.screen.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dev.convocados.wear.data.alarm.AlarmType
+import dev.convocados.wear.data.alarm.GameAlarm
+import dev.convocados.wear.data.alarm.GameAlarmScheduler
+import dev.convocados.wear.data.alarm.GameSettings
+import dev.convocados.wear.data.alarm.GameSettingsStore
+import dev.convocados.wear.data.alarm.computeAlarmTimes
+import dev.convocados.wear.data.repository.WearGameRepository
+import dev.convocados.wear.util.parseInstant
+import dev.convocados.wear.util.sportDurationMinutes
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import java.util.UUID
+import javax.inject.Inject
+
+data class GameSettingsUiState(
+    val isLoading: Boolean = true,
+    val kickoffEpochMs: Long = 0,
+    val isKickoffOverridden: Boolean = false,
+    val alarms: List<GameAlarm> = emptyList(),
+    val canScheduleExact: Boolean = true,
+)
+
+@HiltViewModel
+class GameSettingsViewModel @Inject constructor(
+    private val gameRepository: WearGameRepository,
+    private val store: GameSettingsStore,
+    private val scheduler: GameAlarmScheduler,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(GameSettingsUiState())
+    val uiState: StateFlow<GameSettingsUiState> = _uiState.asStateFlow()
+
+    private var eventId: String = ""
+    private var scheduledKickoffMs: Long = System.currentTimeMillis()
+    private var durationMinutes: Int = 60
+
+    fun load(eventId: String) {
+        if (this.eventId == eventId) return
+        this.eventId = eventId
+        viewModelScope.launch {
+            val game = gameRepository.getGame(eventId)
+            scheduledKickoffMs = game?.dateTime?.let { parseInstant(it)?.toEpochMilli() }
+                ?: System.currentTimeMillis()
+            durationMinutes = game?.let { sportDurationMinutes(it.sport) } ?: 60
+            store.settings(eventId).collect { s ->
+                _uiState.value = GameSettingsUiState(
+                    isLoading = false,
+                    kickoffEpochMs = effectiveKickoff(s),
+                    isKickoffOverridden = s.kickoffEpochMs != null,
+                    alarms = s.alarms,
+                    canScheduleExact = scheduler.canScheduleExact(),
+                )
+            }
+        }
+    }
+
+    fun kickoffNow() = apply { it.copy(kickoffEpochMs = System.currentTimeMillis()) }
+
+    fun nudgeKickoff(deltaMinutes: Int) = apply {
+        it.copy(kickoffEpochMs = (it.kickoffEpochMs ?: scheduledKickoffMs) + deltaMinutes * 60_000L)
+    }
+
+    fun resetKickoff() = apply { it.copy(kickoffEpochMs = null) }
+
+    fun addRecurring(minute: Int = 5) = apply {
+        it.copy(alarms = it.alarms + newAlarm(it.alarms, AlarmType.RECURRING, minute))
+    }
+
+    fun addSingle(minute: Int = 25) = apply {
+        it.copy(alarms = it.alarms + newAlarm(it.alarms, AlarmType.SINGLE, minute))
+    }
+
+    fun toggleAlarm(id: String) = apply {
+        it.copy(alarms = it.alarms.map { a -> if (a.id == id) a.copy(enabled = !a.enabled) else a })
+    }
+
+    fun changeMinute(id: String, delta: Int) = apply {
+        it.copy(alarms = it.alarms.map { a -> if (a.id == id) a.copy(minute = (a.minute + delta).coerceIn(1, 120)) else a })
+    }
+
+    fun removeAlarm(id: String) = apply {
+        it.copy(alarms = it.alarms.filterNot { a -> a.id == id })
+    }
+
+    private fun newAlarm(existing: List<GameAlarm>, type: AlarmType, minute: Int) =
+        GameAlarm(UUID.randomUUID().toString(), type, minute, pulses = (existing.size % 3) + 1)
+
+    private fun effectiveKickoff(s: GameSettings): Long = s.kickoffEpochMs ?: scheduledKickoffMs
+
+    /** Persist a change and re-schedule all alarms from the (possibly new) kickoff. */
+    private fun apply(transform: (GameSettings) -> GameSettings) {
+        val updated = store.update(eventId, transform)
+        scheduler.reschedule(
+            eventId,
+            computeAlarmTimes(effectiveKickoff(updated), updated.alarms, durationMinutes, System.currentTimeMillis()),
+        )
+    }
+}

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/teams/TeamsScreen.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/teams/TeamsScreen.kt
@@ -29,6 +29,7 @@ fun TeamsScreen(
     eventId: String,
     viewModel: TeamsViewModel,
     onDone: () -> Unit = {},
+    onSettings: () -> Unit = {},
 ) {
     LaunchedEffect(eventId) { viewModel.load(eventId) }
 
@@ -37,20 +38,22 @@ fun TeamsScreen(
         ScalingLazyColumnDefaults.responsive()
     )
 
-    // Pull down while already at the top to go back to the score.
+    // Edge over-scroll gestures: pull down at the top -> score; pull up at the bottom -> settings.
     val pullThreshold = with(LocalDensity.current) { 72.dp.toPx() }
     var pulled by remember { mutableFloatStateOf(0f) }
-    val pullToBack = remember(onDone) {
+    val edgeNav = remember(onDone, onSettings) {
         object : NestedScrollConnection {
             override fun onPostScroll(consumed: Offset, available: Offset, source: NestedScrollSource): Offset {
-                if (available.y > 0f && !columnState.state.canScrollBackward) {
-                    pulled += available.y
-                    if (pulled >= pullThreshold) {
-                        pulled = 0f
-                        onDone()
+                when {
+                    available.y > 0f && !columnState.state.canScrollBackward -> {
+                        pulled += available.y
+                        if (pulled >= pullThreshold) { pulled = 0f; onDone() }
                     }
-                } else if (available.y < 0f) {
-                    pulled = 0f
+                    available.y < 0f && !columnState.state.canScrollForward -> {
+                        pulled += available.y
+                        if (pulled <= -pullThreshold) { pulled = 0f; onSettings() }
+                    }
+                    else -> pulled = 0f
                 }
                 return Offset.Zero
             }
@@ -67,7 +70,7 @@ fun TeamsScreen(
             else -> {
                 ScalingLazyColumn(
                     columnState = columnState,
-                    modifier = Modifier.fillMaxSize().nestedScroll(pullToBack),
+                    modifier = Modifier.fillMaxSize().nestedScroll(edgeNav),
                 ) {
                     // Header
                     item {

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/teams/TeamsScreen.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/teams/TeamsScreen.kt
@@ -4,6 +4,11 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -32,6 +37,26 @@ fun TeamsScreen(
         ScalingLazyColumnDefaults.responsive()
     )
 
+    // Pull down while already at the top to go back to the score.
+    val pullThreshold = with(LocalDensity.current) { 72.dp.toPx() }
+    var pulled by remember { mutableFloatStateOf(0f) }
+    val pullToBack = remember(onDone) {
+        object : NestedScrollConnection {
+            override fun onPostScroll(consumed: Offset, available: Offset, source: NestedScrollSource): Offset {
+                if (available.y > 0f && !columnState.state.canScrollBackward) {
+                    pulled += available.y
+                    if (pulled >= pullThreshold) {
+                        pulled = 0f
+                        onDone()
+                    }
+                } else if (available.y < 0f) {
+                    pulled = 0f
+                }
+                return Offset.Zero
+            }
+        }
+    }
+
     ScreenScaffold(scrollState = columnState) {
         when {
             state.isLoading -> {
@@ -42,7 +67,7 @@ fun TeamsScreen(
             else -> {
                 ScalingLazyColumn(
                     columnState = columnState,
-                    modifier = Modifier.fillMaxSize(),
+                    modifier = Modifier.fillMaxSize().nestedScroll(pullToBack),
                 ) {
                     // Header
                     item {

--- a/android-app/wear/src/main/res/values/strings.xml
+++ b/android-app/wear/src/main/res/values/strings.xml
@@ -29,17 +29,11 @@
 
     <!-- Score screen -->
     <string name="score_title">Score</string>
-    <string name="no_game_history">No game history</string>
     <string name="start_scoring">Start scoring</string>
-    <string name="start_from_phone">Start the game from\nthe phone app first</string>
+    <string name="teams_hint">↑ Teams</string>
     <string name="syncing">syncing…</string>
     <string name="score_hint">tap +1 · hold −1</string>
-    <string name="score_read_only">Scores are locked</string>
-    <string name="score_not_yet">Scoring available 1h before kickoff</string>
-    <string name="manage_teams">Teams</string>
     <string name="saving">Saving…</string>
-    <string name="save">Save</string>
-    <string name="score_saved">Score saved!</string>
     <string name="will_sync_online">Will sync when online</string>
     <string name="retry">Retry</string>
     <string name="done">Done</string>

--- a/android-app/wear/src/main/res/values/strings.xml
+++ b/android-app/wear/src/main/res/values/strings.xml
@@ -30,6 +30,7 @@
     <!-- Score screen -->
     <string name="score_title">Score</string>
     <string name="no_game_history">No game history</string>
+    <string name="start_scoring">Start scoring</string>
     <string name="start_from_phone">Start the game from\nthe phone app first</string>
     <string name="syncing">syncing…</string>
     <string name="score_hint">tap +1 · hold −1</string>

--- a/android-app/wear/src/test/java/dev/convocados/wear/data/alarm/GameAlarmScheduleTest.kt
+++ b/android-app/wear/src/test/java/dev/convocados/wear/data/alarm/GameAlarmScheduleTest.kt
@@ -1,0 +1,63 @@
+package dev.convocados.wear.data.alarm
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class GameAlarmScheduleTest {
+
+    private val kickoff = 1_000_000_000_000L // arbitrary epoch ms
+    private fun min(m: Int) = m * 60_000L
+
+    @Test
+    fun `single alarm fires once at its minute`() {
+        val alarms = listOf(GameAlarm("a", AlarmType.SINGLE, minute = 25, pulses = 2))
+        val fires = computeAlarmTimes(kickoff, alarms, durationMinutes = 60, nowMs = kickoff)
+        assertEquals(1, fires.size)
+        assertEquals(kickoff + min(25), fires[0].triggerAtMs)
+        assertEquals(2, fires[0].pulses)
+    }
+
+    @Test
+    fun `recurring alarm fires every interval until game end`() {
+        val alarms = listOf(GameAlarm("a", AlarmType.RECURRING, minute = 5, pulses = 1))
+        val fires = computeAlarmTimes(kickoff, alarms, durationMinutes = 20, nowMs = kickoff)
+        // 5,10,15,20 (20 == end is inclusive); 25 is past end
+        assertEquals(listOf(min(5), min(10), min(15), min(20)).map { kickoff + it }, fires.map { it.triggerAtMs })
+    }
+
+    @Test
+    fun `past fire times are skipped`() {
+        val alarms = listOf(GameAlarm("a", AlarmType.RECURRING, minute = 5))
+        // now is 12 minutes in: 5 and 10 already passed, 15 and 20 remain
+        val fires = computeAlarmTimes(kickoff, alarms, 20, nowMs = kickoff + min(12))
+        assertEquals(listOf(kickoff + min(15), kickoff + min(20)), fires.map { it.triggerAtMs })
+    }
+
+    @Test
+    fun `disabled alarms and non-positive minutes are ignored`() {
+        val alarms = listOf(
+            GameAlarm("a", AlarmType.SINGLE, minute = 10, enabled = false),
+            GameAlarm("b", AlarmType.RECURRING, minute = 0),
+        )
+        assertEquals(emptyList<AlarmFire>(), computeAlarmTimes(kickoff, alarms, 60, kickoff))
+    }
+
+    @Test
+    fun `single alarm past game end does not fire`() {
+        val alarms = listOf(GameAlarm("a", AlarmType.SINGLE, minute = 90))
+        assertEquals(emptyList<AlarmFire>(), computeAlarmTimes(kickoff, alarms, 60, kickoff))
+    }
+
+    @Test
+    fun `multiple alarms are merged and sorted`() {
+        val alarms = listOf(
+            GameAlarm("switch", AlarmType.SINGLE, minute = 25, pulses = 3),
+            GameAlarm("rotate", AlarmType.RECURRING, minute = 10, pulses = 1),
+        )
+        val fires = computeAlarmTimes(kickoff, alarms, 50, kickoff)
+        assertEquals(
+            listOf(min(10), min(20), min(25), min(30), min(40), min(50)).map { kickoff + it },
+            fires.map { it.triggerAtMs },
+        )
+    }
+}

--- a/android-app/wear/src/test/java/dev/convocados/wear/ui/screen/score/ScoreViewModelTest.kt
+++ b/android-app/wear/src/test/java/dev/convocados/wear/ui/screen/score/ScoreViewModelTest.kt
@@ -2,6 +2,9 @@ package dev.convocados.wear.ui.screen.score
 
 import app.cash.turbine.test
 import dev.convocados.wear.data.api.ApiException
+import dev.convocados.wear.data.alarm.GameAlarmScheduler
+import dev.convocados.wear.data.alarm.GameSettings
+import dev.convocados.wear.data.alarm.GameSettingsStore
 import dev.convocados.wear.data.local.entity.WearGameEntity
 import dev.convocados.wear.data.local.entity.WearHistoryEntity
 import dev.convocados.wear.data.repository.WearGameRepository
@@ -10,6 +13,7 @@ import androidx.work.WorkManager
 import io.mockk.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.test.*
@@ -27,12 +31,15 @@ class ScoreViewModelTest {
 
     private val repository = mockk<WearGameRepository>(relaxed = true)
     private val scoreRepository = mockk<WearScoreRepository>(relaxed = true)
+    private val settingsStore = mockk<GameSettingsStore>(relaxed = true)
+    private val scheduler = mockk<GameAlarmScheduler>(relaxed = true)
     private val workManager = mockk<WorkManager>(relaxed = true)
     private val testDispatcher = StandardTestDispatcher()
 
     @Before
     fun setup() {
         Dispatchers.setMain(testDispatcher)
+        every { settingsStore.settings(any()) } returns MutableStateFlow(GameSettings())
     }
 
     @After
@@ -41,14 +48,14 @@ class ScoreViewModelTest {
     }
 
     private fun makeViewModel(): ScoreViewModel {
-        val vm = ScoreViewModel(repository, scoreRepository, workManager)
+        val vm = ScoreViewModel(repository, scoreRepository, settingsStore, scheduler, workManager)
         vm.tickProvider = { flowOf(Instant.now()) }
         return vm
     }
 
     @Test
     fun `initial state is loading`() = runTest {
-        val viewModel = ScoreViewModel(repository, scoreRepository, workManager)
+        val viewModel = ScoreViewModel(repository, scoreRepository, settingsStore, scheduler, workManager)
 
         viewModel.uiState.test {
             val state = awaitItem()

--- a/android-app/wear/src/test/java/dev/convocados/wear/ui/screen/score/ScoreViewModelTest.kt
+++ b/android-app/wear/src/test/java/dev/convocados/wear/ui/screen/score/ScoreViewModelTest.kt
@@ -1,11 +1,11 @@
 package dev.convocados.wear.ui.screen.score
 
 import app.cash.turbine.test
+import dev.convocados.wear.data.api.ApiException
 import dev.convocados.wear.data.local.entity.WearGameEntity
 import dev.convocados.wear.data.local.entity.WearHistoryEntity
 import dev.convocados.wear.data.repository.WearGameRepository
 import dev.convocados.wear.data.repository.WearScoreRepository
-import dev.convocados.wear.util.canScoreGame
 import androidx.work.WorkManager
 import io.mockk.*
 import kotlinx.coroutines.Dispatchers
@@ -155,39 +155,69 @@ class ScoreViewModelTest {
     }
 
     @Test
-    fun `canScore is true for game within 1 hour`() = runTest {
-        val game = makeGame("e1", time = Instant.now().plus(30, ChronoUnit.MINUTES))
-        coEvery { repository.getGame("e1") } returns game
+    fun `incrementing persists the latest score`() = runTest {
+        coEvery { repository.getGame("e1") } returns makeGame("e1")
         coEvery { repository.refreshHistory("e1") } returns Result.success(Unit)
         coEvery { repository.observeLatestHistory("e1") } returns flowOf(makeHistory("h1", "e1", 0, 0))
+        coEvery { scoreRepository.submitScore(any(), any(), any(), any(), any(), any()) } returns Result.success(Unit)
 
         val viewModel = makeViewModel()
         viewModel.load("e1")
         advanceUntilIdle()
 
-        assertTrue(canScoreGame(game.dateTime))
+        viewModel.incrementScoreOne()
+        advanceUntilIdle()
+
+        coVerify { scoreRepository.submitScore("e1", "h1", 1, 0, any(), any()) }
+    }
+
+    @Test
+    fun `rapid taps coalesce into one save with the final score`() = runTest {
+        coEvery { repository.getGame("e1") } returns makeGame("e1")
+        coEvery { repository.refreshHistory("e1") } returns Result.success(Unit)
+        coEvery { repository.observeLatestHistory("e1") } returns flowOf(makeHistory("h1", "e1", 0, 0))
+        coEvery { scoreRepository.submitScore(any(), any(), any(), any(), any(), any()) } returns Result.success(Unit)
+
+        val viewModel = makeViewModel()
+        viewModel.load("e1")
+        advanceUntilIdle()
+
+        viewModel.incrementScoreOne()
+        viewModel.incrementScoreOne()
+        viewModel.incrementScoreOne()
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { scoreRepository.submitScore("e1", "h1", 3, 0, any(), any()) }
+        coVerify(exactly = 0) { scoreRepository.submitScore("e1", "h1", 1, 0, any(), any()) }
+    }
+
+    @Test
+    fun `startGame success leaves no error`() = runTest {
+        coEvery { repository.startGame(any()) } returns Result.success(Unit)
+
+        val viewModel = makeViewModel()
+        viewModel.startGame()
+        advanceUntilIdle()
+
         viewModel.uiState.test {
-            assertTrue(awaitItem().canScore)
+            val state = awaitItem()
+            assertFalse(state.isStarting)
+            assertNull(state.error)
             cancelAndIgnoreRemainingEvents()
         }
     }
 
     @Test
-    fun `canScore is false for game more than 1 hour away`() = runTest {
-        val game = makeGame("e1", time = Instant.now().plus(180, ChronoUnit.MINUTES))
-        coEvery { repository.getGame("e1") } returns game
-        coEvery { repository.refreshHistory("e1") } returns Result.success(Unit)
-        coEvery { repository.observeLatestHistory("e1") } returns flowOf(makeHistory("h1", "e1", 0, 0))
+    fun `startGame failure with 400 asks to assign teams`() {
+        assertEquals("Assign teams first", startErrorMessage(ApiException(400, "Teams must be assigned first.")))
+    }
 
-        val viewModel = makeViewModel()
-        viewModel.load("e1")
-        advanceUntilIdle()
-
-        assertFalse(canScoreGame(game.dateTime))
-        viewModel.uiState.test {
-            assertFalse(awaitItem().canScore)
-            cancelAndIgnoreRemainingEvents()
-        }
+    @Test
+    fun `startErrorMessage maps auth, other api and network errors`() {
+        assertNull(startErrorMessage(null))
+        assertEquals("Session expired — sign in again", startErrorMessage(ApiException(401, "x")))
+        assertEquals("Couldn't start (500)", startErrorMessage(ApiException(500, "x")))
+        assertEquals("Couldn't start — check connection", startErrorMessage(java.io.IOException("offline")))
     }
 
     // ── Helpers ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Makes score tracking — the watch app's core feature — reachable in one tap from a game, with a fast two-button UI.

## Changes
- **Start scoring**: tapping a game with no history now shows a **Start scoring** button that creates today's game-history record via the existing `POST /api/watch/events` (requires teams assigned) — no need to start from the phone first.
- **Redesigned score editor** (Wear Material 3): two large team-coloured tiles, left vs right, each showing the **team name + score**.
  - **Tap = +1**, **long-press = −1** (with haptics).
  - **No Save button** — every change auto-persists (500 ms debounce) and is **queued offline**, syncing automatically when back online (via existing `ScoreSyncWorker`).
- The editor now appears whenever **editable teams exist**, regardless of the game's time window (removed the time-gated "Score not yet" screen).

## Testing
Verified on a physical Galaxy Watch4:
- Tap left/right tiles → score increments and auto-saves ✅
- Long-press → decrements ✅
- `Start scoring` creates the history record and opens the editor ✅
- `:wear:assembleRelease` builds; pre-push checks (lint/typecheck/tests) pass ✅

## Screenshot
Two-tile editor: Team 1 (primary container) vs Team 2 (tertiary container), large scores, elapsed-time arc at top.