### PR TITLE
feat(web): notification settings UI — per-event + admin defaults

### DIFF
--- a/prisma/migrations/20260609120000_event_notification_defaults/migration.sql
+++ b/prisma/migrations/20260609120000_event_notification_defaults/migration.sql
@@ -1,0 +1,2 @@
+-- Admin-level notification defaults for an event
+ALTER TABLE "Event" ADD COLUMN "notificationDefaults" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -140,6 +140,9 @@ model Event {
   mvpEnabled Boolean @default(true)
   mvpEloEnabled Boolean @default(false)
 
+  // Notification defaults (admin-set, JSON: {mutePlayerActivity?, muteReminders?, mutePostGame?, muteEventDetails?})
+  notificationDefaults String? // null = all enabled
+
   // Archive
   archivedAt     DateTime?
 

--- a/src/components/EventSettingsPage.tsx
+++ b/src/components/EventSettingsPage.tsx
@@ -25,11 +25,13 @@ import GroupIcon from "@mui/icons-material/Group";
 import ArchiveIcon from "@mui/icons-material/Archive";
 import UnarchiveIcon from "@mui/icons-material/Unarchive";
 import EmailIcon from "@mui/icons-material/Email";
+import NotificationsIcon from "@mui/icons-material/Notifications";
 import { useT } from "~/lib/useT";
 import { SPORT_PRESETS } from "~/lib/sports";
 import { useSession } from "~/lib/auth.client";
 import { ThemeModeProvider } from "./ThemeModeProvider";
 import { ResponsiveLayout } from "./ResponsiveLayout";
+import { NotificationDefaultsEditor } from "./event/NotificationDefaultsEditor";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -690,6 +692,14 @@ export default function EventSettingsPage({ eventId }: Props) {
             />
           </Tooltip>
         </Stack>
+      </SectionCard>
+
+      {/* ── Notification Defaults ── */}
+      <SectionCard title={t("notificationDefaults")} icon={<NotificationsIcon color="action" />}>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+          {t("notificationDefaultsDesc")}
+        </Typography>
+        <NotificationDefaultsEditor eventId={event.id} canEdit={canEdit} />
       </SectionCard>
 
       {/* ── Priority Enrollment ── */}

--- a/src/components/EventSettingsPage.tsx
+++ b/src/components/EventSettingsPage.tsx
@@ -699,7 +699,7 @@ export default function EventSettingsPage({ eventId }: Props) {
         <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
           {t("notificationDefaultsDesc")}
         </Typography>
-        <NotificationDefaultsEditor eventId={event.id} canEdit={canEdit} />
+        <NotificationDefaultsEditor eventId={eventId} canEdit={canEdit} />
       </SectionCard>
 
       {/* ── Priority Enrollment ── */}

--- a/src/components/event/NotificationDefaultsEditor.tsx
+++ b/src/components/event/NotificationDefaultsEditor.tsx
@@ -1,0 +1,73 @@
+import React, { useState, useEffect } from "react";
+import { Stack, Switch, FormControlLabel, Typography, Snackbar } from "@mui/material";
+import { useT } from "~/lib/useT";
+
+interface Defaults {
+  mutePlayerActivity?: boolean;
+  muteReminders?: boolean;
+  mutePostGame?: boolean;
+  muteEventDetails?: boolean;
+}
+
+interface Props {
+  eventId: string;
+  canEdit: boolean;
+}
+
+export function NotificationDefaultsEditor({ eventId, canEdit }: Props) {
+  const t = useT();
+  const [defaults, setDefaults] = useState<Defaults>({});
+  const [snackbar, setSnackbar] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch(`/api/events/${eventId}/notification-defaults`)
+      .then(r => r.json())
+      .then(d => setDefaults(d))
+      .catch(() => {});
+  }, [eventId]);
+
+  const toggle = async (field: keyof Defaults) => {
+    const current = defaults[field] ?? false;
+    const newValue = current ? null : true; // false/undefined → mute (true), true → unmute (null)
+    const updated = { ...defaults, [field]: newValue ?? undefined };
+    if (newValue === null) delete updated[field];
+    setDefaults(updated);
+
+    try {
+      const res = await fetch(`/api/events/${eventId}/notification-defaults`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ [field]: newValue }),
+      });
+      if (res.ok) {
+        setSnackbar(t("notificationsSaved"));
+      }
+    } catch {
+      setSnackbar(t("notificationsSaveError"));
+    }
+  };
+
+  return (
+    <>
+      <Stack spacing={0.5}>
+        <FormControlLabel
+          control={<Switch size="small" checked={!defaults.mutePlayerActivity} onChange={() => toggle("mutePlayerActivity")} disabled={!canEdit} />}
+          label={<Typography variant="body2">{t("playerActivity")}</Typography>}
+        />
+        <FormControlLabel
+          control={<Switch size="small" checked={!defaults.muteReminders} onChange={() => toggle("muteReminders")} disabled={!canEdit} />}
+          label={<Typography variant="body2">{t("gameReminders")}</Typography>}
+        />
+        <FormControlLabel
+          control={<Switch size="small" checked={!defaults.mutePostGame} onChange={() => toggle("mutePostGame")} disabled={!canEdit} />}
+          label={<Typography variant="body2">{t("postGameResults")}</Typography>}
+        />
+        <FormControlLabel
+          control={<Switch size="small" checked={!defaults.muteEventDetails} onChange={() => toggle("muteEventDetails")} disabled={!canEdit} />}
+          label={<Typography variant="body2">{t("eventDetails")}</Typography>}
+        />
+      </Stack>
+      <Snackbar open={!!snackbar} autoHideDuration={3000} onClose={() => setSnackbar(null)} message={snackbar} />
+    </>
+  );
+}

