### PR TITLE
fix(ci): ignore CVE-2025-48065 in pnpm audit (vitest UI, dev-only)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Security audit
-        run: pnpm audit --audit-level=high
+        # CVE-2025-48065: Vitest UI server file read — dev-only tool, not exposed in CI/prod.
+        # Blocked by vitest 4.x migration (breaking config changes). Track in a follow-up.
+        run: pnpm audit --audit-level=high --ignore CVE-2025-48065
       - name: Generate Prisma client
         run: pnpm prisma generate
       - name: Type check


### PR DESCRIPTION
Adds `--ignore CVE-2025-48065` to the `pnpm audit` CI step. The vuln affects Vitest's UI server (dev-only, never exposed in CI/prod). Fixing it requires vitest 4.x which has breaking config changes (59 test files fail) — tracked separately.