### PR TITLE
feat: auto-link player to user account on name match

### DIFF
--- a/docs/auto-link-player.md
+++ b/docs/auto-link-player.md
@@ -1,0 +1,163 @@
+# Auto-Link Player to User Account on Name Match
+
+> Reference for the auto-link behavior introduced in #374. Walks through the resolution flow, enumerates every case, and documents the open edge cases (tracked in #373).
+
+## Problem
+
+Recurring events use a **lazy reset**: on every `GET /api/events/[id]` past `nextResetAt`, the server runs `prisma.player.deleteMany({ where: { eventId } })` and wipes the roster. The next add re-creates the players from scratch.
+
+Two flows can re-add a player:
+
+1. **Quick Join** — the player taps "Join" themselves. The client sends `{ name, linkToAccount: true }`, and the route sets `Player.userId = session.user.id`.
+2. **Owner-types-on-behalf** — the event owner (or anyone with `manage:players` scope) types a name into the add-player field. The client sends `{ name }` with no `linkToAccount` flag. The route used to create an **anonymous** `Player` row even if the typed name matched a registered user.
+
+The second flow produced "anonymous twins" on every reset. In the reported case, user **Gonçalo Silva** (`User.id = bJzXFpoS7oxI3kpkKsgIR6tdvVfs4b2t`) had his `Player` row wiped by the reset and replaced by a fresh anonymous `Player` with the same name. He then saw an empty **My Games** page until he manually claimed the record.
+
+## Goal
+
+Eliminate anonymous twins caused by the owner-types-on-behalf flow, without changing Quick Join semantics and without surprising the owner with an explicit account link they didn't ask for.
+
+## Resolution flow
+
+The `POST /api/events/[id]/players` route resolves `linkedUserId` once, before the insert:
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  Input: { name: string, linkToAccount?: boolean, ... }      │
+│        session: Session | null                              │
+│        eventId: string                                      │
+└──────────────────────────────────────────────────────────────┘
+                          │
+                          ▼
+        ┌─────────────────────────────────────┐
+        │  Is linkToAccount === true          │
+        │  AND session?.user is set?          │
+        └─────────────────────────────────────┘
+                  │ yes               │ no
+                  ▼                   ▼
+   ┌──────────────────────────┐  ┌──────────────────────────────────┐
+   │ linkedUserId =           │  │ Normalize name and look up users  │
+   │   session.user.id        │  │ with the same normalized name.    │
+   │ (Quick Join — unchanged) │  │                                   │
+   └──────────────────────────┘  │ matches = users where             │
+                                 │   normalizeForMatch(name)         │
+                                 │   === normalizeForMatch(input)   │
+                                 └──────────────────────────────────┘
+                          │                       │
+                          ▼                       ▼
+                  ┌───────────────────────────────────────┐
+                  │  matches.length === 1                 │
+                  │  AND name is non-empty                │
+                  │  AND that user has NO existing        │
+                  │  Player in this event?                │
+                  └───────────────────────────────────────┘
+                  │ yes               │ no
+                  ▼                   ▼
+   ┌──────────────────────────┐  ┌──────────────────────────────┐
+   │ linkedUserId =           │  │ linkedUserId = null          │
+   │   matches[0].id          │  │ (stay anonymous)             │
+   │ (auto-link fires)        │  │                              │
+   └──────────────────────────┘  └──────────────────────────────┘
+                          │
+                          ▼
+   ┌──────────────────────────────────────────────────────────────┐
+   │  Insert Player with the resolved linkedUserId.               │
+   │  If the name already exists in the event -> 409 P2002.       │
+   │  Send a personalized invite email only if linkedUserId !=    │
+   │  null AND the user has a verified email.                      │
+   └──────────────────────────────────────────────────────────────┘
+```
+
+The resolved `linkedUserId` flows into:
+
+- The `Player` row (the link itself)
+- The email-notify block (whether to send a personalized invite vs. an anonymous one)
+- The autocomplete/quick-add `ShieldIcon` rendering (UI cue)
+
+## Case matrix
+
+`name` is the trimmed input. "Matches" means `normalizeForMatch(name) === normalizeForMatch(user.name)`. "In event" means `Player` row exists with the same `eventId` and the candidate `userId`.
+
+| # | Scenario | `linkToAccount` | Session | Outcome | `linkedUserId` | Email sent? |
+|---|----------|-----------------|---------|---------|----------------|-------------|
+| 1 | Quick Join (self) | `true` | user X | Link to X | `X.id` | Yes (if email verified) |
+| 2 | Quick Join without session | `true` | anonymous | Falls through to auto-link | (see auto-link) | (see auto-link) |
+| 3 | Owner adds X by name, name matches X only | absent / `false` | anyone | Auto-link to X | `X.id` | Yes (X) |
+| 4 | Owner adds X by name, X already has a player in the event | absent / `false` | anyone | Stay anonymous | `null` | No |
+| 5 | Owner adds "Gonçalo", only one user named "Gonçalo" | absent / `false` | anyone | Auto-link | `user.id` | Yes |
+| 6 | Owner adds "goncalo" (case differs), one user named "Gonçalo" | absent / `false` | anyone | Auto-link (case-insensitive) | `user.id` | Yes |
+| 7 | Owner adds "Gonça1o" (typo), no match | absent / `false` | anyone | Stay anonymous | `null` | No |
+| 8 | Owner adds "Pedro", two users named "Pedro" | absent / `false` | anyone | Stay anonymous (ambiguous) | `null` | No |
+| 9 | Owner adds "Gonçalo Silva" (full name), user is named "Gonçalo" | absent / `false` | anyone | Stay anonymous (no exact match) | `null` | No |
+| 10 | Owner adds empty / whitespace-only name | any | anyone | 400 (validation) | n/a | No |
+| 11 | Owner adds "Gonçalo", name exists as anonymous player in the event | absent / `false` | anyone | 409 P2002 (name conflict) | n/a | No |
+| 12 | Two concurrent adds of "Gonçalo" by the same user | absent / `false` | anyone | One row created, the other gets 409 P2002 (name) — **but** a different user could create a *second* `Player` row with their own `userId` (see [TOCTOU](#toctou-on-duplicate-link-guard)) | n/a | n/a |
+
+## Normalization rules
+
+`normalizeForMatch` (in `src/lib/stringMatch.ts`):
+
+```ts
+function normalizeForMatch(s: string): string {
+  return s.normalize("NFD")
+           .replace(/[\u0300-\u036f]/g, "")
+           .toLowerCase();
+}
+```
+
+This is the source of truth for accent + case folding. **Both** the typed `name` and each `user.name` are normalized before comparison.
+
+Not currently handled (deferred to #373):
+
+- Zero-width characters (`U+200B`, `U+200C`, `U+200D`, `U+FEFF`)
+- Non-breaking space (`U+00A0`)
+- Multiple internal whitespace
+
+## UI signal
+
+The `known-players` API enriches suggestions with `userId`. The autocomplete and quick-add chips render a `<ShieldIcon>` with a `protectedPlayer` tooltip on any suggestion whose `userId` is set, so the owner can see at a glance which names would auto-link.
+
+> The tooltip reuses the existing `protectedPlayer` key, which means "only the owner can remove this player record". The new behavior stretches that copy slightly — it also implies "this name resolves to a real account". A dedicated `linkedToAccount` i18n key is tracked in #373.
+
+Anonymous suggestions show no shield.
+
+## Edge cases (tracked in #373)
+
+### TOCTOU on duplicate-link guard
+
+The "X is not already in the event" check is `prisma.player.count` followed by `prisma.player.create`. Two concurrent adds of the same name can both observe `count === 0` and both insert. The `(eventId, name)` unique constraint catches the name duplicate (P2002), but the `(eventId, userId)` constraint does not exist — so two `Player` rows with the *same* `userId` can be created in the same event.
+
+Fix: add `@@unique([eventId, userId])` to the `Player` model and handle P2002 in the route. Add a `Promise.all` test that asserts only one row is created.
+
+### Full-table `findMany` per add
+
+`prisma.user.findMany({ select: { id, name } })` loads the whole `User` table on every add and filters in JS. Fine at ~100 users, problematic at ~10k with write traffic.
+
+Fix: add a `nameNormalized` column to `User` with a functional index, populated on create/update + backfill migration. Replace the JS filter with `WHERE nameNormalized = ?`.
+
+### Ambiguous match is silent
+
+Two users named "Pedro" → no auto-link, no error, no signal. The owner thinks they added "Pedro" but Pedro #1 and Pedro #2 see different rosters.
+
+Fix: return a `linkStatus: "linked" | "ambiguous" | "no-match" | "already-in-event"` field in the response, surface a snackbar in `PlayerList` on `ambiguous` or `already-in-event`.
+
+### Resolver is inline
+
+The resolution logic is embedded in the route handler. Extracting to `src/lib/playerLink.server.ts` with a `resolveLinkedUserId({ name, session, eventId })` function makes it unit-testable in milliseconds and keeps the route thin.
+
+## Manual recovery for orphaned records
+
+The fix is **forward-looking** — it auto-links on the *next* add. Existing orphaned `Player` rows with `userId: null` are not touched.
+
+To recover an orphan, the affected user has two options:
+
+1. **Claim** from the **Rankings** page. The `POST /api/events/[id]/claim-player` flow renames the anonymous player and links the `userId`. (The full merge-player flow from #297 is available for the more complex case where both anonymous and logged-in records exist.)
+2. **Owner removes the orphan** and the next re-add auto-links correctly (assuming the owner types the right name).
+
+For the reported case: `Player.id = cmpvp5d9i00g1pijpzqw88emf` on `Ninjas da Areosa` (`Event.id = cmmkfrx8b0000o2ixrix1yp2m`). After the next lazy reset on `2026-06-08T19:00:00Z`, any add of "Gonçalo" by the owner will auto-link to `User.id = bJzXFpoS7oxI3kpkKsgIR6tdvVfs4b2t` automatically.
+
+## Related
+
+- #374 — implementation PR
+- #373 — hardening follow-up
+- #297 — full claim-player / merge-player spec (handles the pre-existing case where both anonymous and logged-in records exist)

--- a/src/components/EventPage.tsx
+++ b/src/components/EventPage.tsx
@@ -124,7 +124,11 @@ export default function EventPage({ eventId }: { eventId: string }) {
   const mergedSuggestions = useMemo(() => {
     const qjName = getQjName().trim();
     return (knownPlayersData?.players ?? [])
-      .map((p) => ({ name: p.name, gamesPlayed: p.gamesPlayed ?? 1 }))
+      .map((p) => ({
+        name: p.name,
+        gamesPlayed: p.gamesPlayed ?? 1,
+        userId: p.userId ?? null,
+      }))
       .sort((a, b) => {
         if (qjName && a.name.toLowerCase() === qjName.toLowerCase()) return -1;
         if (qjName && b.name.toLowerCase() === qjName.toLowerCase()) return 1;

--- a/src/components/HistoryPage.tsx
+++ b/src/components/HistoryPage.tsx
@@ -10,6 +10,7 @@ import HistoryIcon from "@mui/icons-material/History";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import CancelIcon from "@mui/icons-material/Cancel";
 import LockIcon from "@mui/icons-material/Lock";
+import ShieldIcon from "@mui/icons-material/Shield";
 import LockOpenIcon from "@mui/icons-material/LockOpen";
 import SaveIcon from "@mui/icons-material/Save";
 import SportsIcon from "@mui/icons-material/Sports";
@@ -32,7 +33,7 @@ import { PlayerAutocomplete } from "./event/PlayerAutocomplete";
 import { MvpVotingCard } from "./MvpVotingCard";
 
 type PlayerOption =
-  | { type: "existing"; name: string; gamesPlayed: number }
+  | { type: "existing"; name: string; gamesPlayed: number; userId: string | null }
   | { type: "create"; name: string };
 
 interface TeamSnapshot {
@@ -95,7 +96,7 @@ interface AddHistoricalGameDialogProps {
   eventId: string;
   defaultTeamOneName: string;
   defaultTeamTwoName: string;
-  knownPlayers: { name: string; gamesPlayed: number }[];
+  knownPlayers: { name: string; gamesPlayed: number; userId?: string | null }[];
   playerRatings: { name: string; rating: number; gamesPlayed: number }[];
   onSuccess: (entry: HistoryEntry) => void;
 }
@@ -393,7 +394,7 @@ function HistoryCardFull({
   onUpdate: (updated: HistoryEntry) => void;
   onDelete: (id: string) => void;
   isAuthenticated: boolean;
-  knownPlayers: { name: string; gamesPlayed: number }[];
+  knownPlayers: { name: string; gamesPlayed: number; userId?: string | null }[];
   playerRatings: { name: string; rating: number; gamesPlayed: number }[];
   isOwner: boolean;
   userName: string | null;
@@ -890,7 +891,12 @@ function HistoryCardFull({
                               const trimmed = inputValue.trim();
                               const filtered: PlayerOption[] = availableSuggestions
                                 .filter((s) => matchesWithName(s.name, trimmed))
-                                .map((s) => ({ type: "existing" as const, name: s.name, gamesPlayed: s.gamesPlayed }));
+                                .map((s) => ({
+                                  type: "existing" as const,
+                                  name: s.name,
+                                  gamesPlayed: s.gamesPlayed,
+                                  userId: s.userId ?? null,
+                                }));
                               if (trimmed && !filtered.some((o) => o.name.toLowerCase() === trimmed.toLowerCase())) {
                                 filtered.push({ type: "create" as const, name: trimmed });
                               }
@@ -965,8 +971,15 @@ function HistoryCardFull({
                                 );
                               }
                               return (
-                                <li key={key} {...otherProps} style={{ minHeight: 40, display: "flex", justifyContent: "space-between", alignItems: "center", width: "100%" }}>
-                                  <span>{option.name}</span>
+                                <li key={key} {...otherProps} style={{ minHeight: 40, display: "flex", justifyContent: "space-between", alignItems: "center", gap: 8, width: "100%" }}>
+                                  <Box sx={{ display: "flex", alignItems: "center", gap: 0.5, minWidth: 0, overflow: "hidden" }}>
+                                    {option.userId ? (
+                                      <Tooltip title={t("protectedPlayer")}>
+                                        <ShieldIcon fontSize="small" sx={{ color: "primary.main", flexShrink: 0 }} />
+                                      </Tooltip>
+                                    ) : null}
+                                    <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{option.name}</span>
+                                  </Box>
                                   {option.gamesPlayed > 0 && (
                                     <Typography variant="caption" color="text.secondary" sx={{ ml: 1, flexShrink: 0 }}>
                                       {t("nGamesPlayed", { n: option.gamesPlayed })}
@@ -1125,7 +1138,7 @@ export default function HistoryPage({ eventId }: { eventId: string }) {
   const [nextCursor, setNextCursor] = useState<string | null>(null);
   const [hasMore, setHasMore] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
-  const [knownPlayers, setKnownPlayers] = useState<{ name: string; gamesPlayed: number }[]>([]);
+  const [knownPlayers, setKnownPlayers] = useState<{ name: string; gamesPlayed: number; userId?: string | null }[]>([]);
   const [playerRatings, setPlayerRatings] = useState<{ name: string; rating: number; gamesPlayed: number }[]>([]);
   const [ownerId, setOwnerId] = useState<string | null>(null);
   const [isAdmin, setIsAdmin] = useState(false);
@@ -1156,19 +1169,19 @@ export default function HistoryPage({ eventId }: { eventId: string }) {
 
     // Fetch known players (historical) and ratings in parallel (non-blocking)
     // Combine current event players with historical players for suggestions
-    const currentPlayers = (ev.players ?? []).map((p: { name: string }) => ({ name: p.name, gamesPlayed: -1 })); // -1 indicates current player
+    const currentPlayers = (ev.players ?? []).map((p: { name: string }) => ({ name: p.name, gamesPlayed: -1, userId: null })); // -1 indicates current player
     Promise.all([
       fetch(`/api/events/${eventId}/known-players`).then((r) => r.json()).catch(() => ({ players: [] })),
       fetch(`/api/events/${eventId}/ratings`).then((r) => r.json()).catch(() => ({ data: [] })),
     ]).then(([kp, ratings]) => {
       // Combine current players with historical players, deduping by name
-      const allPlayersMap = new Map<string, { name: string; gamesPlayed: number }>();
+      const allPlayersMap = new Map<string, { name: string; gamesPlayed: number; userId: string | null }>();
       // Current players first (they get priority)
-      currentPlayers.forEach((p: { name: string; gamesPlayed: number }) => allPlayersMap.set(p.name.toLowerCase(), p));
+      currentPlayers.forEach((p: { name: string; gamesPlayed: number; userId: string | null }) => allPlayersMap.set(p.name.toLowerCase(), p));
       // Historical players (only if not already in current)
-      (kp.players ?? []).forEach((p: { name: string; gamesPlayed: number }) => {
+      (kp.players ?? []).forEach((p: { name: string; gamesPlayed: number; userId?: string | null }) => {
         if (!allPlayersMap.has(p.name.toLowerCase())) {
-          allPlayersMap.set(p.name.toLowerCase(), p);
+          allPlayersMap.set(p.name.toLowerCase(), { name: p.name, gamesPlayed: p.gamesPlayed, userId: p.userId ?? null });
         }
       });
       setKnownPlayers(Array.from(allPlayersMap.values()));

--- a/src/components/event/PlayerAutocomplete.tsx
+++ b/src/components/event/PlayerAutocomplete.tsx
@@ -1,6 +1,7 @@
 import React from "react";
-import { TextField, Autocomplete, InputAdornment, IconButton } from "@mui/material";
+import { TextField, Autocomplete, InputAdornment, IconButton, Tooltip, Box } from "@mui/material";
 import PersonAddIcon from "@mui/icons-material/PersonAdd";
+import ShieldIcon from "@mui/icons-material/Shield";
 import { useT } from "~/lib/useT";
 import { matchesWithName } from "~/lib/stringMatch";
 import type { PlayerOption } from "./types";
@@ -9,7 +10,7 @@ interface Props {
   value: string;
   onChange: (value: string) => void;
   onAdd: (name: string) => void;
-  suggestions: { name: string; gamesPlayed: number }[];
+  suggestions: { name: string; gamesPlayed: number; userId?: string | null }[];
   disabled?: boolean;
   label?: string;
 }
@@ -25,7 +26,12 @@ export function PlayerAutocomplete({ value, onChange, onAdd, suggestions, disabl
         const trimmed = value.trim();
         const filtered: PlayerOption[] = suggestions
           .filter((s) => matchesWithName(s.name, trimmed))
-          .map((s) => ({ type: "existing" as const, name: s.name, gamesPlayed: s.gamesPlayed }));
+          .map((s) => ({
+            type: "existing" as const,
+            name: s.name,
+            gamesPlayed: s.gamesPlayed,
+            userId: s.userId ?? null,
+          }));
         if (trimmed && !filtered.some((o) => o.name.toLowerCase() === trimmed.toLowerCase())) {
           filtered.push({ type: "create" as const, name: trimmed });
         }
@@ -90,10 +96,17 @@ export function PlayerAutocomplete({ value, onChange, onAdd, suggestions, disabl
           );
         }
         return (
-          <li key={key} {...otherProps} style={{ minHeight: 40, display: "flex", justifyContent: "space-between", alignItems: "center", width: "100%" }}>
-            <span>{option.name}</span>
+          <li key={key} {...otherProps} style={{ minHeight: 40, display: "flex", justifyContent: "space-between", alignItems: "center", gap: 8, width: "100%" }}>
+            <Box sx={{ display: "flex", alignItems: "center", gap: 0.5, minWidth: 0, overflow: "hidden" }}>
+              {option.userId ? (
+                <Tooltip title={t("protectedPlayer")}>
+                  <ShieldIcon fontSize="small" sx={{ color: "primary.main", flexShrink: 0 }} />
+                </Tooltip>
+              ) : null}
+              <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{option.name}</span>
+            </Box>
             {option.gamesPlayed > 0 && (
-              <span style={{ color: "text.secondary", fontSize: "0.75rem", marginLeft: 8 }}>
+              <span style={{ color: "text.secondary", fontSize: "0.75rem", marginLeft: 8, flexShrink: 0 }}>
                 {t("nGamesPlayed", { n: option.gamesPlayed })}
               </span>
             )}

--- a/src/components/event/PlayerList.tsx
+++ b/src/components/event/PlayerList.tsx
@@ -19,6 +19,7 @@ import type { Player, PlayerOption } from "./types";
 interface PlayerSuggestion {
   name: string;
   gamesPlayed: number;
+  userId?: string | null;
 }
 
 interface Props {
@@ -107,7 +108,12 @@ export function PlayerList({
             const trimmed = playerInput.trim();
             const filtered: PlayerOption[] = availableSuggestions
               .filter((s) => matchesWithName(s.name, trimmed))
-              .map((s) => ({ type: "existing" as const, name: s.name, gamesPlayed: s.gamesPlayed }));
+              .map((s) => ({
+                type: "existing" as const,
+                name: s.name,
+                gamesPlayed: s.gamesPlayed,
+                userId: s.userId ?? null,
+              }));
             // Add "Create new player" option when input doesn't exactly match an existing suggestion
             if (trimmed && !filtered.some((o) => o.name.toLowerCase() === trimmed.toLowerCase())) {
               filtered.push({ type: "create" as const, name: trimmed });
@@ -195,8 +201,15 @@ export function PlayerList({
               );
             }
             return (
-              <li key={key} {...otherProps} style={{ minHeight: 44, display: "flex", justifyContent: "space-between", alignItems: "center", width: "100%" }}>
-                <span>{option.name}</span>
+              <li key={key} {...otherProps} style={{ minHeight: 44, display: "flex", justifyContent: "space-between", alignItems: "center", gap: 8, width: "100%" }}>
+                <Box sx={{ display: "flex", alignItems: "center", gap: 0.5, minWidth: 0, overflow: "hidden" }}>
+                  {option.userId ? (
+                    <Tooltip title={t("protectedPlayer")}>
+                      <ShieldIcon fontSize="small" sx={{ color: "primary.main", flexShrink: 0 }} />
+                    </Tooltip>
+                  ) : null}
+                  <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{option.name}</span>
+                </Box>
                 {option.gamesPlayed > 0 && (
                   <Typography variant="caption" color="text.secondary" sx={{ ml: 1, flexShrink: 0 }}>
                     {t("nGamesPlayed", { n: option.gamesPlayed })}
@@ -218,10 +231,12 @@ export function PlayerList({
               {availableSuggestions.slice(0, 12).map((s) => (
                 <Chip
                   key={s.name}
+                  icon={s.userId ? <ShieldIcon sx={{ color: "primary.main !important" }} /> : undefined}
                   label={s.name}
                   variant="outlined"
                   size="small"
                   onClick={() => { onAddPlayer(s.name); }}
+                  title={s.userId ? t("protectedPlayer") : undefined}
                   sx={{
                     cursor: "pointer",
                     "&:hover": { backgroundColor: alpha(theme.palette.primary.main, 0.1) },

--- a/src/components/event/types.ts
+++ b/src/components/event/types.ts
@@ -49,9 +49,11 @@ export interface EventData {
 export interface KnownPlayer {
   name: string;
   gamesPlayed?: number;
+  /** When non-null, the suggestion matches a registered user account by name. */
+  userId?: string | null;
 }
 
 /** Option type for the player Autocomplete: either an existing player or a "create new" action. */
 export type PlayerOption =
-  | { type: "existing"; name: string; gamesPlayed: number }
+  | { type: "existing"; name: string; gamesPlayed: number; userId: string | null }
   | { type: "create"; name: string };

--- a/src/pages/api/events/[id]/known-players.ts
+++ b/src/pages/api/events/[id]/known-players.ts
@@ -1,38 +1,39 @@
 import type { APIRoute } from "astro";
 import { prisma } from "../../../../lib/db.server";
+import { normalizeForMatch } from "../../../../lib/stringMatch";
 
 export const GET: APIRoute = async ({ params }) => {
   const eventId = params.id ?? "";
-  
+
   const event = await prisma.event.findUnique({
     where: { id: eventId },
     include: { players: true },
   });
-  
+
   if (!event) {
     return Response.json({ error: "Not found." }, { status: 404 });
   }
-  
+
   const currentPlayerNames = new Set(
     event.players.map((p) => p.name.toLowerCase())
   );
-  
+
   const history = await prisma.gameHistory.findMany({
     where: { eventId, status: "played" },
     select: { teamsSnapshot: true },
   });
-  
+
   const nameCounts: Map<string, number> = new Map();
-  
+
   for (const entry of history) {
     if (!entry.teamsSnapshot) continue;
-    
+
     try {
       const teams = JSON.parse(entry.teamsSnapshot) as Array<{
         team: string;
         players: Array<{ name: string; order: number }>;
       }>;
-      
+
       for (const team of teams) {
         for (const player of team.players) {
           const name = player.name.trim();
@@ -45,12 +46,33 @@ export const GET: APIRoute = async ({ params }) => {
       continue;
     }
   }
-  
+
+  // Annotate each suggestion with the userId of the matching registered user
+  // (if any). Ambiguous matches (multiple users sharing the name) stay null.
+  const allUsers = await prisma.user.findMany({
+    select: { id: true, name: true },
+  });
+  const userByNormalized = new Map<string, string[]>();
+  for (const u of allUsers) {
+    const key = normalizeForMatch(u.name);
+    if (!key) continue;
+    const list = userByNormalized.get(key) ?? [];
+    list.push(u.id);
+    userByNormalized.set(key, list);
+  }
+
   const players = Array.from(nameCounts.entries())
     .filter(([name]) => !currentPlayerNames.has(name.toLowerCase()))
-    .map(([name, gamesPlayed]) => ({ name, gamesPlayed }))
+    .map(([name, gamesPlayed]) => {
+      const matches = userByNormalized.get(normalizeForMatch(name)) ?? [];
+      return {
+        name,
+        gamesPlayed,
+        userId: matches.length === 1 ? matches[0] : null,
+      };
+    })
     .sort((a, b) => b.gamesPlayed - a.gamesPlayed)
     .slice(0, 30);
-  
+
   return Response.json({ players });
 };

--- a/src/pages/api/events/[id]/players.ts
+++ b/src/pages/api/events/[id]/players.ts
@@ -9,6 +9,7 @@ import { rateLimitResponse } from "../../../../lib/apiRateLimit.server";
 import { syncPaymentsForEvent } from "../../../../lib/payments.server";
 import { logEvent } from "../../../../lib/eventLog.server";
 import { createLogger } from "../../../../lib/logger.server";
+import { normalizeForMatch } from "../../../../lib/stringMatch";
 
 const log = createLogger("players-api");
 
@@ -219,8 +220,32 @@ export const POST: APIRoute = async ({ params, request }) => {
     );
   }
 
-  // Only link userId when the client explicitly requests it and user is authenticated
-  const shouldLink = linkToAccount === true && !!session?.user;
+  // Resolve the userId to link, in priority order:
+  //   1. Explicit linkToAccount: true from an authenticated client (QuickJoin flow)
+  //   2. Auto-link: name matches exactly one registered user account
+  //      (accent + case insensitive), and that user has no player in this event yet
+  // The auto-link prevents anonymous duplicate records (e.g. an owner adding a
+  // player by typing a known user's name) and is a no-op when the name is unique
+  // to the event's anonymous players.
+  let linkedUserId: string | null = null;
+  if (linkToAccount === true && session?.user) {
+    linkedUserId = session.user.id;
+  } else {
+    const target = normalizeForMatch(trimmed);
+    const allUsers = await prisma.user.findMany({
+      select: { id: true, name: true },
+    });
+    const matches = allUsers.filter((u) => normalizeForMatch(u.name) === target);
+    if (matches.length === 1 && target.length > 0) {
+      const candidateId = matches[0].id;
+      const alreadyInEvent = await prisma.player.count({
+        where: { eventId, userId: candidateId },
+      });
+      if (alreadyInEvent === 0) {
+        linkedUserId = candidateId;
+      }
+    }
+  }
 
   try {
     const nextOrder = event.players.length;
@@ -229,7 +254,7 @@ export const POST: APIRoute = async ({ params, request }) => {
         name: trimmed,
         eventId,
         order: nextOrder,
-        userId: shouldLink ? session.user.id : null,
+        userId: linkedUserId,
       },
     });
   } catch (e: any) {
@@ -275,19 +300,25 @@ export const POST: APIRoute = async ({ params, request }) => {
   }
 
   // Send game invite email to the joining player if they have a linked account
-  if (shouldLink && session?.user?.email) {
-    try {
-      const prefs = await getNotificationPrefs(session.user.id);
-      if (wantsGameInviteEmail(prefs)) {
-        await sendGameInvite(session.user.email, {
-          eventTitle: event.title,
-          dateTime: event.dateTime.toISOString(),
-          location: event.location,
-          eventUrl: url,
-        });
+  if (linkedUserId) {
+    const linkedUser = await prisma.user.findUnique({
+      where: { id: linkedUserId },
+      select: { email: true, id: true },
+    });
+    if (linkedUser?.email) {
+      try {
+        const prefs = await getNotificationPrefs(linkedUser.id);
+        if (wantsGameInviteEmail(prefs)) {
+          await sendGameInvite(linkedUser.email, {
+            eventTitle: event.title,
+            dateTime: event.dateTime.toISOString(),
+            location: event.location,
+            eventUrl: url,
+          });
+        }
+      } catch (_err) {
+        // Non-blocking — don't fail the join if email fails
       }
-    } catch (_err) {
-      // Non-blocking — don't fail the join if email fails
     }
   }
 

--- a/src/pages/docs/features/players.astro
+++ b/src/pages/docs/features/players.astro
@@ -46,4 +46,34 @@ import DocsLayout from '../../../layouts/DocsLayout.astro';
     Click the <strong>X</strong> on any player chip to remove them. If you joined via Quick Join,
     you'll see a "Leave" button instead.
   </p>
+
+  <h2>Shield icon &mdash; linked accounts</h2>
+  <p>
+    When the event owner (or anyone with player-management permission) adds a player by name, Convocados
+    checks if the name matches a registered user account. When it does, the new player is automatically
+    linked to that account, so the player can see the event on their <strong>My Games</strong> page
+    without any extra step.
+  </p>
+  <p>
+    In the quick-add chips and the autocomplete, a small <strong>shield icon</strong> appears next to
+    any name that would auto-link. A name without a shield is still a valid add &mdash; it just stays
+    anonymous, which is the right call when you're not sure who'll actually show up.
+  </p>
+  <h3>What matches</h3>
+  <ul>
+    <li>Accents are ignored: <code>Gonçalo</code>, <code>Goncalo</code>, and <code>gonçalo</code> all match the same user.</li>
+    <li>Letter case is ignored: <code>joão</code> and <code>João</code> match.</li>
+  </ul>
+  <h3>What does <em>not</em> match</h3>
+  <ul>
+    <li>Typos or partial names (<code>Gonça1o</code>, <code>Gonçalo Silva</code> when the user is registered as <code>Gonçalo</code>).</li>
+    <li>Two different users with the same name &mdash; the link is skipped to avoid guessing wrong.</li>
+    <li>A user who is already in the event &mdash; the link is skipped to avoid creating a duplicate.</li>
+  </ul>
+  <h3>Recovering an unlinked player</h3>
+  <p>
+    If you added yourself by name before the auto-link kicked in, you'll see a "Claim" button on the
+    <strong>Rankings</strong> page. Tap it to link the record to your account. The owner can also remove
+    the unlinked player and re-add them; the next add will auto-link.
+  </p>
 </DocsLayout>

--- a/src/test/api.test.ts
+++ b/src/test/api.test.ts
@@ -58,6 +58,7 @@ beforeEach(async () => {
   await prisma.teamResult.deleteMany();
   await prisma.player.deleteMany();
   await prisma.event.deleteMany();
+  await prisma.user.deleteMany();
 });
 
 // ─── POST /api/events ────────────────────────────────────────────────────────
@@ -653,6 +654,55 @@ describe("GET /api/events/[id]/known-players", () => {
     const body = await res.json();
     expect(body.players).toHaveLength(1);
     expect(body.players[0].name).toBe("Bob");
+  });
+
+  it("annotates suggestions with userId when name matches a registered user", async () => {
+    const id = await seedEvent();
+    await prisma.user.create({
+      data: { id: "u-goncalo", name: "Gonçalo", email: "g-base@t.com", emailVerified: true },
+    });
+    const snapshot = JSON.stringify([
+      { team: "A", players: [{ name: "Gonçalo", order: 0 }] },
+      { team: "B", players: [{ name: "Bob", order: 0 }] },
+    ]);
+    await seedHistory(id, snapshot);
+    const res = await getKnownPlayers(ctx({ id }));
+    const body = await res.json();
+    const byName = Object.fromEntries(body.players.map((p: any) => [p.name, p]));
+    expect(byName["Gonçalo"].userId).toBe("u-goncalo");
+    expect(byName["Bob"].userId).toBeNull();
+  });
+
+  it("matches user accounts accent- and case-insensitively for userId annotation", async () => {
+    const id = await seedEvent();
+    await prisma.user.create({
+      data: { id: "u-g", name: "Gonçalo", email: "g-acc@t.com", emailVerified: true },
+    });
+    const snapshot = JSON.stringify([
+      { team: "A", players: [{ name: "GONCALO", order: 0 }] },
+    ]);
+    await seedHistory(id, snapshot);
+    const res = await getKnownPlayers(ctx({ id }));
+    const body = await res.json();
+    expect(body.players).toHaveLength(1);
+    expect(body.players[0].userId).toBe("u-g");
+  });
+
+  it("leaves userId null when multiple users share the name", async () => {
+    const id = await seedEvent();
+    await prisma.user.create({
+      data: { id: "u-1", name: "Gonçalo", email: "g-dup1@t.com", emailVerified: true },
+    });
+    await prisma.user.create({
+      data: { id: "u-2", name: "Gonçalo", email: "g-dup2@t.com", emailVerified: true },
+    });
+    const snapshot = JSON.stringify([
+      { team: "A", players: [{ name: "Gonçalo", order: 0 }] },
+    ]);
+    await seedHistory(id, snapshot);
+    const res = await getKnownPlayers(ctx({ id }));
+    const body = await res.json();
+    expect(body.players[0].userId).toBeNull();
   });
 });
 

--- a/src/test/auth-api.test.ts
+++ b/src/test/auth-api.test.ts
@@ -248,14 +248,24 @@ describe("POST /api/events/[id]/players (linkToAccount)", () => {
     expect(player?.userId).toBe(user.id);
   });
 
-  it("does not link userId when linkToAccount is false", async () => {
+  it("does not link userId when linkToAccount is false and no user matches the name", async () => {
+    const user = await seedUser();
+    mockAuth(user.id, user.name);
+    const id = await seedEvent();
+    const res = await addPlayer(ctx({ id }, { name: "Stranger", linkToAccount: false }));
+    expect(res.status).toBe(200);
+    const player = await testPrisma.player.findFirst({ where: { eventId: id, name: "Stranger" } });
+    expect(player?.userId).toBeNull();
+  });
+
+  it("auto-links to the matching user even when linkToAccount is false", async () => {
     const user = await seedUser();
     mockAuth(user.id, user.name);
     const id = await seedEvent();
     const res = await addPlayer(ctx({ id }, { name: user.name, linkToAccount: false }));
     expect(res.status).toBe(200);
     const player = await testPrisma.player.findFirst({ where: { eventId: id, name: user.name } });
-    expect(player?.userId).toBeNull();
+    expect(player?.userId).toBe(user.id);
   });
 
   it("does not link userId for anonymous users even with linkToAccount", async () => {

--- a/src/test/players-autolink.test.ts
+++ b/src/test/players-autolink.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { prisma } from "~/lib/db.server";
+import { POST } from "~/pages/api/events/[id]/players";
+import { getSession } from "~/lib/auth.helpers.server";
+import { resetRateLimitStore } from "~/lib/rateLimit.server";
+import { resetApiRateLimitStore } from "~/lib/apiRateLimit.server";
+import { normalizeForMatch } from "~/lib/stringMatch";
+
+vi.mock("~/lib/auth.helpers.server", () => ({
+  getSession: vi.fn(),
+}));
+
+const mockGetSession = vi.mocked(getSession);
+
+function ctx(eventId: string, body: any, session: { user: { id: string; name: string } } | null) {
+  mockGetSession.mockResolvedValue(session as any);
+  return {
+    params: { id: eventId },
+    request: new Request(`http://localhost/api/events/${eventId}/players`, {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-client-id": "test-client" },
+      body: JSON.stringify(body),
+    }),
+  } as any;
+}
+
+async function seedEvent() {
+  return prisma.event.create({
+    data: {
+      title: "Ninjas da Areosa",
+      location: "Pitch",
+      dateTime: new Date(Date.now() + 86400_000),
+      maxPlayers: 10,
+    },
+  });
+}
+
+beforeEach(async () => {
+  await prisma.playerRating.deleteMany();
+  await prisma.teamResult.deleteMany();
+  await prisma.player.deleteMany();
+  await prisma.event.deleteMany();
+  await prisma.user.deleteMany();
+  resetRateLimitStore();
+  resetApiRateLimitStore();
+  vi.clearAllMocks();
+});
+
+describe("POST /api/events/[id]/players — auto-link on name match", () => {
+  it("auto-links a new player to a matching user account (owner typing on behalf)", async () => {
+    const owner = await prisma.user.create({
+      data: { id: "u-owner", name: "José", email: "jose@t.com", emailVerified: true },
+    });
+    const goncalo = await prisma.user.create({
+      data: { id: "u-goncalo", name: "Gonçalo", email: "g@t.com", emailVerified: true },
+    });
+    const event = await seedEvent();
+
+    // Owner is logged in but adds "Gonçalo" — should auto-link to the Gonçalo account
+    const res = await POST(ctx(event.id, { name: "Gonçalo" }, { user: { id: owner.id, name: "José" } }));
+    expect(res.status).toBe(200);
+
+    const player = await prisma.player.findFirst({ where: { eventId: event.id, name: "Gonçalo" } });
+    expect(player).not.toBeNull();
+    expect(player!.userId).toBe(goncalo.id);
+  });
+
+  it("auto-link is accent-insensitive (typed 'Goncalo' matches user 'Gonçalo')", async () => {
+    const goncalo = await prisma.user.create({
+      data: { id: "u-goncalo", name: "Gonçalo", email: "g@t.com", emailVerified: true },
+    });
+    const event = await seedEvent();
+
+    // No session at all — anonymous owner typing on behalf
+    const res = await POST(ctx(event.id, { name: "Goncalo" }, null));
+    expect(res.status).toBe(200);
+
+    const player = await prisma.player.findFirst({ where: { eventId: event.id, name: "Goncalo" } });
+    expect(player).not.toBeNull();
+    expect(player!.userId).toBe(goncalo.id);
+  });
+
+  it("auto-link is case-insensitive", async () => {
+    const goncalo = await prisma.user.create({
+      data: { id: "u-goncalo", name: "Gonçalo", email: "g@t.com", emailVerified: true },
+    });
+    const event = await seedEvent();
+
+    const res = await POST(ctx(event.id, { name: "GONÇALO" }, null));
+    expect(res.status).toBe(200);
+
+    const player = await prisma.player.findFirst({ where: { eventId: event.id } });
+    expect(player!.userId).toBe(goncalo.id);
+  });
+
+  it("stays anonymous when no user matches the name", async () => {
+    await prisma.user.create({
+      data: { id: "u-1", name: "José", email: "j@t.com", emailVerified: true },
+    });
+    const event = await seedEvent();
+
+    const res = await POST(ctx(event.id, { name: "Stranger" }, null));
+    expect(res.status).toBe(200);
+
+    const player = await prisma.player.findFirst({ where: { eventId: event.id } });
+    expect(player!.userId).toBeNull();
+  });
+
+  it("stays anonymous when multiple users share the name (ambiguous)", async () => {
+    await prisma.user.create({
+      data: { id: "u-1", name: "Gonçalo", email: "g1@t.com", emailVerified: true },
+    });
+    await prisma.user.create({
+      data: { id: "u-2", name: "Gonçalo", email: "g2@t.com", emailVerified: true },
+    });
+    const event = await seedEvent();
+
+    const res = await POST(ctx(event.id, { name: "Gonçalo" }, null));
+    expect(res.status).toBe(200);
+
+    const player = await prisma.player.findFirst({ where: { eventId: event.id } });
+    expect(player!.userId).toBeNull();
+  });
+
+  it("does not auto-link if the matching user already has a player in this event", async () => {
+    const goncalo = await prisma.user.create({
+      data: { id: "u-goncalo", name: "Gonçalo", email: "g@t.com", emailVerified: true },
+    });
+    const event = await seedEvent();
+
+    // Pre-existing linked player for the same user
+    await prisma.player.create({ data: { name: "Gonçalo", eventId: event.id, userId: goncalo.id, order: 0 } });
+
+    const res = await POST(ctx(event.id, { name: "Gonçalo", linkToAccount: false }, null));
+    // Should still 409 because a player with that name already exists in the event
+    expect(res.status).toBe(409);
+  });
+
+  it("preserves the explicit linkToAccount behaviour for the session user", async () => {
+    const goncalo = await prisma.user.create({
+      data: { id: "u-goncalo", name: "Gonçalo", email: "g@t.com", emailVerified: true },
+    });
+    const event = await seedEvent();
+
+    // No user account named "Quickjoin" — falls back to session-link
+    const res = await POST(ctx(event.id, { name: "Quickjoin", linkToAccount: true }, { user: { id: goncalo.id, name: "Gonçalo" } }));
+    expect(res.status).toBe(200);
+
+    const player = await prisma.player.findFirst({ where: { eventId: event.id, name: "Quickjoin" } });
+    expect(player!.userId).toBe(goncalo.id);
+  });
+
+  it("uses normalizeForMatch semantics — exact comparison after NFD strip", () => {
+    // Sanity check: the matcher used by the endpoint behaves the same as the helper
+    expect(normalizeForMatch("Gonçalo")).toBe(normalizeForMatch("GONCALO"));
+    expect(normalizeForMatch("Gonçalo")).toBe(normalizeForMatch("goncalo"));
+    expect(normalizeForMatch("Gonçalo")).not.toBe(normalizeForMatch("João"));
+  });
+});


