### PR TITLE
fix: android CI build - correct package name in google-services placeholder

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -210,7 +210,7 @@ jobs:
           cat > app/google-services.json << 'EOF'
           {
             "project_info": { "project_number": "000000000000", "project_id": "placeholder", "storage_bucket": "placeholder.appspot.com" },
-            "client": [{ "client_info": { "mobilesdk_app_id": "1:000000000000:android:0000000000000000", "android_client_info": { "package_name": "com.cabeda.convocados" } }, "api_key": [{ "current_key": "placeholder" }] }],
+            "client": [{ "client_info": { "mobilesdk_app_id": "1:000000000000:android:0000000000000000", "android_client_info": { "package_name": "com.cabeda.Convocados" } }, "api_key": [{ "current_key": "placeholder" }] }],
             "configuration_version": "1"
           }
           EOF
@@ -310,7 +310,7 @@ jobs:
           cat > app/google-services.json << 'EOF'
           {
             "project_info": { "project_number": "000000000000", "project_id": "placeholder", "storage_bucket": "placeholder.appspot.com" },
-            "client": [{ "client_info": { "mobilesdk_app_id": "1:000000000000:android:0000000000000000", "android_client_info": { "package_name": "com.cabeda.convocados" } }, "api_key": [{ "current_key": "placeholder" }] }],
+            "client": [{ "client_info": { "mobilesdk_app_id": "1:000000000000:android:0000000000000000", "android_client_info": { "package_name": "com.cabeda.Convocados" } }, "api_key": [{ "current_key": "placeholder" }] }],
             "configuration_version": "1"
           }
           EOF

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -151,7 +151,7 @@ jobs:
           cat > app/google-services.json << 'EOF'
           {
             "project_info": { "project_number": "000000000000", "project_id": "placeholder", "storage_bucket": "placeholder.appspot.com" },
-            "client": [{ "client_info": { "mobilesdk_app_id": "1:000000000000:android:0000000000000000", "android_client_info": { "package_name": "com.cabeda.convocados" } }, "api_key": [{ "current_key": "placeholder" }] }],
+            "client": [{ "client_info": { "mobilesdk_app_id": "1:000000000000:android:0000000000000000", "android_client_info": { "package_name": "com.cabeda.Convocados" } }, "api_key": [{ "current_key": "placeholder" }] }],
             "configuration_version": "1"
           }
           EOF


### PR DESCRIPTION
The placeholder `google-services.json` used `com.cabeda.convocados` (lowercase) but the app's `applicationId` is `com.cabeda.Convocados` (capital C). The Google Services Gradle plugin requires an exact package name match, causing CI to fail on every Android PR.

Fixed in both `test.yml` and `release.yml`.