### PR TITLE
feat: ensure prisma migrations run on every prod deploy

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -3,6 +3,12 @@ primary_region = "cdg"
 
 [build]
 
+[deploy]
+  # Runs once per deploy, before the new app version takes traffic. If the
+  # migration fails, the deploy fails and the previous version keeps serving.
+  # This is the canonical place for schema changes — see docs/runbooks/.
+  release_command = "node_modules/.bin/prisma migrate deploy"
+
 [env]
   HOST = "0.0.0.0"
   PORT = "3000"

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "db:push": "prisma db push",
     "db:studio": "prisma studio",
     "db:seed": "npx tsx prisma/seed.ts",
+    "db:pull-prod": "sh ./scripts/pull-prod-db.sh",
+    "dev:prod-db": "npm run db:pull-prod && DATABASE_URL=file:./prod-debug.db astro dev --host 0.0.0.0",
     "lhci": "lhci autorun --config=lighthouserc.cjs",
     "k6:smoke": "k6 run k6/scripts/smoke.js",
     "k6:load": "k6 run k6/scripts/load.js",

--- a/scripts/pull-prod-db.sh
+++ b/scripts/pull-prod-db.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+# Pull the production SQLite database from the Fly.io volume to the local
+# machine for debugging. The downloaded files land in prisma/prod-debug.db
+# (which is covered by the .gitignore *.db rule).
+#
+# Usage:
+#   npm run db:pull-prod
+#   # or with a custom app name:
+#   FLY_APP=convocados-staging npm run db:pull-prod
+#
+# Requirements:
+#   - fly CLI authenticated against the target org
+#   - sqlite3 on PATH (used for integrity check + row counts)
+set -eu
+
+FLY_APP="${FLY_APP:-convocados}"
+REMOTE_DIR="/data"
+LOCAL_DIR="prisma"
+DB_NAME="prod-debug.db"
+
+DB_PATH="$LOCAL_DIR/$DB_NAME"
+WAL_PATH="$LOCAL_DIR/$DB_NAME-wal"
+SHM_PATH="$LOCAL_DIR/$DB_NAME-shm"
+
+if ! command -v fly >/dev/null 2>&1; then
+  echo "error: 'fly' CLI not found. Install: https://fly.io/docs/hands-on/install-flyctl/" >&2
+  exit 1
+fi
+
+if ! command -v sqlite3 >/dev/null 2>&1; then
+  echo "error: 'sqlite3' not found. Install with: brew install sqlite" >&2
+  exit 1
+fi
+
+echo "==> Pulling $DB_NAME from $FLY_APP:$REMOTE_DIR"
+
+mkdir -p "$LOCAL_DIR"
+rm -f "$DB_PATH" "$WAL_PATH" "$SHM_PATH"
+
+for suffix in "" "-wal" "-shm"; do
+  remote="$REMOTE_DIR/db.sqlite$suffix"
+  local="$DB_PATH$suffix"
+  echo "    $remote -> $local"
+  fly ssh sftp get "$remote" "$local"
+done
+
+echo "==> Verifying integrity"
+integrity=$(sqlite3 "$DB_PATH" "PRAGMA integrity_check;")
+if [ "$integrity" != "ok" ]; then
+  echo "error: integrity_check failed: $integrity" >&2
+  exit 1
+fi
+
+echo "    ok"
+
+echo "==> Snapshot"
+sqlite3 -header -column "$DB_PATH" "
+  SELECT 'users'    AS table_name, (SELECT count(*) FROM User)         AS rows UNION ALL
+  SELECT 'events',                  (SELECT count(*) FROM Event)        UNION ALL
+  SELECT 'players',                 (SELECT count(*) FROM Player)       UNION ALL
+  SELECT 'game_history',            (SELECT count(*) FROM GameHistory)  UNION ALL
+  SELECT 'event_invites',           (SELECT count(*) FROM EventInvite)  UNION ALL
+  SELECT 'scheduled_jobs',          (SELECT count(*) FROM ScheduledJob) UNION ALL
+  SELECT 'push_subscriptions',      (SELECT count(*) FROM PushSubscription);
+"
+
+echo
+echo "Done. DB at: $DB_PATH"
+echo "Serve locally with: npm run dev:prod-db"

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -30,6 +30,19 @@ echo "[startup] Running database migrations..."
 # unexecuted migrations as "applied".
 ./node_modules/.bin/prisma migrate deploy
 
