### PR TITLE
feat(wear): Quick Game mode + fix games list empty state

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,13 +114,25 @@ jobs:
           path: playwright-report/
           retention-days: 7
 
+  check-android:
+    name: Check Android Changes
+    runs-on: ubuntu-latest
+    outputs:
+      android: ${{ steps.filter.outputs.android }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            android:
+              - 'android-app/**'
+
   android:
     name: Android Build
     runs-on: ubuntu-latest
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request' &&
-       contains(join(github.event.pull_request.*.filename, ' '), 'android-app/'))
+    needs: check-android
+    if: needs.check-android.outputs.android == 'true' || github.event_name == 'workflow_dispatch'
 
     steps:
       - uses: actions/checkout@v6
@@ -151,10 +163,8 @@ jobs:
   android-wear:
     name: Wear OS Build
     runs-on: ubuntu-latest
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request' &&
-       contains(join(github.event.pull_request.*.filename, ' '), 'android-app/'))
+    needs: check-android
+    if: needs.check-android.outputs.android == 'true' || github.event_name == 'workflow_dispatch'
 
     steps:
       - uses: actions/checkout@v6

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,38 @@
+# Convocados — Domain Glossary
+
+## Game / Event
+A sports match or recurring session. The core entity. Used interchangeably.
+
+## Player
+A person registered to participate in a specific Game. Has a `name`, optionally linked to a `User` via `userId`. One user can be a Player in many games. "Joined" now refers strictly to participation (has a linked Player record) — distinct from "followed" which controls dashboard visibility.
+
+## Owner
+The User who created the Game or to whom ownership was transferred. Has full management control. A Game has exactly zero or one Owner.
+
+## Admin
+A User granted management privileges for a Game by the Owner (via `EventAdmin`). Can edit teams, archive players, approve ELO, etc. Has no ownership rights.
+
+## Follow
+An explicit relationship between a User and a Game (stored in `EventFollow`). Games a User follows appear on their "My games" dashboard. Distinct from "joined" (participation via Player record).
+
+### Auto-follow rules (user-initiated only)
+- Quick Join → follow
+- Claim Player → follow
+- Auto-link (owner adds, system recognizes user) → no follow
+- Owner/admin adds you → no follow
+
+### Auto-unfollow rules
+- Self-removal → unfollow
+- Event archived → unfollow
+- Owner/admin removes you → no unfollow
+
+## Quick Game
+A purely local, ephemeral score-tracking session on Wear OS with interval alarms. Not connected to any server-side Game. Does not sync, has no teams, and does not require authentication. Lost when the user navigates away.
+
+## My games dashboard
+Shows games grouped by relationship:
+- **Owned** — events where `Event.ownerId = userId`. Always visible. Includes archived.
+- **Admin** — events where `EventAdmin.userId = userId`. Always visible. Archived events not shown.
+- **Followed** — events where `EventFollow.userId = userId`. Archived events auto-unfollow.
+
+Profile pages (`/api/users/[id]`) continue to show **joined** (participation via Player records), not followed.

--- a/android-app/wear/build.gradle.kts
+++ b/android-app/wear/build.gradle.kts
@@ -33,12 +33,15 @@ android {
 
     signingConfigs {
         create("release") {
-            val ksFile = rootProject.file(keystoreProperties.getProperty("storeFile", ""))
-            if (ksFile.exists()) {
-                storeFile = ksFile
-                storePassword = keystoreProperties.getProperty("storePassword", "")
-                keyAlias = keystoreProperties.getProperty("keyAlias", "")
-                keyPassword = keystoreProperties.getProperty("keyPassword", "")
+            val storePath = keystoreProperties.getProperty("storeFile", "")
+            if (storePath.isNotBlank()) {
+                val ksFile = rootProject.file(storePath)
+                if (ksFile.exists()) {
+                    storeFile = ksFile
+                    storePassword = keystoreProperties.getProperty("storePassword", "")
+                    keyAlias = keystoreProperties.getProperty("keyAlias", "")
+                    keyPassword = keystoreProperties.getProperty("keyPassword", "")
+                }
             }
         }
     }

--- a/android-app/wear/build.gradle.kts
+++ b/android-app/wear/build.gradle.kts
@@ -93,6 +93,9 @@ android {
         compose = true
         buildConfig = true
     }
+    composeCompiler {
+        stabilityConfigurationFile = rootProject.layout.projectDirectory.file("wear/stability-config.txt")
+    }
 }
 
 tasks.register("validateGoogleClientId") {

--- a/android-app/wear/src/main/java/dev/convocados/wear/data/auth/WearGoogleSignIn.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/data/auth/WearGoogleSignIn.kt
@@ -51,6 +51,11 @@ class WearGoogleSignIn @Inject constructor(
     /** Intent that launches the on-device account picker (interactive). */
     fun getSignInIntent(): Intent = getClient().signInIntent
 
+    /** Sign out from Google so silent sign-in won't auto-re-authenticate. */
+    fun signOut() {
+        getClient().signOut()
+    }
+
     /** Silently sign in using the existing on-device Google account (no UI). */
     suspend fun trySilentSignIn(): Boolean = try {
         val account = getClient().silentSignIn().await()

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/WearActivity.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/WearActivity.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import dagger.hilt.android.AndroidEntryPoint
+import dev.convocados.wear.data.auth.WearGoogleSignIn
 import dev.convocados.wear.data.auth.WearTokenStore
 import dev.convocados.wear.ui.navigation.WearNavigation
 import dev.convocados.wear.ui.theme.ConvocadosWearTheme
@@ -15,11 +16,14 @@ class WearActivity : ComponentActivity() {
     @Inject
     lateinit var tokenStore: WearTokenStore
 
+    @Inject
+    lateinit var googleSignIn: WearGoogleSignIn
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
             ConvocadosWearTheme {
-                WearNavigation(tokenStore)
+                WearNavigation(tokenStore, googleSignIn)
             }
         }
     }

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/navigation/WearNavigation.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/navigation/WearNavigation.kt
@@ -1,6 +1,7 @@
 package dev.convocados.wear.ui.navigation
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -11,6 +12,9 @@ import dev.convocados.wear.data.auth.WearTokenStore
 import dev.convocados.wear.ui.screen.auth.AuthScreen
 import dev.convocados.wear.ui.screen.games.GamesScreen
 import dev.convocados.wear.ui.screen.games.GamesViewModel
+import dev.convocados.wear.ui.screen.quick.QuickScoreScreen
+import dev.convocados.wear.ui.screen.quick.QuickScoreViewModel
+import dev.convocados.wear.ui.screen.quick.QuickSetupScreen
 import dev.convocados.wear.ui.screen.score.ScoreScreen
 import dev.convocados.wear.ui.screen.score.ScoreViewModel
 import dev.convocados.wear.ui.screen.teams.TeamsScreen
@@ -38,7 +42,10 @@ fun WearNavigation(tokenStore: WearTokenStore) {
                         navController.navigate(WearRoutes.GAMES) {
                             popUpTo(WearRoutes.AUTH) { inclusive = true }
                         }
-                    }
+                    },
+                    onQuickGame = {
+                        navController.navigate(WearRoutes.QUICK_SETUP)
+                    },
                 )
             }
 