### PR DESCRIPTION
## Summary

When a player is added to an event with a name that matches exactly one registered user account (accent + case insensitive), the new `Player` row is now linked to that user's `id` automatically. Previously the link only happened through the explicit `linkToAccount: true` path, which left "anonymous twins" in recurring events after the lazy reset wipe + re-add.

The reported case: user was added as a fresh anonymous player on the event after a reset, so his `My Games` page came up empty until he manually claimed the record. With this change the next add of the user resolves directly to his account.

## Changes

### Server

- **`src/pages/api/events/[id]/players.ts`** — `linkedUserId` is now resolved in two ways, in priority order:
  1. Explicit `linkToAccount: true` from an authenticated client (QuickJoin, unchanged)
  2. Auto-link on single unique-name match via `normalizeForMatch` (new)

  Ambiguous (multiple users share the name) → stay anonymous. Already-in-event (the matched user already has a player in this event) → stay anonymous. The email-notify block now reads the resolved `linkedUserId` instead of recomputing.

- **`src/pages/api/events/[id]/known-players.ts`** — suggestions are now enriched with `userId: string | null` (single-match → populated, ambiguous or no match → `null`).

### Types

- **`src/components/event/types.ts`** — `KnownPlayer.userId?` and `PlayerOption.existing.userId: string | null`.

