### PR TITLE
fix: gitignore release-output/ and *.aab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,4 +74,6 @@ android-app/wear/.idea
 .env.wear.local
 android-app/keystore.properties
 android-app/app/release-keystore.jks
+android-app/release-output/
 *.jks
+*.aab


### PR DESCRIPTION
Prevent accidental commit of signed build artifacts. All signing keys are in GitHub Secrets.