### PR TITLE
feat: add merge-player endpoint and UI for admins

### DIFF
--- a/docs/auto-link-player.md
+++ b/docs/auto-link-player.md
@@ -151,10 +151,10 @@ The fix is **forward-looking** — it auto-links on the *next* add. Existing orp
 
 To recover an orphan, the affected user has two options:
 
-1. **Claim** from the **Rankings** page. The `POST /api/events/[id]/claim-player` flow renames the anonymous player and links the `userId`. (The full merge-player flow from #297 is available for the more complex case where both anonymous and logged-in records exist.)
+1. **Claim** from the **Rankings** page. The `POST /api/events/[id]/claim-player` flow renames the anonymous player and links the `userId`.
 2. **Owner removes the orphan** and the next re-add auto-links correctly (assuming the owner types the right name).
 
-For the reported case: `Player.id = cmpvp5d9i00g1pijpzqw88emf` on `Ninjas da Areosa` (`Event.id = cmmkfrx8b0000o2ixrix1yp2m`). After the next lazy reset on `2026-06-08T19:00:00Z`, any add of "Gonçalo" by the owner will auto-link to `User.id = bJzXFpoS7oxI3kpkKsgIR6tdvVfs4b2t` automatically.
+For the more complex case where both anonymous and logged-in records exist (same human, two `PlayerRating` entries), use the admin **merge-player** flow (`POST /api/events/[id]/merge-player`) documented in #297.
 
 ## Related
 

--- a/src/components/RankingsPage.tsx
+++ b/src/components/RankingsPage.tsx
@@ -5,12 +5,14 @@ import {
   CircularProgress, alpha, useTheme, IconButton, Tooltip, Snackbar, Alert,
   Table, TableBody, TableCell, TableContainer, TableHead, TableRow,
   Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions, TextField,
+  Autocomplete,
 } from "@mui/material";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import EmojiEventsIcon from "@mui/icons-material/EmojiEvents";
 import EditIcon from "@mui/icons-material/Edit";
 import DeleteIcon from "@mui/icons-material/Delete";
 import HowToRegIcon from "@mui/icons-material/HowToReg";
+import MergeIcon from "@mui/icons-material/MergeType";
 import { ThemeModeProvider } from "./ThemeModeProvider";
 import { ResponsiveLayout } from "./ResponsiveLayout";
 import { useT } from "~/lib/useT";
@@ -77,6 +79,12 @@ export default function RankingsPage({ eventId }: { eventId: string }) {
   // Claim player state
   const [claimTarget, setClaimTarget] = useState<{ id: string; name: string } | null>(null);
   const [claiming, setClaiming] = useState(false);
+
+  // Merge player state
+  const [mergeOpen, setMergeOpen] = useState(false);
+  const [mergeSource, setMergeSource] = useState<string | null>(null);
+  const [mergeTarget, setMergeTarget] = useState<string | null>(null);
+  const [merging, setMerging] = useState(false);
 
   const load = useCallback(async () => {
     const [evRes, ratRes] = await Promise.all([
@@ -218,6 +226,31 @@ export default function RankingsPage({ eventId }: { eventId: string }) {
   const userHasLinkedPlayer = isAuthenticated && players.some((p) => p.userId === session?.user?.id);
   const canClaimPlayer = isAuthenticated && !userHasLinkedPlayer;
 
+  const handleMergePlayer = async () => {
+    if (!mergeSource || !mergeTarget) return;
+    setMerging(true);
+    try {
+      const res = await fetch(`/api/events/${eventId}/merge-player`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ sourceName: mergeSource, targetName: mergeTarget }),
+      });
+      if (res.ok) {
+        setSnack({ msg: t("mergePlayerSuccess"), severity: "success" });
+        setMergeOpen(false);
+        setMergeSource(null);
+        setMergeTarget(null);
+        load();
+      } else {
+        const data = await res.json();
+        setSnack({ msg: data.error || "Error", severity: "error" });
+      }
+    } catch {
+      setSnack({ msg: "Error", severity: "error" });
+    }
+    setMerging(false);
+  };
+
   const playerByName = new Map(players.map((p) => [p.name, p]));
 
   const tableRows: TableRowData[] = (() => {
@@ -309,6 +342,16 @@ export default function RankingsPage({ eventId }: { eventId: string }) {
                   disabled={recalculating}
                 >
                   {recalculating ? t("recalculating") : t("recalculateRatings")}
+                </Button>
+              )}
+              {canManage && (
+                <Button
+                  variant="outlined"
+                  size="small"
+                  startIcon={<MergeIcon />}
+                  onClick={() => setMergeOpen(true)}
+                >
+                  {t("mergePlayers")}
                 </Button>
               )}
             </Box>
@@ -514,6 +557,40 @@ export default function RankingsPage({ eventId }: { eventId: string }) {
               disabled={saving || !!editError || editValue === ""}
             >
               {saving ? t("loading") : t("saveProfile")}
+            </Button>
+          </DialogActions>
+        </Dialog>
+
+        {/* Merge player dialog */}
+        <Dialog open={mergeOpen} onClose={() => !merging && setMergeOpen(false)} maxWidth="xs" fullWidth>
+          <DialogTitle>{t("mergePlayers")}</DialogTitle>
+          <DialogContent>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+              {t("mergePlayerDesc")}
+            </Typography>
+            <Stack spacing={2} sx={{ mt: 1 }}>
+              <Autocomplete
+                options={ratings.map((r) => r.name).filter((n) => n !== mergeTarget)}
+                value={mergeSource}
+                onChange={(_, v) => setMergeSource(v)}
+                renderInput={(params) => <TextField {...params} label={t("mergeSource")} size="small" />}
+              />
+              <Autocomplete
+                options={ratings.map((r) => r.name).filter((n) => n !== mergeSource)}
+                value={mergeTarget}
+                onChange={(_, v) => setMergeTarget(v)}
+                renderInput={(params) => <TextField {...params} label={t("mergeTarget")} size="small" />}
+              />
+            </Stack>
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={() => setMergeOpen(false)} disabled={merging}>{t("cancel")}</Button>
+            <Button
+              variant="contained"
+              onClick={handleMergePlayer}
+              disabled={merging || !mergeSource || !mergeTarget}
+            >
+              {merging ? t("loading") : t("mergePlayers")}
             </Button>
           </DialogActions>
         </Dialog>

--- a/src/lib/eventLog.server.ts
+++ b/src/lib/eventLog.server.ts
@@ -34,6 +34,7 @@ export type EventAction =
   | "rating_manual_disabled"
   | "player_archived"
   | "player_unarchived"
+  | "player_merged"
   | "override_set"
   | "override_cleared";
 

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -799,6 +799,11 @@ const de: TranslationKeys = {
   purgePlayerConfirm: "\"{name}\" dauerhaft aus diesem Ereignis entfernen? Dadurch werden der Spielerdatensatz, die Bewertungen und alle Spielhistorieneinträge gelöscht. ELO wird neu berechnet. Diese Aktion kann nicht rückgängig gemacht werden.",
   purgePlayerSuccess: "Spieler entfernt.",
   purgePlayerError: "Spieler konnte nicht entfernt werden.",
+  mergePlayers: "Spieler zusammenführen",
+  mergePlayerDesc: "Zwei Spieleridentitäten zusammenführen. Die Spielhistorie des Quellspielers wird in den Zielspieler übernommen. Verwende dies, wenn dieselbe Person unter zwei verschiedenen Namen gespielt hat.",
+  mergeSource: "Quelle (wird entfernt)",
+  mergeTarget: "Ziel (wird beibehalten)",
+  mergePlayerSuccess: "Spieler erfolgreich zusammengeführt.",
 
   // Admin role notifications
   adminRoleAddedSubject: "Du bist jetzt Admin von {title}",

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -663,6 +663,11 @@ const en = {
   purgePlayerConfirm: "Permanently remove \"{name}\" from this event? This will delete their player record, ratings, and remove them from all game history. ELO will be recalculated. This cannot be undone.",
   purgePlayerSuccess: "Player removed.",
   purgePlayerError: "Could not remove player.",
+  mergePlayers: "Merge players",
+  mergePlayerDesc: "Merge two player identities. The source player's game history will be absorbed into the target. Use when the same person played under two different names.",
+  mergeSource: "Source (will be removed)",
+  mergeTarget: "Target (will keep)",
+  mergePlayerSuccess: "Players merged successfully.",
 
   // Event archive (#161)
   archiveEvent: "Archive event",

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -799,6 +799,11 @@ const es: TranslationKeys = {
   purgePlayerConfirm: "¿Eliminar permanentemente a \"{name}\" de este evento? Esto borrará su registro de jugador, clasificaciones y lo eliminará de todo el historial de partidos. El ELO se recalculará. Esta acción no se puede deshacer.",
   purgePlayerSuccess: "Jugador eliminado.",
   purgePlayerError: "No se pudo eliminar al jugador.",
+  mergePlayers: "Unir jugadores",
+  mergePlayerDesc: "Unir dos identidades de jugador. El historial del jugador origen será absorbido por el destino. Usa esto cuando la misma persona jugó con dos nombres diferentes.",
+  mergeSource: "Origen (será eliminado)",
+  mergeTarget: "Destino (se mantendrá)",
+  mergePlayerSuccess: "Jugadores unidos con éxito.",
 
   // Admin role notifications
   adminRoleAddedSubject: "Ahora eres admin de {title}",

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -799,6 +799,11 @@ const fr: TranslationKeys = {
   purgePlayerConfirm: "Retirer définitivement \"{name}\" de cet événement ? Cela supprimera son dossier de joueur, ses classements et le retirera de tout l'historique des matchs. L'ELO sera recalculé. Cette action est irréversible.",
   purgePlayerSuccess: "Joueur retiré.",
   purgePlayerError: "Impossible de retirer le joueur.",
+  mergePlayers: "Fusionner les joueurs",
+  mergePlayerDesc: "Fusionner deux identités de joueur. L'historique du joueur source sera absorbé par la cible. Utilisez ceci quand la même personne a joué sous deux noms différents.",
+  mergeSource: "Source (sera supprimé)",
+  mergeTarget: "Cible (sera conservé)",
+  mergePlayerSuccess: "Joueurs fusionnés avec succès.",
 
   // Admin role notifications
   adminRoleAddedSubject: "Vous êtes maintenant admin de {title}",

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -799,6 +799,11 @@ const it: TranslationKeys = {
   purgePlayerConfirm: "Rimuovere definitivamente \"{name}\" da questo evento? Verranno eliminati il record del giocatore, le classifiche e la sua presenza in tutta la cronologia delle partite. L'ELO verrà ricalcolato. Questa azione non può essere annullata.",
   purgePlayerSuccess: "Giocatore rimosso.",
   purgePlayerError: "Impossibile rimuovere il giocatore.",
+  mergePlayers: "Unisci giocatori",
+  mergePlayerDesc: "Unisci due identità di giocatore. La cronologia del giocatore di origine sarà assorbita dal destinatario. Usa quando la stessa persona ha giocato con due nomi diversi.",
+  mergeSource: "Origine (sarà rimosso)",
+  mergeTarget: "Destinazione (sarà mantenuto)",
+  mergePlayerSuccess: "Giocatori uniti con successo.",
 
   // Admin role notifications
   adminRoleAddedSubject: "Sei ora admin di {title}",

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -845,6 +845,11 @@ const pt: TranslationKeys = {
   purgePlayerConfirm: "Remover permanentemente \"{name}\" deste evento? Isto irá eliminar o registo do jogador, as classificações e removê-lo de todo o histórico de jogos. O ELO será recalculado. Esta ação não pode ser desfeita.",
   purgePlayerSuccess: "Jogador removido.",
   purgePlayerError: "Não foi possível remover o jogador.",
+  mergePlayers: "Unir jogadores",
+  mergePlayerDesc: "Unir duas identidades de jogador. O histórico do jogador de origem será absorvido pelo destino. Usa quando a mesma pessoa jogou com dois nomes diferentes.",
+  mergeSource: "Origem (será removido)",
+  mergeTarget: "Destino (será mantido)",
+  mergePlayerSuccess: "Jogadores unidos com sucesso.",
 
   // Admin role notifications
   adminRoleAddedSubject: "És agora admin de {title}",

--- a/src/pages/api/events/[id]/merge-player.ts
+++ b/src/pages/api/events/[id]/merge-player.ts
@@ -1,0 +1,135 @@
+import type { APIRoute } from "astro";
+import { prisma } from "../../../../lib/db.server";
+import { checkOwnership } from "../../../../lib/auth.helpers.server";
+import { rateLimitResponse } from "../../../../lib/apiRateLimit.server";
+import { recalculateAllRatings } from "../../../../lib/elo.server";
+import { logEvent } from "../../../../lib/eventLog.server";
+
+/**
+ * POST /api/events/:id/merge-player
+ *
+ * Merges two player identities within an event. The source player's history
+ * is absorbed into the target player. Use when the same human played under
+ * two different names (e.g., "Gonçalo" anonymous + "Gonçalo Silva" linked).
+ *
+ * Body: { sourceName: string, targetName: string }
+ *
+ * What happens:
+ * 1. All GameHistory teamsSnapshot entries with sourceName are renamed to targetName
+ * 2. MvpVote references are updated
+ * 3. Source PlayerRating is deleted (recalculate rebuilds from history)
+ * 4. Source Player record is deleted (if present)
+ * 5. Target PlayerRating.userId is preserved (or inherited from source if target has none)
+ * 6. ELO ratings are recalculated from scratch
+ *
+ * Admin/owner only.
+ */
+export const POST: APIRoute = async ({ params, request }) => {
+  const limited = await rateLimitResponse(request, "write");
+  if (limited) return limited;
+
+  const eventId = params.id ?? "";
+  const event = await prisma.event.findUnique({ where: { id: eventId } });
+  if (!event) return Response.json({ error: "Not found." }, { status: 404 });
+
+  const { isOwner, isAdmin, session } = await checkOwnership(request, event.ownerId, undefined, eventId);
+  if (!isOwner && !isAdmin) {
+    return Response.json({ error: "Only the event owner or admin can merge players." }, { status: 403 });
+  }
+
+  const body = await request.json();
+  const { sourceName, targetName } = body as { sourceName?: string; targetName?: string };
+
+  if (!sourceName || !targetName || typeof sourceName !== "string" || typeof targetName !== "string") {
+    return Response.json({ error: "sourceName and targetName are required." }, { status: 400 });
+  }
+
+  if (sourceName === targetName) {
+    return Response.json({ error: "Source and target must be different." }, { status: 400 });
+  }
+
+  // Verify at least one of them exists in the event's history (PlayerRating or GameHistory)
+  const sourceRating = await prisma.playerRating.findUnique({
+    where: { eventId_name: { eventId, name: sourceName } },
+  });
+  const targetRating = await prisma.playerRating.findUnique({
+    where: { eventId_name: { eventId, name: targetName } },
+  });
+
+  if (!sourceRating && !targetRating) {
+    return Response.json({ error: "Neither player has a rating record in this event." }, { status: 404 });
+  }
+
+  // Determine the userId for the merged record: prefer target's, then source's
+  const mergedUserId = targetRating?.userId ?? sourceRating?.userId ?? null;
+
+  // 1. Rename sourceName → targetName in all GameHistory teamsSnapshot
+  const histories = await prisma.gameHistory.findMany({
+    where: { eventId },
+    select: { id: true, teamsSnapshot: true },
+  });
+
+  const snapshotUpdates = histories.flatMap((h) => {
+    if (!h.teamsSnapshot || !h.teamsSnapshot.includes(sourceName)) return [];
+    try {
+      const teams: { team: string; players: { name: string; order: number }[] }[] = JSON.parse(h.teamsSnapshot);
+      let changed = false;
+      for (const team of teams) {
+        for (const p of team.players) {
+          if (p.name === sourceName) {
+            p.name = targetName;
+            changed = true;
+          }
+        }
+      }
+      if (!changed) return [];
+      return [prisma.gameHistory.update({ where: { id: h.id }, data: { teamsSnapshot: JSON.stringify(teams) } })];
+    } catch { return []; }
+  });
+
+  // 2. Update MvpVote references
+  const mvpUpdates = [
+    prisma.mvpVote.updateMany({
+      where: { voterName: sourceName, gameHistory: { eventId } },
+      data: { voterName: targetName },
+    }),
+    prisma.mvpVote.updateMany({
+      where: { votedForName: sourceName, gameHistory: { eventId } },
+      data: { votedForName: targetName },
+    }),
+  ];
+
+  // 3. Delete source PlayerRating + Player, update target userId
+  await prisma.$transaction([
+    ...snapshotUpdates,
+    ...mvpUpdates,
+    prisma.playerRating.deleteMany({ where: { eventId, name: sourceName } }),
+    prisma.player.deleteMany({ where: { eventId, name: sourceName } }),
+    prisma.teamMember.updateMany({ where: { name: sourceName, team: { eventId } }, data: { name: targetName } }),
+    // Ensure target rating exists and has the merged userId
+    ...(targetRating
+      ? [prisma.playerRating.update({ where: { id: targetRating.id }, data: { userId: mergedUserId } })]
+      : [prisma.playerRating.create({ data: { eventId, name: targetName, userId: mergedUserId } })]),
+  ]);
+
+  // 4. Recalculate ELO from scratch (history now has all games under targetName)
+  if (event.eloEnabled) {
+    await recalculateAllRatings(eventId);
+  }
+  // Ensure target rating exists with correct userId (recalculate may recreate without it)
+  if (mergedUserId) {
+    await prisma.playerRating.upsert({
+      where: { eventId_name: { eventId, name: targetName } },
+      create: { eventId, name: targetName, userId: mergedUserId },
+      update: { userId: mergedUserId },
+    });
+  }
+
+  await logEvent(eventId, "player_merged", session?.user?.name ?? null, session?.user?.id ?? null, {
+    sourceName,
+    targetName,
+    mergedUserId,
+  });
+
+  return Response.json({ ok: true, mergedInto: targetName, userId: mergedUserId });
+};

--- a/src/test/merge-player.test.ts
+++ b/src/test/merge-player.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { prisma } from "~/lib/db.server";
+import { POST } from "~/pages/api/events/[id]/merge-player";
+import { checkOwnership } from "~/lib/auth.helpers.server";
+import { resetRateLimitStore } from "~/lib/rateLimit.server";
+import { resetApiRateLimitStore } from "~/lib/apiRateLimit.server";
+
+vi.mock("~/lib/auth.helpers.server", () => ({
+  checkOwnership: vi.fn(),
+  getSession: vi.fn(),
+}));
+
+const mockCheckOwnership = vi.mocked(checkOwnership);
+
+function ctx(eventId: string, body: any, ownership: { isOwner: boolean; isAdmin: boolean }) {
+  mockCheckOwnership.mockResolvedValue({ ...ownership, session: { user: { id: "owner", name: "Owner" } } } as any);
+  return {
+    params: { id: eventId },
+    request: new Request(`http://localhost/api/events/${eventId}/merge-player`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+  } as any;
+}
+
+async function seedEvent() {
+  return prisma.event.create({
+    data: { title: "Test", location: "Pitch", dateTime: new Date(Date.now() + 86400_000), maxPlayers: 10 },
+  });
+}
+
+beforeEach(async () => {
+  await prisma.mvpVote.deleteMany();
+  await prisma.gameHistory.deleteMany();
+  await prisma.playerRating.deleteMany();
+  await prisma.teamMember.deleteMany();
+  await prisma.teamResult.deleteMany();
+  await prisma.player.deleteMany();
+  await prisma.event.deleteMany();
+  await prisma.user.deleteMany();
+  resetRateLimitStore();
+  resetApiRateLimitStore();
+  vi.clearAllMocks();
+});
+
+describe("POST /api/events/[id]/merge-player", () => {
+  it("rejects non-admin/owner", async () => {
+    const event = await seedEvent();
+    const res = await POST(ctx(event.id, { sourceName: "A", targetName: "B" }, { isOwner: false, isAdmin: false }));
+    expect(res.status).toBe(403);
+  });
+
+  it("rejects same source and target", async () => {
+    const event = await seedEvent();
+    const res = await POST(ctx(event.id, { sourceName: "A", targetName: "A" }, { isOwner: true, isAdmin: false }));
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects when neither player has a rating", async () => {
+    const event = await seedEvent();
+    const res = await POST(ctx(event.id, { sourceName: "Ghost", targetName: "Also Ghost" }, { isOwner: true, isAdmin: false }));
+    expect(res.status).toBe(404);
+  });
+
+  it("merges source into target: renames in history, deletes source rating, recalculates ELO", async () => {
+    const user = await prisma.user.create({ data: { id: "u1", name: "Gonçalo Silva", email: "g@t.com", emailVerified: true } });
+    const event = await seedEvent();
+
+    // Source: anonymous "Gonçalo" played 2 games
+    await prisma.playerRating.create({ data: { eventId: event.id, name: "Gonçalo", rating: 1050, gamesPlayed: 2, wins: 1, losses: 1 } });
+
+    // Target: linked "Gonçalo Silva" played 1 game
+    await prisma.playerRating.create({ data: { eventId: event.id, name: "Gonçalo Silva", userId: user.id, rating: 1020, gamesPlayed: 1, wins: 1 } });
+
+    // GameHistory with source name in snapshot
+    await prisma.gameHistory.create({
+      data: {
+        eventId: event.id,
+        dateTime: new Date("2026-01-01"),
+        teamOneName: "A",
+        teamTwoName: "B",
+        scoreOne: 3,
+        scoreTwo: 1,
+        teamsSnapshot: JSON.stringify([
+          { team: "A", players: [{ name: "Gonçalo", order: 0 }, { name: "Other", order: 1 }] },
+          { team: "B", players: [{ name: "Rival", order: 0 }] },
+        ]),
+        editableUntil: new Date(Date.now() + 86400_000),
+        eloProcessed: true,
+      },
+    });
+
+    const res = await POST(ctx(event.id, { sourceName: "Gonçalo", targetName: "Gonçalo Silva" }, { isOwner: true, isAdmin: false }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.ok).toBe(true);
+    expect(json.mergedInto).toBe("Gonçalo Silva");
+    expect(json.userId).toBe(user.id);
+
+    // Source rating deleted
+    const sourceRating = await prisma.playerRating.findUnique({ where: { eventId_name: { eventId: event.id, name: "Gonçalo" } } });
+    expect(sourceRating).toBeNull();
+
+    // Target rating recalculated (now includes the merged game)
+    const targetRating = await prisma.playerRating.findUnique({ where: { eventId_name: { eventId: event.id, name: "Gonçalo Silva" } } });
+    expect(targetRating).not.toBeNull();
+    expect(targetRating!.userId).toBe(user.id);
+    expect(targetRating!.gamesPlayed).toBe(1); // recalculated from 1 game in history
+
+    // History snapshot renamed
+    const history = await prisma.gameHistory.findFirst({ where: { eventId: event.id } });
+    const snapshot = JSON.parse(history!.teamsSnapshot!);
+    expect(snapshot[0].players[0].name).toBe("Gonçalo Silva");
+  });
+
+  it("inherits userId from source when target has none", async () => {
+    const user = await prisma.user.create({ data: { id: "u1", name: "Gonçalo Silva", email: "g@t.com", emailVerified: true } });
+    const event = await seedEvent();
+
+    // Source has userId (was linked before)
+    await prisma.playerRating.create({ data: { eventId: event.id, name: "Gonçalo", userId: user.id, rating: 1050, gamesPlayed: 3 } });
+    // Target is anonymous
+    await prisma.playerRating.create({ data: { eventId: event.id, name: "G. Silva", rating: 1000, gamesPlayed: 1 } });
+
+    const res = await POST(ctx(event.id, { sourceName: "Gonçalo", targetName: "G. Silva" }, { isOwner: true, isAdmin: false }));
+    expect(res.status).toBe(200);
+
+    const targetRating = await prisma.playerRating.findUnique({ where: { eventId_name: { eventId: event.id, name: "G. Silva" } } });
+    expect(targetRating!.userId).toBe(user.id);
+  });
+
+  it("updates MvpVote references", async () => {
+    const event = await seedEvent();
+    await prisma.playerRating.create({ data: { eventId: event.id, name: "Gonçalo", rating: 1000 } });
+    await prisma.playerRating.create({ data: { eventId: event.id, name: "Gonçalo Silva", rating: 1000 } });
+
+    const history = await prisma.gameHistory.create({
+      data: {
+        eventId: event.id,
+        dateTime: new Date(),
+        teamOneName: "A",
+        teamTwoName: "B",
+        teamsSnapshot: JSON.stringify([
+          { team: "A", players: [{ name: "Gonçalo", order: 0 }] },
+          { team: "B", players: [{ name: "Voter", order: 0 }] },
+        ]),
+        editableUntil: new Date(Date.now() + 86400_000),
+      },
+    });
+
+    await prisma.mvpVote.create({
+      data: { gameHistoryId: history.id, voterPlayerId: "p1", voterName: "Voter", votedForPlayerId: "p2", votedForName: "Gonçalo" },
+    });
+
+    const res = await POST(ctx(event.id, { sourceName: "Gonçalo", targetName: "Gonçalo Silva" }, { isOwner: true, isAdmin: false }));
+    expect(res.status).toBe(200);
+
+    const vote = await prisma.mvpVote.findFirst({ where: { gameHistoryId: history.id } });
+    expect(vote!.votedForName).toBe("Gonçalo Silva");
+  });
+
+  it("deletes source Player record if present", async () => {
+    const event = await seedEvent();
+    await prisma.playerRating.create({ data: { eventId: event.id, name: "Gonçalo", rating: 1000 } });
+    await prisma.playerRating.create({ data: { eventId: event.id, name: "Gonçalo Silva", rating: 1000 } });
+    await prisma.player.create({ data: { name: "Gonçalo", eventId: event.id, order: 0 } });
+
+    const res = await POST(ctx(event.id, { sourceName: "Gonçalo", targetName: "Gonçalo Silva" }, { isOwner: true, isAdmin: false }));
+    expect(res.status).toBe(200);
+
+    const sourcePlayer = await prisma.player.findFirst({ where: { eventId: event.id, name: "Gonçalo" } });
+    expect(sourcePlayer).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

When the same person plays under two different names (e.g., anonymous "Gonçalo" and linked "Gonçalo Silva"), their stats are split across two PlayerRating records. This adds an admin-only merge feature to consolidate them.

## Changes

### API: `POST /api/events/:id/merge-player`
- Owner/admin only
- Takes `sourceName` and `targetName`
- Renames source → target in all `GameHistory.teamsSnapshot` entries
- Updates `MvpVote` references
- Deletes source `PlayerRating` and `Player` records
- Recalculates ELO from scratch
- Preserves/inherits `userId` (prefers target's, falls back to source's)
- Logs action in EventLog

### UI: Ratings page
- "Merge players" button visible to owners/admins
- Dialog with two Autocomplete dropdowns (source + target from ratings list)
- Success/error feedback via snackbar

### Other
- Added `player_merged` to `EventAction` type
- i18n strings for all 6 locales (en, pt, es, fr, de, it)
- Updated `docs/auto-link-player.md` to reference the merge flow

## Testing
- 7 new tests covering: auth checks, validation, merge logic (history rename, userId inheritance, MVP vote updates, player deletion)
- All 1714 tests pass
- Typecheck clean