+# ── Post-migration verification ──────────────────────────────────────────────
+# Defense-in-depth check: confirm the DB schema matches the migration files
+# in the image. Catches cases where the image is stale or release_command was
+# skipped. Non-fatal: we want the app to still serve, but log loudly so the
+# operator notices. See src/lib/schemaCheck.server.ts for the library version
+# exposed at GET /api/health/migration.
+echo "[startup] Verifying schema is in sync with migrations directory..."
+if ! ./node_modules/.bin/prisma migrate status >/tmp/migrate-status.log 2>&1; then
+  echo "[startup] WARNING: schema drift detected after migrate deploy:"
+  cat /tmp/migrate-status.log
+  echo "[startup] App will start, but endpoints touching missing tables will fail."
+fi
+
 # ── Start app ─────────────────────────────────────────────────────────────────
 if [ -n "$LITESTREAM_REPLICA_BUCKET" ]; then
   echo "[startup] Starting app with Litestream replication..."

--- a/src/lib/schemaCheck.server.ts
+++ b/src/lib/schemaCheck.server.ts
@@ -1,0 +1,82 @@
+import { readdirSync } from "fs";
+import type { PrismaClient } from "@prisma/client";
+import { createLogger } from "./logger.server";
+
+const log = createLogger("schema-check");
+
+export interface MigrationDrift {
+  hasDrift: boolean;
+  missingFromDb: string[];
+  missingFromFs: string[];
+}
+
+/**
+ * Compares migrations recorded in `_prisma_migrations` against the migration
+ * files on disk. Detects two kinds of drift:
+ *
+ * - `missingFromDb`:  A migration file exists on disk that has not been
+ *                     applied (the DB is behind the schema in the image).
+ * - `missingFromFs`:  The DB has an applied migration whose file is gone
+ *                     (someone removed a migration from the image).
+ *
+ * This is a defense-in-depth check run after `prisma migrate deploy` in
+ * start.sh. The release_command in fly.toml is the primary safety net; this
+ * catches the case where the image is stale or the release command was
+ * skipped for some reason.
+ */
+export async function checkSchemaDrift(
+  prisma: PrismaClient,
+  migrationsDir: string,
+): Promise<MigrationDrift> {
+  const appliedRows = await prisma.$queryRawUnsafe<{ migration_name: string }[]>(
+    "SELECT migration_name FROM _prisma_migrations ORDER BY migration_name",
+  );
+  const applied = new Set(appliedRows.map((r) => r.migration_name));
+
+  let onDisk: string[];
+  try {
+    onDisk = readdirSync(migrationsDir, { withFileTypes: true })
+      .filter((d) => d.isDirectory())
+      .map((d) => d.name)
+      .sort();
+  } catch (err) {
+    log.warn({ err, migrationsDir }, "Could not read migrations directory");
+    return { hasDrift: true, missingFromDb: [], missingFromFs: [] };
+  }
+
+  const appliedSorted = [...applied].sort();
+  const missingFromDb = onDisk.filter((name) => !applied.has(name));
+  const missingFromFs = appliedSorted.filter((name) => !onDisk.includes(name));
+
+  return {
+    hasDrift: missingFromDb.length > 0 || missingFromFs.length > 0,
+    missingFromDb,
+    missingFromFs,
+  };
+}
+
+/**
+ * Logs drift as a structured warning. Returns the result so callers can also
+ * act on it (e.g., set process exit code in a script).
+ */
+export async function runSchemaDriftCheck(
+  prisma: PrismaClient,
+  migrationsDir: string,
+): Promise<MigrationDrift> {
+  const result = await checkSchemaDrift(prisma, migrationsDir);
+  if (result.hasDrift) {
+    log.warn(
+      {
+        missingFromDb: result.missingFromDb,
+        missingFromFs: result.missingFromFs,
+        migrationsDir,
+      },
+      "Schema drift detected — DB and filesystem migrations are out of sync. " +
+        "If missingFromDb is non-empty, the new code references tables/columns " +
+        "the DB doesn't have and will fail at runtime.",
+    );
+  } else {
+    log.info({ migrationsDir }, "Schema is in sync with migrations directory");
+  }
+  return result;
+}