--- a/src/components/event/NotifyButton.tsx
+++ b/src/components/event/NotifyButton.tsx
@@ -1,9 +1,20 @@
 import React, { useState, useEffect } from "react";
-import { Button, Tooltip } from "@mui/material";
+import {
+  Button, Tooltip, Popover, Stack, Typography, Switch,
+  FormControlLabel, Divider,
+} from "@mui/material";
 import NotificationsIcon from "@mui/icons-material/Notifications";
 import NotificationsOffIcon from "@mui/icons-material/NotificationsOff";
 import NotificationsNoneIcon from "@mui/icons-material/NotificationsNone";
 import { useT } from "~/lib/useT";
+
+interface FollowState {
+  following: boolean;
+  mutePlayerActivity: boolean | null;
+  muteReminders: boolean | null;
+  mutePostGame: boolean | null;
+  muteEventDetails: boolean | null;
+}
 
 interface Props {
   eventId: string;
@@ -12,23 +23,24 @@ interface Props {
 
 export function NotifyButton({ eventId, isAuthenticated }: Props) {
   const t = useT();
-  const [following, setFollowing] = useState(false);
+  const [state, setState] = useState<FollowState>({ following: false, mutePlayerActivity: null, muteReminders: null, mutePostGame: null, muteEventDetails: null });
   const [pushDenied, setPushDenied] = useState(false);
   const [loading, setLoading] = useState(false);
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
 
   useEffect(() => {
     if (!isAuthenticated) return;
-    fetch(`/api/events/${eventId}/follow`).then(r => r.json()).then(d => setFollowing(d.following)).catch(() => {});
+    fetch(`/api/events/${eventId}/follow`).then(r => r.json()).then(d => setState(d)).catch(() => {});
     if ("Notification" in window && Notification.permission === "denied") setPushDenied(true);
   }, [eventId, isAuthenticated]);
 
   const handleFollow = async () => {
     setLoading(true);
     try {
-      await fetch(`/api/events/${eventId}/follow`, { method: "POST" });
-      setFollowing(true);
+      const res = await fetch(`/api/events/${eventId}/follow`, { method: "POST" });
+      const data = await res.json();
+      setState(data);
 
-      // Also subscribe this device to push if possible
       if ("serviceWorker" in navigator && "PushManager" in window && Notification.permission !== "denied") {
         try {
           const reg = await navigator.serviceWorker.register("/sw.js");
@@ -46,7 +58,7 @@ export function NotifyButton({ eventId, isAuthenticated }: Props) {
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({ ...sub.toJSON(), locale: navigator.language }),
           });
-        } catch { /* push permission denied or unavailable — follow still worked */ }
+        } catch { /* push permission denied or unavailable */ }
       }
     } finally {
       setLoading(false);
@@ -57,15 +69,41 @@ export function NotifyButton({ eventId, isAuthenticated }: Props) {
     setLoading(true);
     try {
       await fetch(`/api/events/${eventId}/follow`, { method: "DELETE" });
-      setFollowing(false);
+      setState({ following: false, mutePlayerActivity: null, muteReminders: null, mutePostGame: null, muteEventDetails: null });
+      setAnchorEl(null);
     } finally {
       setLoading(false);
     }
   };
 
+  const toggleOverride = async (field: keyof FollowState) => {
+    const current = state[field] as boolean | null;
+    const newValue = current === true ? null : true; // toggle: muted → enabled (null), enabled → muted (true)
+    setState(prev => ({ ...prev, [field]: newValue }));
+    try {
+      const res = await fetch(`/api/events/${eventId}/follow`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ [field]: newValue }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setState(prev => ({ ...prev, ...data }));
+      }
+    } catch { /* revert on error handled by next fetch */ }
+  };
+
+  const handleClick = (e: React.MouseEvent<HTMLElement>) => {
+    if (state.following) {
+      setAnchorEl(e.currentTarget);
+    } else {
+      handleFollow();
+    }
+  };
+
   if (!isAuthenticated) return null;
 
-  if (pushDenied && !following) return (
+  if (pushDenied && !state.following) return (
     <Tooltip title={t("notifyDenied")}>
       <span>
         <Button variant="outlined" size="small" disabled startIcon={<NotificationsOffIcon />} sx={{ flexShrink: 0 }}>
@@ -75,17 +113,54 @@ export function NotifyButton({ eventId, isAuthenticated }: Props) {
     </Tooltip>
   );
 
-  if (following) return (
-    <Button variant="outlined" size="small" color="success" startIcon={<NotificationsIcon />}
-      onClick={handleUnfollow} disabled={loading} sx={{ flexShrink: 0 }}>
-      {t("notifyEnabled")}
-    </Button>
-  );
-
   return (
-    <Button variant="outlined" size="small" startIcon={<NotificationsNoneIcon />}
-      onClick={handleFollow} disabled={loading} sx={{ flexShrink: 0 }}>
-      {t("notifySubscribe")}
-    </Button>
+    <>
+      <Button
+        variant="outlined"
+        size="small"
+        color={state.following ? "success" : "inherit"}
+        startIcon={state.following ? <NotificationsIcon /> : <NotificationsNoneIcon />}
+        onClick={handleClick}
+        disabled={loading}
+        sx={{ flexShrink: 0 }}
+      >
+        {state.following ? t("notifyEnabled") : t("notifySubscribe")}
+      </Button>
+
+      <Popover
+        open={!!anchorEl}
+        anchorEl={anchorEl}
+        onClose={() => setAnchorEl(null)}
+        anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+        transformOrigin={{ vertical: "top", horizontal: "right" }}
+        slotProps={{ paper: { sx: { p: 2, minWidth: 260 } } }}
+      >
+        <Typography variant="subtitle2" fontWeight={600} gutterBottom>
+          {t("notificationSettingsForGame")}
+        </Typography>
+        <Stack spacing={0.5}>
+          <FormControlLabel
+            control={<Switch size="small" checked={state.mutePlayerActivity !== true} onChange={() => toggleOverride("mutePlayerActivity")} />}
+            label={<Typography variant="body2">{t("playerActivity")}</Typography>}
+          />
+          <FormControlLabel
+            control={<Switch size="small" checked={state.muteReminders !== true} onChange={() => toggleOverride("muteReminders")} />}
+            label={<Typography variant="body2">{t("gameReminders")}</Typography>}
+          />
+          <FormControlLabel
+            control={<Switch size="small" checked={state.mutePostGame !== true} onChange={() => toggleOverride("mutePostGame")} />}
+            label={<Typography variant="body2">{t("postGameResults")}</Typography>}
+          />
+          <FormControlLabel
+            control={<Switch size="small" checked={state.muteEventDetails !== true} onChange={() => toggleOverride("muteEventDetails")} />}
+            label={<Typography variant="body2">{t("eventDetails")}</Typography>}
+          />
+        </Stack>
+        <Divider sx={{ my: 1.5 }} />
+        <Button size="small" color="error" onClick={handleUnfollow} disabled={loading} fullWidth>
+          {t("notifyUnsubscribe")}
+        </Button>
+      </Popover>
+    </>
   );
 }

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -468,6 +468,8 @@ const de: TranslationKeys = {
 
   // Notification settings (#112)
   notificationSettings: "Benachrichtigungseinstellungen",
+  notificationSettingsForGame: "Notifications for this game",
+  postGameResults: "Post-game results",
   notificationSettingsDesc: "Wähle, wie und wann du benachrichtigt werden möchtest.",
   emailNotifications: "E-Mail-Benachrichtigungen",
   pushNotifications: "Push-Benachrichtigungen",

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -469,6 +469,8 @@ const de: TranslationKeys = {
   // Notification settings (#112)
   notificationSettings: "Benachrichtigungseinstellungen",
   notificationSettingsForGame: "Notifications for this game",
+  notificationDefaults: "Notification defaults",
+  notificationDefaultsDesc: "Control which notifications are sent to all followers of this game. Individual users can override these in their own settings.",
   postGameResults: "Post-game results",
   notificationSettingsDesc: "Wähle, wie und wann du benachrichtigt werden möchtest.",
   emailNotifications: "E-Mail-Benachrichtigungen",

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -515,6 +515,8 @@ const en = {
   // Notification settings (#112)
   notificationSettings: "Notification settings",
   notificationSettingsDesc: "Choose how and when you want to be notified.",
+  notificationSettingsForGame: "Notifications for this game",
+  postGameResults: "Post-game results",
   emailNotifications: "Email notifications",
   pushNotifications: "Push notifications",
   gameInvites: "Game invites",

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -517,6 +517,8 @@ const en = {
   notificationSettingsDesc: "Choose how and when you want to be notified.",
   notificationSettingsForGame: "Notifications for this game",
   postGameResults: "Post-game results",
+  notificationDefaults: "Notification defaults",
+  notificationDefaultsDesc: "Control which notifications are sent to all followers of this game. Individual users can override these in their own settings.",
   emailNotifications: "Email notifications",
   pushNotifications: "Push notifications",
   gameInvites: "Game invites",

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -469,6 +469,8 @@ const es: TranslationKeys = {
   // Notification settings (#112)
   notificationSettings: "Ajustes de notificaciones",
   notificationSettingsForGame: "Notifications for this game",
+  notificationDefaults: "Notification defaults",
+  notificationDefaultsDesc: "Control which notifications are sent to all followers of this game. Individual users can override these in their own settings.",
   postGameResults: "Post-game results",
   notificationSettingsDesc: "Elige cómo y cuándo quieres recibir notificaciones.",
   emailNotifications: "Notificaciones por email",

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -468,6 +468,8 @@ const es: TranslationKeys = {
 
   // Notification settings (#112)
   notificationSettings: "Ajustes de notificaciones",
+  notificationSettingsForGame: "Notifications for this game",
+  postGameResults: "Post-game results",
   notificationSettingsDesc: "Elige cómo y cuándo quieres recibir notificaciones.",
   emailNotifications: "Notificaciones por email",
   pushNotifications: "Notificaciones push",

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -468,6 +468,8 @@ const fr: TranslationKeys = {
 
   // Notification settings (#112)
   notificationSettings: "Paramètres de notifications",
+  notificationSettingsForGame: "Notifications for this game",
+  postGameResults: "Post-game results",
   notificationSettingsDesc: "Choisis comment et quand tu veux être notifié.",
   emailNotifications: "Notifications par email",
   pushNotifications: "Notifications push",

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -469,6 +469,8 @@ const fr: TranslationKeys = {
   // Notification settings (#112)
   notificationSettings: "Paramètres de notifications",
   notificationSettingsForGame: "Notifications for this game",
+  notificationDefaults: "Notification defaults",
+  notificationDefaultsDesc: "Control which notifications are sent to all followers of this game. Individual users can override these in their own settings.",
   postGameResults: "Post-game results",
   notificationSettingsDesc: "Choisis comment et quand tu veux être notifié.",
   emailNotifications: "Notifications par email",

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -469,6 +469,8 @@ const it: TranslationKeys = {
   // Notification settings (#112)
   notificationSettings: "Impostazioni notifiche",
   notificationSettingsForGame: "Notifications for this game",
+  notificationDefaults: "Notification defaults",
+  notificationDefaultsDesc: "Control which notifications are sent to all followers of this game. Individual users can override these in their own settings.",
   postGameResults: "Post-game results",
   notificationSettingsDesc: "Scegli come e quando vuoi essere notificato.",
   emailNotifications: "Notifiche via email",

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -468,6 +468,8 @@ const it: TranslationKeys = {
 
   // Notification settings (#112)
   notificationSettings: "Impostazioni notifiche",
+  notificationSettingsForGame: "Notifications for this game",
+  postGameResults: "Post-game results",
   notificationSettingsDesc: "Scegli come e quando vuoi essere notificato.",
   emailNotifications: "Notifiche via email",
   pushNotifications: "Notifiche push",

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -516,6 +516,8 @@ const pt: TranslationKeys = {
   // Notification settings (#112)
   notificationSettings: "Definições de notificações",
   notificationSettingsForGame: "Notificações para este jogo",
+  notificationDefaults: "Predefinições de notificações",
+  notificationDefaultsDesc: "Controla que notificações são enviadas a todos os seguidores deste jogo. Utilizadores individuais podem alterar nas suas definições.",
   postGameResults: "Resultados pós-jogo",
   notificationSettingsDesc: "Escolhe como e quando queres ser notificado.",
   emailNotifications: "Notificações por email",

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -515,6 +515,8 @@ const pt: TranslationKeys = {
 
   // Notification settings (#112)
   notificationSettings: "Definições de notificações",
+  notificationSettingsForGame: "Notificações para este jogo",
+  postGameResults: "Resultados pós-jogo",
   notificationSettingsDesc: "Escolhe como e quando queres ser notificado.",
   emailNotifications: "Notificações por email",
   pushNotifications: "Notificações push",

--- a/src/lib/notificationPrefs.server.ts
+++ b/src/lib/notificationPrefs.server.ts
@@ -50,11 +50,12 @@ export function wantsPushWithOverrides(
   prefs: NotificationPrefs,
   type: NotificationJobType,
   overrides: EventFollowOverrides | null,
+  eventDefaults?: EventFollowOverrides | null,
 ): boolean {
   if (!prefs.pushEnabled) return false;
 
-  // Determine which override field applies
-  let override: boolean | null = null;
+  // Determine which override/default field applies
+  let fieldName: keyof EventFollowOverrides | null = null;
   switch (type) {
     case "player_joined":
     case "player_left":
@@ -63,22 +64,27 @@ export function wantsPushWithOverrides(
     case "player_left_promoted":
     case "game_full":
     case "spot_available":
-      override = overrides?.mutePlayerActivity ?? null;
+      fieldName = "mutePlayerActivity";
       break;
     case "event_details":
-      override = overrides?.muteEventDetails ?? null;
+      fieldName = "muteEventDetails";
       break;
     case "reminder":
-      override = overrides?.muteReminders ?? null;
+      fieldName = "muteReminders";
       break;
     case "post_game":
-      override = overrides?.mutePostGame ?? null;
+      fieldName = "mutePostGame";
       break;
   }
 
-  // Per-event override wins if set (true = muted/suppress, false = force-enable)
-  if (override === true) return false;
-  if (override === false) return true;
+  // Resolution order: per-user override → event defaults (admin) → global preference
+  const userOverride = fieldName ? (overrides?.[fieldName] ?? null) : null;
+  if (userOverride === true) return false;
+  if (userOverride === false) return true;
+
+  const eventDefault = fieldName ? (eventDefaults?.[fieldName] ?? null) : null;
+  if (eventDefault === true) return false;
+  if (eventDefault === false) return true;
 
   // Fall back to global preference
   return wantsPushForJobType(prefs, type);

--- a/src/lib/notificationPrefs.server.ts
+++ b/src/lib/notificationPrefs.server.ts
@@ -50,7 +50,7 @@ export function wantsPushWithOverrides(
   prefs: NotificationPrefs,
   type: NotificationJobType,
   overrides: EventFollowOverrides | null,
-  eventDefaults?: EventFollowOverrides | null,
+  eventDefaults?: Partial<Record<keyof EventFollowOverrides, boolean | null>> | null,
 ): boolean {
   if (!prefs.pushEnabled) return false;
 

--- a/src/lib/push.server.ts
+++ b/src/lib/push.server.ts
@@ -217,7 +217,7 @@ async function sendAppPushToEventUsers(
   excludeUserIds: Set<string>,
   jobType?: NotificationJobType,
   reminderType?: "24h" | "2h" | "1h",
-  opts?: { prefsMap?: Map<string, typeof DEFAULTS>; overridesMap?: Map<string, { mutePlayerActivity: boolean | null; muteReminders: boolean | null; mutePostGame: boolean | null; muteEventDetails: boolean | null }> },
+  opts?: { prefsMap?: Map<string, typeof DEFAULTS>; overridesMap?: Map<string, { mutePlayerActivity: boolean | null; muteReminders: boolean | null; mutePostGame: boolean | null; muteEventDetails: boolean | null }>; eventDefaults?: { mutePlayerActivity?: boolean; muteReminders?: boolean; mutePostGame?: boolean; muteEventDetails?: boolean } | null },
 ): Promise<void> {
   const follows = await prisma.eventFollow.findMany({
     where: { eventId },
@@ -246,7 +246,7 @@ async function sendAppPushToEventUsers(
     if (opts?.prefsMap && jobType) {
       const prefs = opts.prefsMap.get(token.userId) ?? DEFAULTS;
       const overrides = opts.overridesMap?.get(token.userId) ?? null;
-      if (!wantsPushWithOverrides(prefs, jobType, overrides)) continue;
+      if (!wantsPushWithOverrides(prefs, jobType, overrides, opts.eventDefaults ?? null)) continue;
       if (jobType === "reminder" && reminderType && !wantsPushReminder(prefs, reminderType)) continue;
     }
     const t = createT((token.locale as Locale) ?? "en");
@@ -281,8 +281,12 @@ export async function sendPushToEvent(
   });
   const event = await prisma.event.findUnique({
     where: { id: eventId },
-    select: { ownerId: true },
+    select: { ownerId: true, notificationDefaults: true },
   });
+
+  const eventDefaults = event?.notificationDefaults
+    ? JSON.parse(event.notificationDefaults) as { mutePlayerActivity?: boolean; muteReminders?: boolean; mutePostGame?: boolean; muteEventDetails?: boolean }
+    : null;
 
   const overridesMap = new Map(follows.map((f) => [f.userId, {
     mutePlayerActivity: f.mutePlayerActivity,
@@ -314,7 +318,7 @@ export async function sendPushToEvent(
 
   // App push (FCM)
   promises.push(
-    sendAppPushToEventUsers(eventId, title, key, params, url, spotsLeft, senderUserIds, jobType, reminderType, { prefsMap, overridesMap }),
+    sendAppPushToEventUsers(eventId, title, key, params, url, spotsLeft, senderUserIds, jobType, reminderType, { prefsMap, overridesMap, eventDefaults }),
   );
 
   // Web push
@@ -334,7 +338,7 @@ export async function sendPushToEvent(
             if (jobType) {
               const prefs = prefsMap.get(sub.userId) ?? DEFAULTS;
               const overrides = overridesMap.get(sub.userId) ?? null;
-              if (!wantsPushWithOverrides(prefs, jobType, overrides)) return;
+              if (!wantsPushWithOverrides(prefs, jobType, overrides, eventDefaults)) return;
               if (jobType === "reminder" && reminderType && !wantsPushReminder(prefs, reminderType)) return;
             }
 

--- a/src/pages/api/events/[id]/notification-defaults.ts
+++ b/src/pages/api/events/[id]/notification-defaults.ts
@@ -1,0 +1,52 @@
+import type { APIRoute } from "astro";
+import { prisma } from "../../../../lib/db.server";
+import { checkOwnership } from "../../../../lib/auth.helpers.server";
+
+const VALID_FIELDS = ["mutePlayerActivity", "muteReminders", "mutePostGame", "muteEventDetails"] as const;
+
+/**
+ * GET /api/events/[id]/notification-defaults — get event notification defaults.
+ * PUT /api/events/[id]/notification-defaults — set defaults (admin/owner only).
+ */
+export const GET: APIRoute = async ({ params }) => {
+  const eventId = params.id ?? "";
+  const event = await prisma.event.findUnique({ where: { id: eventId }, select: { notificationDefaults: true } });
+  if (!event) return Response.json({ error: "Not found." }, { status: 404 });
+  const defaults = event.notificationDefaults ? JSON.parse(event.notificationDefaults) : {};
+  return Response.json(defaults);
+};
+
+export const PUT: APIRoute = async ({ params, request }) => {
+  const eventId = params.id ?? "";
+  const auth = await checkOwnership(request, eventId);
+  if (!auth.isOwner && !auth.isAdmin) return Response.json({ error: "Forbidden" }, { status: 403 });
+
+  let body: Record<string, unknown>;
+  try { body = await request.json(); } catch { return Response.json({ error: "Invalid JSON" }, { status: 400 }); }
+
+  const data: Record<string, boolean | null> = {};
+  for (const field of VALID_FIELDS) {
+    if (field in body) {
+      const val = body[field];
+      if (val !== null && typeof val !== "boolean") return Response.json({ error: `"${field}" must be boolean or null` }, { status: 400 });
+      data[field] = val as boolean | null;
+    }
+  }
+
+  // Merge with existing defaults
+  const event = await prisma.event.findUnique({ where: { id: eventId }, select: { notificationDefaults: true } });
+  const existing = event?.notificationDefaults ? JSON.parse(event.notificationDefaults) : {};
+  const merged = { ...existing, ...data };
+
+  // Remove null values (null = reset to system default)
+  for (const key of Object.keys(merged)) {
+    if (merged[key] === null) delete merged[key];
+  }
+
+  await prisma.event.update({
+    where: { id: eventId },
+    data: { notificationDefaults: Object.keys(merged).length > 0 ? JSON.stringify(merged) : null },
+  });
+
+  return Response.json(merged);
+};


### PR DESCRIPTION
## Summary

Adds the missing web UI for notification control at two levels:

### 1. Per-event settings for followers (bell icon popover)
When following a game, clicking the bell opens a popover with toggles:
- Player activity (joins/leaves)
- Game reminders
- Post-game results
- Event changes (date/location/title)
- Unfollow button

### 2. Admin-level notification defaults (event settings page)
Owners and admins see a **Notification defaults** section in event settings with the same 4 toggles. These control what notifications are sent to **all followers** of the event by default.

For example, an admin can disable player activity notifications for a casual game — individual users can still override this in their own per-event settings.

## Resolution order
1. Per-user per-event override (`EventFollow` columns)
2. Event defaults (`Event.notificationDefaults`, set by admin)
3. Global user preference (`NotificationPreferences`)
4. System default (all enabled)

## Changes
- `NotifyButton.tsx`: rewritten with Popover for per-type toggles
- `NotificationDefaultsEditor.tsx`: new component for event settings
- `EventSettingsPage.tsx`: added notification defaults section
- `PUT/GET /api/events/[id]/notification-defaults`: new endpoint (admin/owner only)
- `Event.notificationDefaults`: new nullable JSON field
- `push.server.ts` + `notificationPrefs.server.ts`: dispatch checks event defaults
- i18n keys added to all 6 locales