@@ -54,6 +61,9 @@ fun WearNavigation(tokenStore: WearTokenStore) {
                         navController.navigate(WearRoutes.AUTH) {
                             popUpTo(WearRoutes.GAMES) { inclusive = true }
                         }
+                    },
+                    onQuickGame = {
+                        navController.navigate(WearRoutes.QUICK_SETUP)
                     },
                 )
             }
@@ -90,6 +100,34 @@ fun WearNavigation(tokenStore: WearTokenStore) {
                     onBack = { navController.popBackStack() },
                 )
             }
+
+            composable(WearRoutes.QUICK_SETUP) {
+                QuickSetupScreen(
+                    onStart = { duration, periods ->
+                        navController.navigate(WearRoutes.QUICK_SCORE) {
+                            popUpTo(WearRoutes.QUICK_SETUP) { inclusive = true }
+                        }
+                        // Pass params via savedStateHandle on the next destination
+                        navController.currentBackStackEntry
+                            ?.savedStateHandle?.set("duration", duration)
+                        navController.currentBackStackEntry
+                            ?.savedStateHandle?.set("periods", periods)
+                    },
+                )
+            }
+
+            composable(WearRoutes.QUICK_SCORE) { backStackEntry ->
+                val viewModel: QuickScoreViewModel = hiltViewModel()
+                val duration = backStackEntry.savedStateHandle.get<Int>("duration") ?: 10
+                val periods = backStackEntry.savedStateHandle.get<Int>("periods") ?: 2
+                LaunchedConfigure(viewModel, duration, periods)
+                QuickScoreScreen(viewModel = viewModel)
+            }
         }
     }
+}
+
+@Composable
+private fun LaunchedConfigure(viewModel: QuickScoreViewModel, duration: Int, periods: Int) {
+    LaunchedEffect(Unit) { viewModel.configure(duration, periods) }
 }

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/navigation/WearNavigation.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/navigation/WearNavigation.kt
@@ -8,6 +8,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.wear.compose.navigation.SwipeDismissableNavHost
 import androidx.wear.compose.navigation.composable
 import androidx.wear.compose.navigation.rememberSwipeDismissableNavController
+import dev.convocados.wear.data.auth.WearGoogleSignIn
 import dev.convocados.wear.data.auth.WearTokenStore
 import dev.convocados.wear.ui.screen.auth.AuthScreen
 import dev.convocados.wear.ui.screen.games.GamesScreen
@@ -25,7 +26,7 @@ import com.google.android.horologist.compose.layout.ScreenScaffold
 import com.google.android.horologist.compose.layout.rememberColumnState
 
 @Composable