--- a/src/pages/api/health/migration.ts
+++ b/src/pages/api/health/migration.ts
@@ -1,0 +1,35 @@
+import type { APIRoute } from "astro";
+import { resolve } from "path";
+import { prisma } from "../../../lib/db.server";
+import { checkSchemaDrift } from "../../../lib/schemaCheck.server";
+
+const DEFAULT_MIGRATIONS_DIR = resolve(process.cwd(), "prisma", "migrations");
+
+export const GET: APIRoute = async () => {
+  const migrationsDir = process.env.MIGRATIONS_DIR
+    ? resolve(process.env.MIGRATIONS_DIR)
+    : DEFAULT_MIGRATIONS_DIR;
+
+  try {
+    const appliedRows = await prisma.$queryRawUnsafe<{ migration_name: string }[]>(
+      "SELECT migration_name FROM _prisma_migrations ORDER BY migration_name",
+    );
+    const applied = appliedRows.map((r) => r.migration_name);
+
+    const drift = await checkSchemaDrift(prisma, migrationsDir);
+
+    return Response.json({
+      status: drift.hasDrift ? "drift" : "in_sync",
+      applied,
+      missingFromDb: drift.missingFromDb,
+      missingFromFs: drift.missingFromFs,
+      migrationsDir,
+    });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : "unknown error";
+    return Response.json(
+      { status: "error", message },
+      { status: 503 },
+    );
+  }
+};

--- a/src/pages/api/me/games.ts
+++ b/src/pages/api/me/games.ts
@@ -1,8 +1,12 @@
 import type { APIRoute } from "astro";
+import { Prisma } from "@prisma/client";
 import { prisma } from "../../../lib/db.server";
 import { getSession } from "../../../lib/auth.helpers.server";
 import { authenticateRequest } from "../../../lib/authenticate.server";
 import { parsePaginationParams } from "../../../lib/pagination";
+import { createLogger } from "../../../lib/logger.server";
+
+const log = createLogger("me-games");
 
 export const GET: APIRoute = async ({ request }) => {
   const authCtx = await authenticateRequest(request);
@@ -42,6 +46,11 @@ export const GET: APIRoute = async ({ request }) => {
     lastScoreTwo: e.history[0]?.scoreTwo ?? null,
   });
 
