### PR TITLE
feat: show vote counts on each player chip during mvp voting

### DIFF
--- a/src/components/MvpVotingCard.tsx
+++ b/src/components/MvpVotingCard.tsx
@@ -20,7 +20,7 @@ interface MvpData {
   hasVoted: boolean | null;
   totalVotes: number;
   eligibleVoters: number;
-  participants?: { id: string; name: string }[];
+  participants?: { id: string; name: string; voteCount: number }[];
   votes?: { voterName: string; votedForName: string }[];
 }
 
@@ -143,7 +143,7 @@ export function MvpVotingCard({ eventId, historyId, compact }: Props) {
               <Chip
                 key={p.id}
                 data-testid={`mvp-vote-chip-${p.name}`}
-                label={p.name}
+                label={`${p.name} (${p.voteCount})`}
                 size="small"
                 variant={myVote?.votedForName.toLowerCase() === p.name.toLowerCase() ? "filled" : "outlined"}
                 color="primary"

--- a/src/pages/api/events/[id]/history/[historyId]/mvp.ts
+++ b/src/pages/api/events/[id]/history/[historyId]/mvp.ts
@@ -113,12 +113,17 @@ export const GET: APIRoute = async ({ params, request }) => {
   }
 
   // Extract participants from teamsSnapshot for the voting UI
-  let participants: Array<{ id: string; name: string }> = [];
+  let participants: Array<{ id: string; name: string; voteCount: number }> = [];
   let eligibleVoters = 0;
   if (history.teamsSnapshot) {
     try {
       const teams = JSON.parse(history.teamsSnapshot) as Array<{ team: string; players: Array<{ name: string }> }>;
       const names = teams.flatMap((t) => t.players.map((p) => p.name));
+      // Build tally map from votes
+      const tally = new Map<string, number>();
+      for (const v of votes) {
+        tally.set(v.votedForPlayerId, (tally.get(v.votedForPlayerId) ?? 0) + 1);
+      }
       // Try to resolve Player IDs; fall back to name-based IDs
       const players = await prisma.player.findMany({
         where: { eventId: params.id, name: { in: names } },
@@ -126,12 +131,13 @@ export const GET: APIRoute = async ({ params, request }) => {
       });
       const byName = new Map(players.map((p) => [p.name.toLowerCase(), p]));
       const seen = new Set<string>();
-      participants = names.reduce<Array<{ id: string; name: string }>>((acc, n) => {
+      participants = names.reduce<Array<{ id: string; name: string; voteCount: number }>>((acc, n) => {
         const key = n.toLowerCase();
         if (seen.has(key)) return acc;
         seen.add(key);
         const match = byName.get(key);
-        acc.push(match ? { id: match.id, name: match.name } : { id: `name:${n}`, name: n });
+        const id = match ? match.id : `name:${n}`;
+        acc.push({ id, name: match?.name ?? n, voteCount: tally.get(id) ?? 0 });
         return acc;
       }, []);
 

--- a/src/test/mvp-vote.test.ts
+++ b/src/test/mvp-vote.test.ts
@@ -520,6 +520,51 @@ describe("GET mvp", () => {
     const body = await res.json();
     expect(body.participants).toBeDefined();
     expect(body.participants.map((p: any) => p.name).sort()).toEqual(["Alice", "Bob", "Charlie", "Dave"]);
+    // All participants have voteCount=0 when no votes
+    body.participants.forEach((p: any) => {
+      expect(p).toHaveProperty("voteCount");
+      expect(p.voteCount).toBe(0);
+    });
+  });
+
+  it("includes voteCount for each participant when votes exist", async () => {
+    const event = await seedEvent();
+    const alice = await seedPlayer(event.id, "Alice");
+    const bob = await seedPlayer(event.id, "Bob");
+    const charlie = await seedPlayer(event.id, "Charlie");
+    await seedPlayer(event.id, "Dave");
+    const history = await seedHistory(event.id);
+
+    await prisma.mvpVote.create({
+      data: {
+        gameHistoryId: history.id,
+        voterPlayerId: alice.id, voterName: "Alice",
+        votedForPlayerId: bob.id, votedForName: "Bob",
+      },
+    });
+    await prisma.mvpVote.create({
+      data: {
+        gameHistoryId: history.id,
+        voterPlayerId: charlie.id, voterName: "Charlie",
+        votedForPlayerId: bob.id, votedForName: "Bob",
+      },
+    });
+    await prisma.mvpVote.create({
+      data: {
+        gameHistoryId: history.id,
+        voterPlayerId: bob.id, voterName: "Bob",
+        votedForPlayerId: charlie.id, votedForName: "Charlie",
+      },
+    });
+
+    const res = await getMvp(getCtx({ id: event.id, historyId: history.id }));
+    const body = await res.json();
+
+    const getByName = (name: string) => body.participants.find((p: any) => p.name === name);
+    expect(getByName("Bob")!.voteCount).toBe(2);
+    expect(getByName("Charlie")!.voteCount).toBe(1);
+    expect(getByName("Alice")!.voteCount).toBe(0);
+    expect(getByName("Dave")!.voteCount).toBe(0);
   });
 
   it("returns 404 for non-existent event", async () => {


### PR DESCRIPTION
**Changes:**
- API (`mvp.ts`): Builds a tally map from existing votes and includes `voteCount` on each participant in the response
- Component (`MvpVotingCard.tsx`): Updated chip labels from `p.name` to `${p.name} (${p.voteCount})` so players see live vote counts during the voting window
- Tests: Updated participants test to assert `voteCount` property exists (0 when no votes), and added a new test verifying correct counts per player when votes exist