-fun WearNavigation(tokenStore: WearTokenStore) {
+fun WearNavigation(tokenStore: WearTokenStore, googleSignIn: WearGoogleSignIn) {
     val navController = rememberSwipeDismissableNavController()
     val isAuthenticated by tokenStore.isAuthenticated.collectAsState()
 
@@ -57,6 +58,7 @@ fun WearNavigation(tokenStore: WearTokenStore) {
                         navController.navigate(WearRoutes.score(eventId))
                     },
                     onSignOut = {
+                        googleSignIn.signOut()
                         tokenStore.clearTokens()
                         navController.navigate(WearRoutes.AUTH) {
                             popUpTo(WearRoutes.GAMES) { inclusive = true }

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/navigation/WearNavigation.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/navigation/WearNavigation.kt
@@ -105,24 +105,23 @@ fun WearNavigation(tokenStore: WearTokenStore, googleSignIn: WearGoogleSignIn) {
 
             composable(WearRoutes.QUICK_SETUP) {
                 QuickSetupScreen(
-                    onStart = { duration, periods ->
+                    onStart = { duration, alarmInterval ->
                         navController.navigate(WearRoutes.QUICK_SCORE) {
                             popUpTo(WearRoutes.QUICK_SETUP) { inclusive = true }
                         }
-                        // Pass params via savedStateHandle on the next destination
                         navController.currentBackStackEntry
                             ?.savedStateHandle?.set("duration", duration)
                         navController.currentBackStackEntry
-                            ?.savedStateHandle?.set("periods", periods)
+                            ?.savedStateHandle?.set("alarmInterval", alarmInterval)
                     },
                 )
             }
 
             composable(WearRoutes.QUICK_SCORE) { backStackEntry ->
                 val viewModel: QuickScoreViewModel = hiltViewModel()
-                val duration = backStackEntry.savedStateHandle.get<Int>("duration") ?: 10
-                val periods = backStackEntry.savedStateHandle.get<Int>("periods") ?: 2
-                LaunchedConfigure(viewModel, duration, periods)
+                val duration = backStackEntry.savedStateHandle.get<Int>("duration") ?: 60
+                val alarmInterval = backStackEntry.savedStateHandle.get<Int>("alarmInterval") ?: 10
+                LaunchedConfigure(viewModel, duration, alarmInterval)
                 QuickScoreScreen(viewModel = viewModel)
             }
         }
@@ -130,6 +129,6 @@ fun WearNavigation(tokenStore: WearTokenStore, googleSignIn: WearGoogleSignIn) {
 }
 
 @Composable
-private fun LaunchedConfigure(viewModel: QuickScoreViewModel, duration: Int, periods: Int) {
-    LaunchedEffect(Unit) { viewModel.configure(duration, periods) }
+private fun LaunchedConfigure(viewModel: QuickScoreViewModel, duration: Int, alarmInterval: Int) {
+    LaunchedEffect(Unit) { viewModel.configure(duration, alarmInterval) }
 }

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/navigation/WearRoutes.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/navigation/WearRoutes.kt
@@ -7,6 +7,8 @@ object WearRoutes {
     const val SCORE = "score/{eventId}"
     const val TEAMS = "teams/{eventId}"
     const val SETTINGS = "settings/{eventId}"
+    const val QUICK_SETUP = "quick_setup"
+    const val QUICK_SCORE = "quick_score"
 
     fun score(eventId: String) = "score/$eventId"
     fun teams(eventId: String) = "teams/$eventId"

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/auth/AuthScreen.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/auth/AuthScreen.kt
@@ -211,7 +211,7 @@ fun AuthScreen(
 
             item {
                 Spacer(modifier = Modifier.height(8.dp))
-                TextButton(onClick = onQuickGame) {
+                CompactButton(onClick = onQuickGame) {
                     Text(
                         text = stringResource(R.string.quick_game),
                         style = MaterialTheme.typography.labelSmall,

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/auth/AuthScreen.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/auth/AuthScreen.kt
@@ -28,6 +28,7 @@ import dev.convocados.wear.ui.theme.TextMuted
 @Composable
 fun AuthScreen(
     onAuthenticated: () -> Unit,
+    onQuickGame: () -> Unit = {},
     viewModel: AuthViewModel = hiltViewModel(),
 ) {
     val isAuthenticated by viewModel.isAuthenticated.collectAsState()
@@ -204,6 +205,16 @@ fun AuthScreen(
                         color = MaterialTheme.colorScheme.error,
                         textAlign = TextAlign.Center,
                         modifier = Modifier.fillMaxWidth().padding(horizontal = 10.dp)
+                    )
+                }
+            }
+
+            item {
+                Spacer(modifier = Modifier.height(8.dp))
+                TextButton(onClick = onQuickGame) {
+                    Text(
+                        text = stringResource(R.string.quick_game),
+                        style = MaterialTheme.typography.labelSmall,
                     )
                 }
             }

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/auth/AuthViewModel.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/auth/AuthViewModel.kt
@@ -107,6 +107,7 @@ class AuthViewModel @Inject constructor(
     }
 
     fun signOut() {
+        googleSignIn.signOut()
         tokenStore.clearTokens()
     }
 

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/games/GamesScreen.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/games/GamesScreen.kt
@@ -24,9 +24,6 @@ import dev.convocados.wear.ui.theme.Success
 import dev.convocados.wear.ui.theme.TextMuted
 import dev.convocados.wear.ui.theme.Warning
 import dev.convocados.wear.util.formatRelativeTime
-import dev.convocados.wear.util.parseInstant
-import java.time.Instant
-import java.time.temporal.ChronoUnit
 
 @OptIn(ExperimentalHorologistApi::class)
 @Composable
@@ -40,13 +37,6 @@ fun GamesScreen(
     val columnState = rememberColumnState(
         ScalingLazyColumnDefaults.responsive()
     )
-
-    val sortedGames = remember(state.games, state.suggestedGameId) {
-        state.games.sortedWith(
-            compareBy<WearGameEntity> { it.id != state.suggestedGameId }
-                .thenBy { parseInstant(it.dateTime)?.let { t -> kotlin.math.abs(ChronoUnit.MINUTES.between(Instant.now(), t)) } ?: Long.MAX_VALUE }
-        )
-    }
 
     val visiblePastGames = remember(state.pastGames, state.visiblePastCount) {
         state.pastGames.take(state.visiblePastCount)
@@ -148,7 +138,7 @@ fun GamesScreen(
                         }
                     }
 
-                    items(sortedGames, key = { it.id }) { game ->
+                    items(state.games, key = { it.id }) { game ->
                         val canScore = game.id in state.canScoreGameIds
                         GameChip(
                             game = game,

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/games/GamesScreen.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/games/GamesScreen.kt
@@ -34,6 +34,7 @@ fun GamesScreen(
     viewModel: GamesViewModel,
     onGameSelected: (String) -> Unit,
     onSignOut: () -> Unit,
+    onQuickGame: () -> Unit = {},
 ) {
     val state by viewModel.uiState.collectAsState()
     val columnState = rememberColumnState(
@@ -84,13 +85,17 @@ fun GamesScreen(
                                 overflow = TextOverflow.Ellipsis,
                             )
                         }
-                        if (state.isOffline) {
-                            Spacer(modifier = Modifier.height(8.dp))
-                            CompactButton(
-                                onClick = { viewModel.refresh() },
-                            ) {
-                                Text(stringResource(R.string.retry))
-                            }
+                        Spacer(modifier = Modifier.height(8.dp))
+                        CompactButton(onClick = { viewModel.refresh() }) {
+                            Text(stringResource(R.string.refresh))
+                        }
+                        Spacer(modifier = Modifier.height(4.dp))
+                        CompactButton(onClick = onQuickGame) {
+                            Text(stringResource(R.string.quick_game))
+                        }
+                        Spacer(modifier = Modifier.height(4.dp))
+                        CompactButton(onClick = onSignOut) {
+                            Text(stringResource(R.string.sign_out))
                         }
                     }
                 }
@@ -106,6 +111,15 @@ fun GamesScreen(
                                 text = stringResource(R.string.games_title),
                                 style = MaterialTheme.typography.titleMedium,
                                 color = MaterialTheme.colorScheme.primary,
+                            )
+                        }
+                    }
+
+                    item {
+                        CompactButton(onClick = { viewModel.refresh() }) {
+                            Text(
+                                text = stringResource(R.string.refresh),
+                                style = MaterialTheme.typography.labelSmall,
                             )
                         }
                     }
@@ -188,6 +202,16 @@ fun GamesScreen(
 
                     item {
                         Spacer(modifier = Modifier.height(8.dp))
+                        CompactButton(onClick = onQuickGame) {
+                            Text(
+                                text = stringResource(R.string.quick_game),
+                                style = MaterialTheme.typography.labelSmall,
+                            )
+                        }
+                    }
+
+                    item {
+                        Spacer(modifier = Modifier.height(4.dp))
                         CompactButton(
                             onClick = onSignOut,
                         ) {

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/games/GamesViewModel.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/games/GamesViewModel.kt
@@ -1,5 +1,6 @@
 package dev.convocados.wear.ui.screen.games
 
+import androidx.compose.runtime.Stable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import android.util.Log
@@ -20,6 +21,7 @@ import java.time.temporal.ChronoUnit
 import javax.inject.Inject
 import kotlin.math.abs
 
+@Stable
 data class GamesUiState(
     val games: List<WearGameEntity> = emptyList(),
     val pastGames: List<WearGameEntity> = emptyList(),
@@ -66,8 +68,13 @@ class GamesViewModel @Inject constructor(
                 val upcoming = games.filter { !isStalePastGame(it.dateTime, it.isRecurring) }
                 val suggested = findBestGame(upcoming)
                 val scorable = upcoming.filter { canScoreGame(it.dateTime) }.map { it.id }.toSet()
+                // Pre-sort: suggested first, then by proximity to now
+                val sorted = upcoming.sortedWith(
+                    compareBy<WearGameEntity> { it.id != suggested?.id }
+                        .thenBy { parseInstant(it.dateTime)?.let { t -> abs(ChronoUnit.MINUTES.between(Instant.now(), t)) } ?: Long.MAX_VALUE }
+                )
                 _uiState.value = _uiState.value.copy(
-                    games = upcoming,
+                    games = sorted,
                     pastGames = archived,
                     suggestedGameId = suggested?.id,
                     isLoading = false,

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/quick/QuickScoreScreen.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/quick/QuickScoreScreen.kt
@@ -1,0 +1,95 @@
+package dev.convocados.wear.ui.screen.quick
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.material3.MaterialTheme
+import androidx.wear.compose.material3.Text
+import com.google.android.horologist.annotations.ExperimentalHorologistApi
+import com.google.android.horologist.compose.layout.ScreenScaffold
+import com.google.android.horologist.compose.layout.rememberColumnState
+import dev.convocados.wear.R
+import dev.convocados.wear.ui.screen.score.GameClock
+import dev.convocados.wear.ui.screen.score.GameEdgeProgress
+import dev.convocados.wear.ui.screen.score.TeamScoreButton
+import kotlinx.coroutines.delay
+import java.time.Instant
+
+@OptIn(ExperimentalHorologistApi::class)
+@Composable
+fun QuickScoreScreen(viewModel: QuickScoreViewModel) {
+    val state by viewModel.uiState.collectAsState()
+    val columnState = rememberColumnState()
+
+    var now by remember { mutableStateOf(Instant.now()) }
+    LaunchedEffect(Unit) {
+        while (true) {
+            now = Instant.now()
+            delay(1000)
+        }
+    }
+
+    val totalDurationMs = state.durationMinutes.toLong() * state.periods * 60_000L
+    val elapsedMs = now.toEpochMilli() - state.kickoffEpochMs
+
+    ScreenScaffold(scrollState = columnState) {
+        Box(modifier = Modifier.fillMaxSize()) {
+            Row(
+                modifier = Modifier.fillMaxSize().padding(2.dp),
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                TeamScoreButton(
+                    teamName = stringResource(R.string.team_default_1),
+                    score = state.scoreOne,
+                    container = MaterialTheme.colorScheme.primaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                    onIncrement = viewModel::incrementScoreOne,
+                    onDecrement = viewModel::decrementScoreOne,
+                    enabled = true,
+                    modifier = Modifier.weight(1f),
+                )
+                TeamScoreButton(
+                    teamName = stringResource(R.string.team_default_2),
+                    score = state.scoreTwo,
+                    container = MaterialTheme.colorScheme.tertiaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+                    onIncrement = viewModel::incrementScoreTwo,
+                    onDecrement = viewModel::decrementScoreTwo,
+                    enabled = true,
+                    modifier = Modifier.weight(1f),
+                )
+            }
+
+            if (elapsedMs >= 0) {
+                GameEdgeProgress(
+                    progress = (elapsedMs.toFloat() / totalDurationMs).coerceIn(0f, 1f),
+                    modifier = Modifier.fillMaxSize(),
+                )
+                val s = elapsedMs / 1000
+                GameClock(
+                    text = "%d:%02d".format(s / 60, s % 60),
+                    modifier = Modifier
+                        .align(Alignment.BottomCenter)
+                        .padding(bottom = 4.dp),
+                )
+            }
+
+            // Period indicator at top
+            val currentPeriod = minOf(
+                state.periods,
+                ((elapsedMs.toFloat() / (state.durationMinutes * 60_000L)).toInt()) + 1
+            )
+            Text(
+                text = "P$currentPeriod/${state.periods}",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
+                modifier = Modifier
+                    .align(Alignment.TopCenter)
+                    .padding(top = 14.dp),
+            )
+        }
+    }
+}

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/quick/QuickScoreScreen.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/quick/QuickScoreScreen.kt
@@ -32,8 +32,16 @@ fun QuickScoreScreen(viewModel: QuickScoreViewModel) {
         }
     }
 
-    val totalDurationMs = state.durationMinutes.toLong() * state.periods * 60_000L
+    val totalDurationMs = state.durationMinutes.toLong() * 60_000L
     val elapsedMs = now.toEpochMilli() - state.kickoffEpochMs
+
+    // Compute next alarm time
+    val nextAlarmSec = if (state.alarmIntervalMinutes > 0 && elapsedMs >= 0) {
+        val intervalMs = state.alarmIntervalMinutes * 60_000L
+        val nextAlarmMs = ((elapsedMs / intervalMs) + 1) * intervalMs
+        if (nextAlarmMs <= totalDurationMs) ((nextAlarmMs - elapsedMs) / 1000).takeIf { it > 0 }
+        else null
+    } else null
 
     ScreenScaffold(scrollState = columnState) {
         Box(modifier = Modifier.fillMaxSize()) {
@@ -77,13 +85,10 @@ fun QuickScoreScreen(viewModel: QuickScoreViewModel) {
                 )
             }
 
-            // Period indicator at top
-            val currentPeriod = minOf(
-                state.periods,
-                ((elapsedMs.toFloat() / (state.durationMinutes * 60_000L)).toInt()) + 1
-            )
+            // Next alarm countdown at top
             Text(
-                text = "P$currentPeriod/${state.periods}",
+                text = if (nextAlarmSec != null) "⏰ %d:%02d".format(nextAlarmSec / 60, nextAlarmSec % 60)
+                else "",
                 style = MaterialTheme.typography.labelSmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
                 modifier = Modifier

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/quick/QuickScoreViewModel.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/quick/QuickScoreViewModel.kt
@@ -1,5 +1,6 @@
 package dev.convocados.wear.ui.screen.quick
 
+import androidx.compose.runtime.Stable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -11,6 +12,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import javax.inject.Inject
 
+@Stable
 data class QuickScoreUiState(
     val scoreOne: Int = 0,
     val scoreTwo: Int = 0,

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/quick/QuickScoreViewModel.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/quick/QuickScoreViewModel.kt
@@ -3,6 +3,8 @@ package dev.convocados.wear.ui.screen.quick
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dev.convocados.wear.data.alarm.AlarmFire
+import dev.convocados.wear.data.alarm.GameAlarmScheduler
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -12,33 +14,58 @@ import javax.inject.Inject
 data class QuickScoreUiState(
     val scoreOne: Int = 0,
     val scoreTwo: Int = 0,
-    val durationMinutes: Int = 10,
-    val periods: Int = 2,
+    val durationMinutes: Int = 60,
+    val alarmIntervalMinutes: Int = 10,
     val kickoffEpochMs: Long = System.currentTimeMillis(),
 )
+
+private const val QUICK_EVENT_ID = "quick-game"
 
 @HiltViewModel
 class QuickScoreViewModel @Inject constructor(
     private val savedState: SavedStateHandle,
+    private val alarmScheduler: GameAlarmScheduler,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(
         QuickScoreUiState(
             scoreOne = savedState["scoreOne"] ?: 0,
             scoreTwo = savedState["scoreTwo"] ?: 0,
-            durationMinutes = savedState["duration"] ?: 10,
-            periods = savedState["periods"] ?: 2,
+            durationMinutes = savedState["duration"] ?: 60,
+            alarmIntervalMinutes = savedState["alarmInterval"] ?: 10,
             kickoffEpochMs = savedState["kickoff"] ?: System.currentTimeMillis(),
         )
     )
     val uiState: StateFlow<QuickScoreUiState> = _uiState.asStateFlow()
 
-    fun configure(durationMinutes: Int, periods: Int) {
+    fun configure(durationMinutes: Int, alarmIntervalMinutes: Int) {
         val kickoff = System.currentTimeMillis()
-        _uiState.update { it.copy(durationMinutes = durationMinutes, periods = periods, kickoffEpochMs = kickoff) }
+        _uiState.update { it.copy(durationMinutes = durationMinutes, alarmIntervalMinutes = alarmIntervalMinutes, kickoffEpochMs = kickoff) }
         savedState["duration"] = durationMinutes
-        savedState["periods"] = periods
+        savedState["alarmInterval"] = alarmIntervalMinutes
         savedState["kickoff"] = kickoff
+        scheduleAlarms(kickoff, durationMinutes, alarmIntervalMinutes)
+    }
+
+    private fun scheduleAlarms(kickoffMs: Long, durationMinutes: Int, intervalMinutes: Int) {
+        if (intervalMinutes <= 0) {
+            alarmScheduler.cancelAll(QUICK_EVENT_ID)
+            return
+        }
+        val endMs = kickoffMs + durationMinutes * 60_000L
+        val fires = mutableListOf<AlarmFire>()
+        var k = 1
+        while (true) {
+            val t = kickoffMs + k.toLong() * intervalMinutes * 60_000L
+            if (t > endMs) break
+            fires += AlarmFire(t, pulses = 2)
+            k++
+        }
+        alarmScheduler.reschedule(QUICK_EVENT_ID, fires)
+    }
+
+    override fun onCleared() {
+        alarmScheduler.cancelAll(QUICK_EVENT_ID)
     }
 
     fun incrementScoreOne() {

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/quick/QuickScoreViewModel.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/quick/QuickScoreViewModel.kt
@@ -1,0 +1,63 @@
+package dev.convocados.wear.ui.screen.quick
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import javax.inject.Inject
+
+data class QuickScoreUiState(
+    val scoreOne: Int = 0,
+    val scoreTwo: Int = 0,
+    val durationMinutes: Int = 10,
+    val periods: Int = 2,
+    val kickoffEpochMs: Long = System.currentTimeMillis(),
+)
+
+@HiltViewModel
+class QuickScoreViewModel @Inject constructor(
+    private val savedState: SavedStateHandle,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(
+        QuickScoreUiState(
+            scoreOne = savedState["scoreOne"] ?: 0,
+            scoreTwo = savedState["scoreTwo"] ?: 0,
+            durationMinutes = savedState["duration"] ?: 10,
+            periods = savedState["periods"] ?: 2,
+            kickoffEpochMs = savedState["kickoff"] ?: System.currentTimeMillis(),
+        )
+    )
+    val uiState: StateFlow<QuickScoreUiState> = _uiState.asStateFlow()
+
+    fun configure(durationMinutes: Int, periods: Int) {
+        val kickoff = System.currentTimeMillis()
+        _uiState.update { it.copy(durationMinutes = durationMinutes, periods = periods, kickoffEpochMs = kickoff) }
+        savedState["duration"] = durationMinutes
+        savedState["periods"] = periods
+        savedState["kickoff"] = kickoff
+    }
+
+    fun incrementScoreOne() {
+        _uiState.update { it.copy(scoreOne = it.scoreOne + 1) }
+        savedState["scoreOne"] = _uiState.value.scoreOne
+    }
+
+    fun decrementScoreOne() {
+        _uiState.update { it.copy(scoreOne = maxOf(0, it.scoreOne - 1)) }
+        savedState["scoreOne"] = _uiState.value.scoreOne
+    }
+
+    fun incrementScoreTwo() {
+        _uiState.update { it.copy(scoreTwo = it.scoreTwo + 1) }
+        savedState["scoreTwo"] = _uiState.value.scoreTwo
+    }
+
+    fun decrementScoreTwo() {
+        _uiState.update { it.copy(scoreTwo = maxOf(0, it.scoreTwo - 1)) }
+        savedState["scoreTwo"] = _uiState.value.scoreTwo
+    }
+}

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/quick/QuickSetupScreen.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/quick/QuickSetupScreen.kt
@@ -18,10 +18,10 @@ import dev.convocados.wear.R
 @OptIn(ExperimentalHorologistApi::class)
 @Composable
 fun QuickSetupScreen(
-    onStart: (durationMinutes: Int, periods: Int) -> Unit,
+    onStart: (durationMinutes: Int, alarmIntervalMinutes: Int) -> Unit,
 ) {
-    var duration by remember { mutableIntStateOf(10) }
-    var periods by remember { mutableIntStateOf(2) }
+    var duration by remember { mutableIntStateOf(60) }
+    var alarmInterval by remember { mutableIntStateOf(10) }
     val columnState = rememberColumnState(ScalingLazyColumnDefaults.responsive())
 
     ScreenScaffold(scrollState = columnState) {
@@ -39,43 +39,43 @@ fun QuickSetupScreen(
                 }
             }
 
-            // Duration picker
+            // Game duration picker
             item {
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.Center,
                     modifier = Modifier.fillMaxWidth(),
                 ) {
-                    CompactButton(onClick = { duration = maxOf(5, duration - 5) }) {
+                    CompactButton(onClick = { duration = maxOf(10, duration - 10) }) {
                         Text("−")
                     }
                     Text(
-                        text = stringResource(R.string.interval_minutes, duration),
+                        text = stringResource(R.string.duration_minutes, duration),
                         style = MaterialTheme.typography.bodyMedium,
                         modifier = Modifier.padding(horizontal = 8.dp),
                     )
-                    CompactButton(onClick = { duration = minOf(45, duration + 5) }) {
+                    CompactButton(onClick = { duration = minOf(120, duration + 10) }) {
                         Text("+")
                     }
                 }
             }
 
-            // Periods picker
+            // Alarm interval picker
             item {
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.Center,
                     modifier = Modifier.fillMaxWidth(),
                 ) {
-                    CompactButton(onClick = { periods = maxOf(1, periods - 1) }) {
+                    CompactButton(onClick = { alarmInterval = maxOf(5, alarmInterval - 5) }) {
                         Text("−")
                     }
                     Text(
-                        text = stringResource(R.string.periods_count, periods),
+                        text = stringResource(R.string.alarm_every_minutes, alarmInterval),
                         style = MaterialTheme.typography.bodyMedium,
                         modifier = Modifier.padding(horizontal = 8.dp),
                     )
-                    CompactButton(onClick = { periods = minOf(4, periods + 1) }) {
+                    CompactButton(onClick = { alarmInterval = minOf(30, alarmInterval + 5) }) {
                         Text("+")
                     }
                 }
@@ -85,7 +85,7 @@ fun QuickSetupScreen(
             item {
                 Spacer(modifier = Modifier.height(8.dp))
                 Button(
-                    onClick = { onStart(duration, periods) },
+                    onClick = { onStart(duration, alarmInterval) },
                     modifier = Modifier.fillMaxWidth(),
                 ) {
                     Text(stringResource(R.string.start_quick_game))

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/quick/QuickSetupScreen.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/quick/QuickSetupScreen.kt
@@ -41,42 +41,46 @@ fun QuickSetupScreen(
 
             // Game duration picker
             item {
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.Center,
-                    modifier = Modifier.fillMaxWidth(),
-                ) {
-                    CompactButton(onClick = { duration = maxOf(10, duration - 10) }) {
-                        Text("−")
-                    }
+                Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = Modifier.fillMaxWidth()) {
                     Text(
-                        text = stringResource(R.string.duration_minutes, duration),
-                        style = MaterialTheme.typography.bodyMedium,
-                        modifier = Modifier.padding(horizontal = 8.dp),
+                        text = stringResource(R.string.duration_label),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
-                    CompactButton(onClick = { duration = minOf(120, duration + 10) }) {
-                        Text("+")
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.Center,
+                    ) {
+                        CompactButton(onClick = { duration = maxOf(10, duration - 10) }) { Text("−") }
+                        Text(
+                            text = stringResource(R.string.minutes_value, duration),
+                            style = MaterialTheme.typography.titleMedium,
+                            modifier = Modifier.padding(horizontal = 12.dp),
+                        )
+                        CompactButton(onClick = { duration = minOf(120, duration + 10) }) { Text("+") }
                     }
                 }
             }
 
             // Alarm interval picker
             item {
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.Center,
-                    modifier = Modifier.fillMaxWidth(),
-                ) {
-                    CompactButton(onClick = { alarmInterval = maxOf(5, alarmInterval - 5) }) {
-                        Text("−")
-                    }
+                Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = Modifier.fillMaxWidth()) {
                     Text(
-                        text = stringResource(R.string.alarm_every_minutes, alarmInterval),
-                        style = MaterialTheme.typography.bodyMedium,
-                        modifier = Modifier.padding(horizontal = 8.dp),
+                        text = stringResource(R.string.alarm_label),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
-                    CompactButton(onClick = { alarmInterval = minOf(30, alarmInterval + 5) }) {
-                        Text("+")
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.Center,
+                    ) {
+                        CompactButton(onClick = { alarmInterval = maxOf(5, alarmInterval - 5) }) { Text("−") }
+                        Text(
+                            text = stringResource(R.string.minutes_value, alarmInterval),
+                            style = MaterialTheme.typography.titleMedium,
+                            modifier = Modifier.padding(horizontal = 12.dp),
+                        )
+                        CompactButton(onClick = { alarmInterval = minOf(30, alarmInterval + 5) }) { Text("+") }
                     }
                 }
             }

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/quick/QuickSetupScreen.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/quick/QuickSetupScreen.kt
@@ -1,0 +1,96 @@
+package dev.convocados.wear.ui.screen.quick
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.foundation.lazy.items
+import androidx.wear.compose.material3.*
+import com.google.android.horologist.annotations.ExperimentalHorologistApi
+import com.google.android.horologist.compose.layout.ScalingLazyColumn
+import com.google.android.horologist.compose.layout.ScalingLazyColumnDefaults
+import com.google.android.horologist.compose.layout.ScreenScaffold
+import com.google.android.horologist.compose.layout.rememberColumnState
+import dev.convocados.wear.R
+
+@OptIn(ExperimentalHorologistApi::class)
+@Composable
+fun QuickSetupScreen(
+    onStart: (durationMinutes: Int, periods: Int) -> Unit,
+) {
+    var duration by remember { mutableIntStateOf(10) }
+    var periods by remember { mutableIntStateOf(2) }
+    val columnState = rememberColumnState(ScalingLazyColumnDefaults.responsive())
+
+    ScreenScaffold(scrollState = columnState) {
+        ScalingLazyColumn(
+            columnState = columnState,
+            modifier = Modifier.fillMaxSize(),
+        ) {
+            item {
+                ListHeader {
+                    Text(
+                        text = stringResource(R.string.quick_setup_title),
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                }
+            }
+
+            // Duration picker
+            item {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.Center,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    CompactButton(onClick = { duration = maxOf(5, duration - 5) }) {
+                        Text("−")
+                    }
+                    Text(
+                        text = stringResource(R.string.interval_minutes, duration),
+                        style = MaterialTheme.typography.bodyMedium,
+                        modifier = Modifier.padding(horizontal = 8.dp),
+                    )
+                    CompactButton(onClick = { duration = minOf(45, duration + 5) }) {
+                        Text("+")
+                    }
+                }
+            }
+
+            // Periods picker
+            item {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.Center,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    CompactButton(onClick = { periods = maxOf(1, periods - 1) }) {
+                        Text("−")
+                    }
+                    Text(
+                        text = stringResource(R.string.periods_count, periods),
+                        style = MaterialTheme.typography.bodyMedium,
+                        modifier = Modifier.padding(horizontal = 8.dp),
+                    )
+                    CompactButton(onClick = { periods = minOf(4, periods + 1) }) {
+                        Text("+")
+                    }
+                }
+            }
+
+            // Start button
+            item {
+                Spacer(modifier = Modifier.height(8.dp))
+                Button(
+                    onClick = { onStart(duration, periods) },
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text(stringResource(R.string.start_quick_game))
+                }
+            }
+        }
+    }
+}

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/score/ScoreComponents.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/score/ScoreComponents.kt
@@ -1,0 +1,160 @@
+package dev.convocados.wear.ui.screen.score
+
+import android.view.HapticFeedbackConstants
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.PathMeasure
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.wear.compose.material3.MaterialTheme
+import androidx.wear.compose.material3.Text
+
+/**
+ * A full-height team tile: tap to add a point, long-press to subtract one.
+ */
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+internal fun TeamScoreButton(
+    teamName: String,
+    score: Int,
+    container: Color,
+    contentColor: Color,
+    onIncrement: () -> Unit,
+    onDecrement: () -> Unit,
+    enabled: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val view = LocalView.current
+    val interactionSource = remember { MutableInteractionSource() }
+    val pressed by interactionSource.collectIsPressedAsState()
+    val scale by animateFloatAsState(if (pressed && enabled) 0.97f else 1f, label = "press")
+    Column(
+        modifier = modifier
+            .scale(scale)
+            .fillMaxHeight()
+            .clip(RoundedCornerShape(28.dp))
+            .background(container)
+            .combinedClickable(
+                interactionSource = interactionSource,
+                indication = null,
+                enabled = enabled,
+                onClickLabel = "Add a point to $teamName",
+                onLongClickLabel = "Remove a point from $teamName",
+                onClick = {
+                    view.performHapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
+                    onIncrement()
+                },
+                onLongClick = {
+                    view.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
+                    onDecrement()
+                },
+            )
+            .semantics { contentDescription = "$teamName, $score points" }
+            .padding(horizontal = 6.dp, vertical = 10.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Text(
+            text = teamName,
+            style = MaterialTheme.typography.titleSmall,
+            color = contentColor,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            textAlign = TextAlign.Center,
+        )
+        Text(
+            text = "$score",
+            style = MaterialTheme.typography.displayLarge.copy(
+                fontSize = 44.sp,
+                fontWeight = FontWeight.Bold,
+            ),
+            color = contentColor,
+        )
+    }
+}
+
+/** Game-progress indicator that hugs the screen edge, starting at 12 o'clock. */
+@Composable
+internal fun GameEdgeProgress(progress: Float, modifier: Modifier = Modifier) {
+    if (progress <= 0f) return
+
+    val isRound = LocalConfiguration.current.isScreenRound
+    val fillColor = MaterialTheme.colorScheme.primary
+    val trackColor = MaterialTheme.colorScheme.surfaceContainer
+    val tickColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f)
+
+    Canvas(modifier = modifier.fillMaxSize()) {
+        val stroke = 5.dp.toPx()
+        val left = stroke / 2f + 1.dp.toPx()
+        val top = left
+        val right = size.width - left
+        val bottom = size.height - top
+        val w = right - left
+        val h = bottom - top
+        val r = if (isRound) minOf(w, h) / 2f else 28.dp.toPx()
+        val cx = left + w / 2f
+
+        val path = Path().apply {
+            moveTo(cx, top)
+            lineTo(right - r, top)
+            arcTo(Rect(right - 2 * r, top, right, top + 2 * r), -90f, 90f, false)
+            lineTo(right, bottom - r)
+            arcTo(Rect(right - 2 * r, bottom - 2 * r, right, bottom), 0f, 90f, false)
+            lineTo(left + r, bottom)
+            arcTo(Rect(left, bottom - 2 * r, left + 2 * r, bottom), 90f, 90f, false)
+            lineTo(left, top + r)
+            arcTo(Rect(left, top, left + 2 * r, top + 2 * r), 180f, 90f, false)
+            close()
+        }
+
+        drawPath(path, trackColor, style = Stroke(width = stroke))
+
+        val measure = PathMeasure().apply { setPath(path, false) }
+        val ticks = 12
+        for (i in 0 until ticks) {
+            drawCircle(tickColor, radius = 1.5.dp.toPx(), center = measure.getPosition(measure.length * i / ticks))
+        }
+
+        val segment = Path()
+        measure.getSegment(0f, measure.length * progress.coerceIn(0f, 1f), segment, true)
+        drawPath(segment, fillColor, style = Stroke(width = stroke, cap = StrokeCap.Round))
+    }
+}
+
+/** Lightweight elapsed-time pill (m:ss). */
+@Composable
+internal fun GameClock(text: String, modifier: Modifier = Modifier) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.labelMedium,
+        color = MaterialTheme.colorScheme.onSurface,
+        modifier = modifier
+            .clip(RoundedCornerShape(50))
+            .background(MaterialTheme.colorScheme.surfaceContainer)
+            .padding(horizontal = 10.dp, vertical = 2.dp),
+    )
+}

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/score/ScoreScreen.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/score/ScoreScreen.kt
@@ -2,36 +2,22 @@ package dev.convocados.wear.ui.screen.score
 
 import android.view.HapticFeedbackConstants
 import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
-import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.gestures.detectVerticalDragGestures
-import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.scale
-import androidx.compose.ui.geometry.Rect
-import androidx.compose.ui.graphics.Path
-import androidx.compose.ui.graphics.PathMeasure
-import androidx.compose.ui.graphics.StrokeCap
-import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.wear.compose.material3.*
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.compose.layout.ScreenScaffold
@@ -246,130 +232,7 @@ private fun ScoreEditor(
 /**
  * A full-height team tile: tap to add a point, long-press to subtract one.
  * The team name stays visible above the score so each side is clearly labelled.
+ * NOTE: Moved to ScoreComponents.kt as internal — kept here as delegation.
  */
-@OptIn(ExperimentalFoundationApi::class)
-@Composable
-private fun TeamScoreButton(
-    teamName: String,
-    score: Int,
-    container: androidx.compose.ui.graphics.Color,
-    contentColor: androidx.compose.ui.graphics.Color,
-    onIncrement: () -> Unit,
-    onDecrement: () -> Unit,
-    enabled: Boolean,
-    modifier: Modifier = Modifier,
-) {
-    val view = LocalView.current
-    val interactionSource = remember { MutableInteractionSource() }
-    val pressed by interactionSource.collectIsPressedAsState()
-    val scale by animateFloatAsState(if (pressed && enabled) 0.97f else 1f, label = "press")
-    Column(
-        modifier = modifier
-            .scale(scale)
-            .fillMaxHeight()
-            .clip(RoundedCornerShape(28.dp))
-            .background(container)
-            .combinedClickable(
-                interactionSource = interactionSource,
-                indication = null,
-                enabled = enabled,
-                onClickLabel = "Add a point to $teamName",
-                onLongClickLabel = "Remove a point from $teamName",
-                onClick = {
-                    view.performHapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
-                    onIncrement()
-                },
-                onLongClick = {
-                    view.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
-                    onDecrement()
-                },
-            )
-            .semantics { contentDescription = "$teamName, $score points" }
-            .padding(horizontal = 6.dp, vertical = 10.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center,
-    ) {
-        Text(
-            text = teamName,
-            style = MaterialTheme.typography.titleSmall,
-            color = contentColor,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-            textAlign = TextAlign.Center,
-        )
-        Text(
-            text = "$score",
-            style = MaterialTheme.typography.displayLarge.copy(
-                fontSize = 44.sp,
-                fontWeight = FontWeight.Bold,
-            ),
-            color = contentColor,
-        )
-    }
-}
 
-/** Game-progress indicator that hugs the screen edge (circle on round watches,
- *  rounded-rectangle perimeter on rectangular ones), starting at 12 o'clock.
- *  Non-interactive: draws only, so taps fall through to the tiles. */
-@Composable
-private fun GameEdgeProgress(progress: Float, modifier: Modifier = Modifier) {
-    if (progress <= 0f) return
-
-    val isRound = LocalConfiguration.current.isScreenRound
-    val fillColor = MaterialTheme.colorScheme.primary
-    val trackColor = MaterialTheme.colorScheme.surfaceContainer
-    val tickColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f)
-
-    Canvas(modifier = modifier.fillMaxSize()) {
-        val stroke = 5.dp.toPx()
-        val left = stroke / 2f + 1.dp.toPx()
-        val top = left
-        val right = size.width - left
-        val bottom = size.height - top
-        val w = right - left
-        val h = bottom - top
-        val r = if (isRound) minOf(w, h) / 2f else 28.dp.toPx()
-        val cx = left + w / 2f
-
-        // Perimeter path, clockwise from top-center.
-        val path = Path().apply {
-            moveTo(cx, top)
-            lineTo(right - r, top)
-            arcTo(Rect(right - 2 * r, top, right, top + 2 * r), -90f, 90f, false)
-            lineTo(right, bottom - r)
-            arcTo(Rect(right - 2 * r, bottom - 2 * r, right, bottom), 0f, 90f, false)
-            lineTo(left + r, bottom)
-            arcTo(Rect(left, bottom - 2 * r, left + 2 * r, bottom), 90f, 90f, false)
-            lineTo(left, top + r)
-            arcTo(Rect(left, top, left + 2 * r, top + 2 * r), 180f, 90f, false)
-            close()
-        }
-
-        drawPath(path, trackColor, style = Stroke(width = stroke))
-
-        val measure = PathMeasure().apply { setPath(path, false) }
-        // Chronograph bezel: faint tick marks evenly around the perimeter.
-        val ticks = 12
-        for (i in 0 until ticks) {
-            drawCircle(tickColor, radius = 1.5.dp.toPx(), center = measure.getPosition(measure.length * i / ticks))
-        }
-
-        val segment = Path()
-        measure.getSegment(0f, measure.length * progress.coerceIn(0f, 1f), segment, true)
-        drawPath(segment, fillColor, style = Stroke(width = stroke, cap = StrokeCap.Round))
-    }
-}
-
-/** Lightweight elapsed-time pill (m:ss). */
-@Composable
-private fun GameClock(text: String, modifier: Modifier = Modifier) {
-    Text(
-        text = text,
-        style = MaterialTheme.typography.labelMedium,
-        color = MaterialTheme.colorScheme.onSurface,
-        modifier = modifier
-            .clip(RoundedCornerShape(50))
-            .background(MaterialTheme.colorScheme.surfaceContainer)
-            .padding(horizontal = 10.dp, vertical = 2.dp),
-    )
-}
+/** Game-progress indicator — see ScoreComponents.kt */

--- a/android-app/wear/src/main/res/values/strings.xml
+++ b/android-app/wear/src/main/res/values/strings.xml
@@ -40,6 +40,14 @@
     <string name="team_default_1">Team 1</string>
     <string name="team_default_2">Team 2</string>
 
+    <!-- Quick Game -->
+    <string name="quick_game">Quick Game</string>
+    <string name="quick_setup_title">Setup</string>
+    <string name="interval_minutes">Interval: %1$d min</string>
+    <string name="periods_count">Periods: %1$d</string>
+    <string name="start_quick_game">Start</string>
+    <string name="refresh">Refresh</string>
+
     <!-- Teams screen -->
     <string name="teams_title">Teams</string>
     <string name="teams_chip">Teams ↑</string>

--- a/android-app/wear/src/main/res/values/strings.xml
+++ b/android-app/wear/src/main/res/values/strings.xml
@@ -43,8 +43,8 @@
     <!-- Quick Game -->
     <string name="quick_game">Quick Game</string>
     <string name="quick_setup_title">Setup</string>
-    <string name="interval_minutes">Interval: %1$d min</string>
-    <string name="periods_count">Periods: %1$d</string>
+    <string name="duration_minutes">Duration: %1$d min</string>
+    <string name="alarm_every_minutes">Alarm: every %1$d min</string>
     <string name="start_quick_game">Start</string>
     <string name="refresh">Refresh</string>
 

--- a/android-app/wear/src/main/res/values/strings.xml
+++ b/android-app/wear/src/main/res/values/strings.xml
@@ -43,8 +43,9 @@
     <!-- Quick Game -->
     <string name="quick_game">Quick Game</string>
     <string name="quick_setup_title">Setup</string>
-    <string name="duration_minutes">Duration: %1$d min</string>
-    <string name="alarm_every_minutes">Alarm: every %1$d min</string>
+    <string name="duration_label">Game</string>
+    <string name="alarm_label">Alarm</string>
+    <string name="minutes_value">%1$d min</string>
     <string name="start_quick_game">Start</string>
     <string name="refresh">Refresh</string>
 

--- a/android-app/wear/stability-config.txt
+++ b/android-app/wear/stability-config.txt
@@ -1,0 +1,5 @@
+// Treat all data classes in our packages as stable
+dev.convocados.wear.ui.screen.games.GamesUiState
+dev.convocados.wear.ui.screen.quick.QuickScoreUiState
+dev.convocados.wear.ui.screen.score.ScoreUiState
+dev.convocados.wear.data.local.entity.*

--- a/docs/adr/0002-wear-quick-game-separate-screen.md
+++ b/docs/adr/0002-wear-quick-game-separate-screen.md
@@ -1,0 +1,12 @@
+# Separate QuickScoreScreen for detached Wear OS scoring
+
+The existing `ScoreScreen` is tightly coupled to a server-side Game entity — it fetches teams, syncs scores via `ScoreSyncWorker`, and requires an `eventId` for all operations. We considered reusing it with a special local-only ID and conditionals (option A) vs. creating a dedicated `QuickScoreScreen` (option B).
+
+We chose option B: a separate `QuickScoreScreen` that shares UI composables (score tap areas, timer arc, haptic feedback) extracted into reusable components, but has its own ViewModel with no API/sync dependencies. Quick Game state uses `SavedStateHandle` only — no Room persistence, no network calls.
+
+Reasons:
+- ScoreScreen's sync, team-fetching, and event-loading logic would require pervasive `if (isLocal)` branching
+- Quick Game doesn't need teams, game settings from server, or offline-queue sync
+- Shared UI is extracted as composables, keeping DRY where it matters (presentation) without coupling data concerns
+
+Trade-off accepted: two screen files with some structural similarity, in exchange for clean separation of concerns and no risk of Quick Game accidentally triggering sync or API calls.


### PR DESCRIPTION
## Summary

Fixes the stuck-user bug where the games list empty state had no actionable buttons, and adds a new Quick Game feature for detached score tracking.

### Changes

**Bug fix:**
- Empty games list now shows Refresh, Quick Game, and Sign Out buttons (previously showed only 'No games yet' text with no escape)

**Games list improvements:**
- Refresh button at top of populated games list
- Quick Game button at bottom of populated games list

**Quick Game feature:**
- Accessible from both auth screen (skip login) and games list (logged-in users)
- QuickSetupScreen: configure interval duration (5-45 min) and periods (1-4)
- QuickScoreScreen: local-only score tracking with timer arc and period indicator
- Uses SavedStateHandle for process-death survival, no API/Room/sync

**DRY refactor:**
- Extracted TeamScoreButton, GameEdgeProgress, GameClock into ScoreComponents.kt
- Reused by both ScoreScreen and QuickScoreScreen

### Testing
- Built and deployed to physical watch (debug APK)
- App launches without crashes on auth screen with Quick Game button visible

### Docs
- Added 'Quick Game' to CONTEXT.md glossary
- Added ADR 0002 explaining separate QuickScoreScreen decision