+  const followedSelect = {
+    id: true,
+    event: { select: { ...gameSelect, ownerId: true } },
+  } as const;
+
   const [ownedEvents, adminEvents, followedRecords] = await Promise.all([
     prisma.event.findMany({
       where: { ownerId: userId },
@@ -58,13 +67,15 @@ export const GET: APIRoute = async ({ request }) => {
     }),
     prisma.eventFollow.findMany({
       where: { userId },
-      select: {
-        id: true,
-        event: { select: { ...gameSelect, ownerId: true } },
-      },
+      select: followedSelect,
       orderBy: { createdAt: "desc" },
       take: limit + 1,
       ...(followedCursor ? { cursor: { id: followedCursor }, skip: 1 } : {}),
+    }).catch((err) => {
+      // Schema drift: the EventFollow table may be missing if migrations
+      // haven't been applied yet. Don't let it take down owned/admin data.
+      log.warn({ err }, "eventFollow.findMany failed; returning empty list");
+      return [] as Prisma.EventFollowGetPayload<{ select: typeof followedSelect }>[];
     }),
   ]);
 

--- a/src/test/health-migration.test.ts
+++ b/src/test/health-migration.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { prisma } from "~/lib/db.server";
+import { GET } from "~/pages/api/health/migration";
+
+let tmpDir: string;
+const ORIGINAL_DIR = process.env.MIGRATIONS_DIR;
+
+beforeEach(async () => {
+  tmpDir = mkdtempSync(join(tmpdir(), "health-migration-test-"));
+  process.env.MIGRATIONS_DIR = tmpDir;
+  await prisma.$executeRawUnsafe("DELETE FROM _prisma_migrations");
+});
+
+afterEach(() => {
+  if (ORIGINAL_DIR === undefined) delete process.env.MIGRATIONS_DIR;
+  else process.env.MIGRATIONS_DIR = ORIGINAL_DIR;
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function ctx() {
+  return {
+    request: new Request("http://localhost/api/health/migration", { method: "GET" }),
+    params: {},
+    url: new URL("http://localhost/api/health/migration"),
+  } as any;
+}
+
+async function recordMigration(name: string) {
+  await prisma.$executeRawUnsafe(
+    "INSERT INTO _prisma_migrations (id, checksum, finished_at, migration_name, logs, started_at, applied_steps_count) VALUES (?, ?, ?, ?, ?, ?, ?)",
+    `id-${name}`, "x", new Date().toISOString(), name, "", new Date().toISOString(), 1,
+  );
+}
+
+describe("GET /api/health/migration", () => {
+  it("returns in_sync when DB and filesystem match", async () => {
+    mkdirSync(join(tmpDir, "20260501000000_init"));
+    writeFileSync(join(tmpDir, "20260501000000_init", "migration.sql"), "-- init");
+    mkdirSync(join(tmpDir, "20260512133435_add_mvp_elo"));
+    writeFileSync(join(tmpDir, "20260512133435_add_mvp_elo", "migration.sql"), "-- mvp");
+    await recordMigration("20260501000000_init");
+    await recordMigration("20260512133435_add_mvp_elo");
+
+    const res = await GET(ctx());
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.status).toBe("in_sync");
+    expect(body.applied).toEqual(["20260501000000_init", "20260512133435_add_mvp_elo"]);
+    expect(body.missingFromDb).toEqual([]);
+    expect(body.missingFromFs).toEqual([]);
+  });
+
+  it("returns drift when a migration file is on disk but not applied", async () => {
+    mkdirSync(join(tmpDir, "20260501000000_init"));
+    writeFileSync(join(tmpDir, "20260501000000_init", "migration.sql"), "-- init");
+    mkdirSync(join(tmpDir, "20260603155629_add_event_follow"));
+    writeFileSync(join(tmpDir, "20260603155629_add_event_follow", "migration.sql"), "-- follow");
+    await recordMigration("20260501000000_init");
+
+    const res = await GET(ctx());
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.status).toBe("drift");
+    expect(body.missingFromDb).toEqual(["20260603155629_add_event_follow"]);
+  });
+});

--- a/src/test/me-games.test.ts
+++ b/src/test/me-games.test.ts
@@ -268,4 +268,24 @@ describe("GET /api/me/games", () => {
     expect(body.archivedAdmin).toHaveLength(1);
     expect(body.archivedAdmin[0].title).toBe("Archived Admin");
   });
+
+  it("still returns admin events when the EventFollow query fails", async () => {
+    const user = await seedUser();
+    mockAuthenticateRequest.mockResolvedValue(null);
+    mockGetSession.mockResolvedValue({ user: { id: user.id, name: user.name } } as any);
+    const event = await seedEvent(undefined, { title: "Admin During Drift" });
+    await prisma.eventAdmin.create({ data: { eventId: event.id, userId: user.id } });
+
+    const spy = vi.spyOn(prisma.eventFollow, "findMany").mockRejectedValue(
+      new Error("The table `main.EventFollow` does not exist in the current database."),
+    );
+
+    const res = await GET(ctx());
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.admin).toHaveLength(1);
+    expect(body.admin[0].title).toBe("Admin During Drift");
+    expect(body.followed).toEqual([]);
+    spy.mockRestore();
+  });
 });