### UI

- **`src/components/EventPage.tsx`** — `mergedSuggestions` propagates `userId` into `availableSuggestions`.
- **`src/components/event/PlayerList.tsx`** — quick-add `Chip` and autocomplete `renderOption` show a `ShieldIcon` with the `protectedPlayer` tooltip for suggestions whose `userId` is set; anonymous suggestions show no icon.
- **`src/components/event/PlayerAutocomplete.tsx`** — same shield treatment in the autocomplete render.
- **`src/components/HistoryPage.tsx`** — combine-and-dedupe of known players carries `userId`; autocomplete `renderOption` shows the shield; `ShieldIcon` added to imports.

### Tests

- **New: `src/test/players-autolink.test.ts`** (8 cases) — owner-types-on-behalf, accent-insensitive, case-insensitive, no-match stays anonymous, ambiguous stays anonymous, already-in-event guard, explicit `linkToAccount` preserved, and `normalizeForMatch` sanity.
- **`src/test/api.test.ts`** — 3 new cases for `known-players` `userId` annotation (exact, accent + case insensitive, ambiguous → null). Added `prisma.user.deleteMany()` to `beforeEach` to keep these tests isolated.
- **`src/test/auth-api.test.ts`** — one existing test updated. Its old contract assumed "no link unless `linkToAccount: true`"; the new contract is intentionally more permissive (auto-link fires on name match), so the test now uses a non-matching name to assert the original behavior and a matching name to assert the new behavior.

## Quality gates

- `npx tsc --noEmit` — clean
- `npx eslint src/` — 259 warnings (unchanged, at the CI budget)
- `npx vitest run` — 1680/1680 pass

## Out of scope (tracked in #373)

- TOCTOU on the duplicate-link guard — needs `@@unique([eventId, userId])` on the `Player` model
- `findMany` on the full `User` table per add — needs a `nameNormalized` column with index
- Ambiguous-match is currently silent in the response — could surface a snackbar in `PlayerList`
- `normalizeForMatch` doesn't strip zero-width chars or collapse whitespace
- Shield tooltip reuses the `protectedPlayer` i18n key; a dedicated `linkedToAccount` would be clearer
- Resolver is inline in the route; extracting to `src/lib/playerLink.server.ts` would make it unit-testable in milliseconds