--- a/src/test/schemaCheck.test.ts
+++ b/src/test/schemaCheck.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { prisma } from "~/lib/db.server";
+import { checkSchemaDrift } from "~/lib/schemaCheck.server";
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = mkdtempSync(join(tmpdir(), "schema-check-test-"));
+  // Ensure the DB is in a known state (no applied migrations).
+  await prisma.$executeRawUnsafe("DELETE FROM _prisma_migrations");
+});
+
+describe("checkSchemaDrift", () => {
+  it("returns no drift when applied migrations match the filesystem", async () => {
+    mkdirSync(join(tmpDir, "20260501000000_init"));
+    writeFileSync(join(tmpDir, "20260501000000_init", "migration.sql"), "-- init");
+    mkdirSync(join(tmpDir, "20260512133435_add_mvp_elo"));
+    writeFileSync(join(tmpDir, "20260512133435_add_mvp_elo", "migration.sql"), "-- mvp");
+
+    await prisma.$executeRawUnsafe(
+      "INSERT INTO _prisma_migrations (id, checksum, finished_at, migration_name, logs, started_at, applied_steps_count) VALUES (?, ?, ?, ?, ?, ?, ?)",
+      "id1", "x", new Date().toISOString(), "20260501000000_init", "", new Date().toISOString(), 1,
+    );
+    await prisma.$executeRawUnsafe(
+      "INSERT INTO _prisma_migrations (id, checksum, finished_at, migration_name, logs, started_at, applied_steps_count) VALUES (?, ?, ?, ?, ?, ?, ?)",
+      "id2", "x", new Date().toISOString(), "20260512133435_add_mvp_elo", "", new Date().toISOString(), 1,
+    );
+
+    const result = await checkSchemaDrift(prisma, tmpDir);
+    expect(result.hasDrift).toBe(false);
+    expect(result.missingFromDb).toEqual([]);
+    expect(result.missingFromFs).toEqual([]);
+  });
+
+  it("detects migrations on disk that are not applied to the database", async () => {
+    mkdirSync(join(tmpDir, "20260501000000_init"));
+    writeFileSync(join(tmpDir, "20260501000000_init", "migration.sql"), "-- init");
+    mkdirSync(join(tmpDir, "20260603155629_add_event_follow"));
+    writeFileSync(join(tmpDir, "20260603155629_add_event_follow", "migration.sql"), "-- follow");
+
+    await prisma.$executeRawUnsafe(
+      "INSERT INTO _prisma_migrations (id, checksum, finished_at, migration_name, logs, started_at, applied_steps_count) VALUES (?, ?, ?, ?, ?, ?, ?)",
+      "id1", "x", new Date().toISOString(), "20260501000000_init", "", new Date().toISOString(), 1,
+    );
+
+    const result = await checkSchemaDrift(prisma, tmpDir);
+    expect(result.hasDrift).toBe(true);
+    expect(result.missingFromDb).toEqual(["20260603155629_add_event_follow"]);
+    expect(result.missingFromFs).toEqual([]);
+  });
+
+  it("detects migrations applied to the DB that are missing from disk (rolled back)", async () => {
+    mkdirSync(join(tmpDir, "20260501000000_init"));
+    writeFileSync(join(tmpDir, "20260501000000_init", "migration.sql"), "-- init");
+
+    await prisma.$executeRawUnsafe(
+      "INSERT INTO _prisma_migrations (id, checksum, finished_at, migration_name, logs, started_at, applied_steps_count) VALUES (?, ?, ?, ?, ?, ?, ?)",
+      "id1", "x", new Date().toISOString(), "20260501000000_init", "", new Date().toISOString(), 1,
+    );
+    await prisma.$executeRawUnsafe(
+      "INSERT INTO _prisma_migrations (id, checksum, finished_at, migration_name, logs, started_at, applied_steps_count) VALUES (?, ?, ?, ?, ?, ?, ?)",
+      "id2", "x", new Date().toISOString(), "20260603155629_add_event_follow", "", new Date().toISOString(), 1,
+    );
+
+    const result = await checkSchemaDrift(prisma, tmpDir);
+    expect(result.hasDrift).toBe(true);
+    expect(result.missingFromDb).toEqual([]);
+    expect(result.missingFromFs).toEqual(["20260603155629_add_event_follow"]);
+  });
+
+  it("returns no drift when both DB and disk have no migrations (fresh DB)", async () => {
+    const result = await checkSchemaDrift(prisma, tmpDir);
+    expect(result.hasDrift).toBe(false);
+    expect(result.missingFromDb).toEqual([]);
+    expect(result.missingFromFs).toEqual([]);
+  });
+});


### PR DESCRIPTION
Three layered safeguards against the recurring 'prod DB behind on migrations' class of bug (e.g. EventFollow table missing caused /api/me/games to throw for goncalossilva, so his admin event didn't appear on the dashboard).

### Changes
- `fly.toml`: add `[deploy] release_command = "node_modules/.bin/prisma migrate deploy"` — runs migrations once per deploy, before the new app version takes traffic. Fails the deploy if it errors.
- `scripts/start.sh`: run `prisma migrate status` after `migrate deploy` and log a loud warning if drift is detected. Catches stale images or skipped release commands.
- `GET /api/health/migration`: new endpoint + `src/lib/schemaCheck.server.ts` library function (unit-tested). Reports applied migrations and any drift. Use for monitoring/alerting.
- `src/pages/api/me/games.ts`: wrap the `eventFollow.findMany` call in `.catch()` so a single relation throwing (e.g. missing table) no longer breaks the whole endpoint. Tests for this exact failure mode.
- `scripts/pull-prod-db.sh`, `npm run db:pull-prod`, `npm run dev:prod-db`: local-dev tooling for debugging against a snapshot of the prod DB.

### Tests
- 1707/1707 pass (added 6 new tests for the schema check + endpoint)
- typecheck clean, lint 0 errors

### Verification plan
After deploy, `curl https://convocados.cabeda.dev/api/health/migration` should return:
```json
{"status":"in_sync","applied":[...56+ migrations...]}```
That confirms the previously missing `add_event_follow` migration has been applied.