### PR TITLE
fix(wear): resolve live game regression bugs

### DIFF
--- a/android-app/wear/src/main/java/dev/convocados/wear/data/api/Models.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/data/api/Models.kt
@@ -37,6 +37,7 @@ data class GameHistory(
     val scoreTwo: Int? = null,
     val teamOneName: String = "",
     val teamTwoName: String = "",
+    val teamsSnapshot: String? = null,
     val editable: Boolean = false,
 )
 

--- a/android-app/wear/src/main/java/dev/convocados/wear/data/api/WearApiClient.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/data/api/WearApiClient.kt
@@ -92,13 +92,19 @@ class WearApiClient @Inject constructor(private val tokenStore: WearTokenStore) 
     @PublishedApi
     internal suspend fun refreshToken() {
         val tokens = tokenStore.getTokens() ?: throw ApiException(401, "No refresh token")
-        val response = client.post("$baseUrl/api/auth/oauth2/token") {
-            contentType(ContentType.Application.FormUrlEncoded)
-            setBody("grant_type=refresh_token&refresh_token=${tokens.refreshToken}&client_id=mobile-app")
+        val response = try {
+            client.post("$baseUrl/api/auth/oauth2/token") {
+                contentType(ContentType.Application.FormUrlEncoded)
+                setBody("grant_type=refresh_token&refresh_token=${tokens.refreshToken}&client_id=mobile-app")
+            }
+        } catch (e: Exception) {
+            throw ApiException(0, "Network error during refresh: ${e.message}")
         }
         if (!response.status.isSuccess()) {
-            tokenStore.clearTokens()
-            throw ApiException(401, "Session expired")
+            if (response.status.value == 401 || response.status.value == 403) {
+                tokenStore.clearTokens()
+            }
+            throw ApiException(response.status.value, "Refresh failed (${response.status.value})")
         }
         val data: OAuthTokenResponse = response.body()
         tokenStore.setTokens(

--- a/android-app/wear/src/main/java/dev/convocados/wear/data/local/WearDatabase.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/data/local/WearDatabase.kt
@@ -21,7 +21,7 @@ import dev.convocados.wear.data.local.entity.WearPlayerEntity
         WearPlayerEntity::class,
         PendingRosterChangeEntity::class,
     ],
-    version = 3,
+    version = 4,
     exportSchema = false,
 )
 abstract class WearDatabase : RoomDatabase() {

--- a/android-app/wear/src/main/java/dev/convocados/wear/data/local/dao/Daos.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/data/local/dao/Daos.kt
@@ -37,7 +37,10 @@ interface WearHistoryDao {
     @Query("SELECT * FROM wear_history WHERE eventId = :eventId ORDER BY dateTime DESC LIMIT 1")
     suspend fun getLatestHistory(eventId: String): WearHistoryEntity?
 
-    @Query("SELECT * FROM wear_history WHERE eventId = :eventId ORDER BY dateTime DESC LIMIT 1")
+    @Query("SELECT * FROM wear_history WHERE eventId = :eventId AND editable = 1 ORDER BY dateTime DESC LIMIT 1")
+    suspend fun getLatestEditableHistory(eventId: String): WearHistoryEntity?
+
+    @Query("SELECT * FROM wear_history WHERE eventId = :eventId AND editable = 1 ORDER BY dateTime DESC LIMIT 1")
     fun observeLatestHistory(eventId: String): Flow<WearHistoryEntity?>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)

--- a/android-app/wear/src/main/java/dev/convocados/wear/data/local/entity/Entities.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/data/local/entity/Entities.kt
@@ -45,6 +45,7 @@ data class WearHistoryEntity(
     val scoreTwo: Int?,
     val teamOneName: String,
     val teamTwoName: String,
+    val teamsSnapshot: String? = null,
     val editable: Boolean,
 )
 

--- a/android-app/wear/src/main/java/dev/convocados/wear/data/repository/WearGameRepository.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/data/repository/WearGameRepository.kt
@@ -6,6 +6,7 @@ import dev.convocados.wear.data.local.dao.WearGameDao
 import dev.convocados.wear.data.local.dao.WearHistoryDao
 import dev.convocados.wear.data.local.entity.WearGameEntity
 import dev.convocados.wear.data.local.entity.WearHistoryEntity
+import dev.convocados.wear.data.repository.WearTeamRepository
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -15,6 +16,7 @@ class WearGameRepository @Inject constructor(
     private val client: WearApiClient,
     private val gameDao: WearGameDao,
     private val historyDao: WearHistoryDao,
+    private val teamRepository: WearTeamRepository,
 ) {
     /** Observable list of all cached games, sorted by dateTime. */
     fun observeGames(): Flow<List<WearGameEntity>> = gameDao.getAllGames()
@@ -26,7 +28,7 @@ class WearGameRepository @Inject constructor(
     fun observeLatestHistory(eventId: String): Flow<WearHistoryEntity?> =
         historyDao.observeLatestHistory(eventId)
 
-    /** Refresh games from the API, falling back to cache on failure. */
+    /** Refresh games from the API, falling back to cache on failure. Also pre-fetches teams for active games. */
     suspend fun refreshGames(): Result<Unit> = try {
         val response = client.get<dev.convocados.wear.data.api.MyGamesResponse>("/api/me/games")
         val owned = response.owned.map { it.toEntity("owned") }
@@ -37,6 +39,11 @@ class WearGameRepository @Inject constructor(
         gameDao.refreshGames("admin", admin)
         gameDao.refreshGames("followed", followed)
         gameDao.refreshGames("archived_owned", archivedOwned)
+        // Pre-fetch teams for all active (non-archived) games
+        val activeIds = (owned + admin + followed).map { it.id }
+        for (id in activeIds) {
+            try { teamRepository.refreshTeams(id) } catch (_: Exception) {}
+        }
         Result.success(Unit)
     } catch (e: Exception) {
         Log.w("WearGameRepo", "Failed to refresh games", e)
@@ -58,6 +65,10 @@ class WearGameRepository @Inject constructor(
     /** Get the latest history entry for a game (from cache). */
     suspend fun getLatestHistory(eventId: String): WearHistoryEntity? =
         historyDao.getLatestHistory(eventId)
+
+    /** Get the latest editable history entry (active game session). */
+    suspend fun getLatestEditableHistory(eventId: String): WearHistoryEntity? =
+        historyDao.getLatestEditableHistory(eventId)
 
     /**
      * Start score tracking for an event (creates today's history record if
@@ -99,6 +110,7 @@ class WearGameRepository @Inject constructor(
             scoreTwo = scoreTwo,
             teamOneName = teamOneName,
             teamTwoName = teamTwoName,
+            teamsSnapshot = teamsSnapshot,
             editable = editable,
         )
 }

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/WearActivity.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/WearActivity.kt
@@ -3,12 +3,21 @@ package dev.convocados.wear.ui
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.wear.ambient.AmbientLifecycleObserver
 import dagger.hilt.android.AndroidEntryPoint
 import dev.convocados.wear.data.auth.WearGoogleSignIn
 import dev.convocados.wear.data.auth.WearTokenStore
 import dev.convocados.wear.ui.navigation.WearNavigation
 import dev.convocados.wear.ui.theme.ConvocadosWearTheme
 import javax.inject.Inject
+
+/** Whether the display is in ambient (always-on) mode. */
+val LocalAmbientMode = compositionLocalOf { false }
 
 @AndroidEntryPoint
 class WearActivity : ComponentActivity() {
@@ -19,11 +28,30 @@ class WearActivity : ComponentActivity() {
     @Inject
     lateinit var googleSignIn: WearGoogleSignIn
 
+    private var isAmbient by mutableStateOf(false)
+
+    private val ambientCallback = object : AmbientLifecycleObserver.AmbientLifecycleCallback {
+        override fun onEnterAmbient(ambientDetails: AmbientLifecycleObserver.AmbientDetails) {
+            isAmbient = true
+        }
+        override fun onExitAmbient() {
+            isAmbient = false
+        }
+    }
+
+    private lateinit var ambientObserver: AmbientLifecycleObserver
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        ambientObserver = AmbientLifecycleObserver(this, ambientCallback)
+        lifecycle.addObserver(ambientObserver)
+
         setContent {
             ConvocadosWearTheme {
-                WearNavigation(tokenStore, googleSignIn)
+                CompositionLocalProvider(LocalAmbientMode provides isAmbient) {
+                    WearNavigation(tokenStore, googleSignIn)
+                }
             }
         }
     }

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/navigation/WearNavigation.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/navigation/WearNavigation.kt
@@ -18,12 +18,11 @@ import dev.convocados.wear.ui.screen.quick.QuickScoreViewModel
 import dev.convocados.wear.ui.screen.quick.QuickSetupScreen
 import dev.convocados.wear.ui.screen.score.ScoreScreen
 import dev.convocados.wear.ui.screen.score.ScoreViewModel
+import dev.convocados.wear.ui.screen.settings.GameSettingsViewModel
 import dev.convocados.wear.ui.screen.teams.TeamsScreen
 import dev.convocados.wear.ui.screen.teams.TeamsViewModel
 
 import com.google.android.horologist.compose.layout.AppScaffold
-import com.google.android.horologist.compose.layout.ScreenScaffold
-import com.google.android.horologist.compose.layout.rememberColumnState
 
 @Composable
 fun WearNavigation(tokenStore: WearTokenStore, googleSignIn: WearGoogleSignIn) {
@@ -85,21 +84,13 @@ fun WearNavigation(tokenStore: WearTokenStore, googleSignIn: WearGoogleSignIn) {
             composable(WearRoutes.TEAMS) { backStackEntry ->
                 val eventId = backStackEntry.arguments?.getString("eventId") ?: return@composable
                 val viewModel: TeamsViewModel = hiltViewModel()
+                val settingsViewModel: GameSettingsViewModel = hiltViewModel()
                 TeamsScreen(
                     eventId = eventId,
                     viewModel = viewModel,
+                    settingsViewModel = settingsViewModel,
                     onDone = { navController.popBackStack() },
-                    onSettings = { navController.navigate(WearRoutes.settings(eventId)) },
-                )
-            }
-
-            composable(WearRoutes.SETTINGS) { backStackEntry ->
-                val eventId = backStackEntry.arguments?.getString("eventId") ?: return@composable
-                val viewModel: dev.convocados.wear.ui.screen.settings.GameSettingsViewModel = hiltViewModel()
-                dev.convocados.wear.ui.screen.settings.GameSettingsScreen(
-                    eventId = eventId,
-                    viewModel = viewModel,
-                    onBack = { navController.popBackStack() },
+                    onKickoff = { navController.popBackStack() },
                 )
             }
 

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/navigation/WearRoutes.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/navigation/WearRoutes.kt
@@ -6,11 +6,9 @@ object WearRoutes {
     const val GAMES = "games"
     const val SCORE = "score/{eventId}"
     const val TEAMS = "teams/{eventId}"
-    const val SETTINGS = "settings/{eventId}"
     const val QUICK_SETUP = "quick_setup"
     const val QUICK_SCORE = "quick_score"
 
     fun score(eventId: String) = "score/$eventId"
     fun teams(eventId: String) = "teams/$eventId"
-    fun settings(eventId: String) = "settings/$eventId"
 }

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/score/ScoreScreen.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/score/ScoreScreen.kt
@@ -29,6 +29,8 @@ import dev.convocados.wear.util.sportDurationMinutes
 import kotlinx.coroutines.delay
 import java.time.Instant
 
+import dev.convocados.wear.ui.LocalAmbientMode
+
 @OptIn(ExperimentalHorologistApi::class)
 @Composable
 fun ScoreScreen(
@@ -40,6 +42,7 @@ fun ScoreScreen(
 
     val state by viewModel.uiState.collectAsState()
     val columnState = rememberColumnState()
+    val isAmbient = LocalAmbientMode.current
 
     ScreenScaffold(scrollState = columnState) {
         Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
@@ -102,16 +105,18 @@ fun ScoreScreen(
                     )
                 }
                 else -> {
-                    // Teams exist and are editable — go straight to score tracking,
-                    // regardless of the game's time window.
-                    ScoreEditor(
-                        state = state,
-                        onIncrementOne = viewModel::incrementScoreOne,
-                        onDecrementOne = viewModel::decrementScoreOne,
-                        onIncrementTwo = viewModel::incrementScoreTwo,
-                        onDecrementTwo = viewModel::decrementScoreTwo,
-                        onTeams = onTeams,
-                    )
+                    if (isAmbient) {
+                        AmbientScoreDisplay(state = state)
+                    } else {
+                        ScoreEditor(
+                            state = state,
+                            onIncrementOne = viewModel::incrementScoreOne,
+                            onDecrementOne = viewModel::decrementScoreOne,
+                            onIncrementTwo = viewModel::incrementScoreTwo,
+                            onDecrementTwo = viewModel::decrementScoreTwo,
+                            onTeams = onTeams,
+                        )
+                    }
                 }
             }
         }
@@ -236,3 +241,52 @@ private fun ScoreEditor(
  */
 
 /** Game-progress indicator — see ScoreComponents.kt */
+
+/** Simplified white-on-black score display for ambient (always-on) mode. */
+@Composable
+private fun AmbientScoreDisplay(state: ScoreUiState) {
+    var now by remember { mutableStateOf(Instant.now()) }
+    // Update once per minute in ambient to save power
+    LaunchedEffect(Unit) {
+        while (true) {
+            now = Instant.now()
+            delay(60_000)
+        }
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(androidx.compose.ui.graphics.Color.Black),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            // Score
+            Text(
+                text = "${state.scoreOne} - ${state.scoreTwo}",
+                style = MaterialTheme.typography.displayMedium,
+                color = androidx.compose.ui.graphics.Color.White,
+            )
+            // Team names
+            Text(
+                text = "${state.teamOneName} vs ${state.teamTwoName}",
+                style = MaterialTheme.typography.labelSmall,
+                color = androidx.compose.ui.graphics.Color.White.copy(alpha = 0.7f),
+            )
+            // Game clock
+            val kickoffMs = state.kickoffEpochMs
+            if (kickoffMs != null) {
+                val elapsedMs = now.toEpochMilli() - kickoffMs
+                if (elapsedMs >= 0) {
+                    val s = elapsedMs / 1000
+                    Text(
+                        text = "%d:%02d".format(s / 60, s % 60),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = androidx.compose.ui.graphics.Color.White.copy(alpha = 0.5f),
+                        modifier = Modifier.padding(top = 4.dp),
+                    )
+                }
+            }
+        }
+    }
+}

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/score/ScoreViewModel.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/score/ScoreViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.viewModelScope
 import androidx.work.WorkManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dev.convocados.wear.data.api.ApiException
-import dev.convocados.wear.data.alarm.GameAlarmScheduler
 import dev.convocados.wear.data.alarm.GameSettingsStore
 import dev.convocados.wear.data.alarm.computeAlarmTimes
 import dev.convocados.wear.data.local.entity.WearGameEntity
@@ -42,7 +41,6 @@ class ScoreViewModel @Inject constructor(
     private val repository: WearGameRepository,
     private val scoreRepository: WearScoreRepository,
     private val settingsStore: GameSettingsStore,
-    private val alarmScheduler: GameAlarmScheduler,
     private val workManager: WorkManager,
 ) : ViewModel() {
 
@@ -92,11 +90,6 @@ class ScoreViewModel @Inject constructor(
                 }
             }
         }
-    }
-
-    /** Leaving the game cancels all of its pending alarms. */
-    override fun onCleared() {
-        if (eventId.isNotEmpty()) alarmScheduler.cancelAll(eventId)
     }
 
     /** Start tracking the score for this game (creates today's history record). */

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/settings/GameSettingsViewModel.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/settings/GameSettingsViewModel.kt
@@ -65,7 +65,11 @@ class GameSettingsViewModel @Inject constructor(
         }
     }
 
-    fun kickoffNow() = apply { it.copy(kickoffEpochMs = System.currentTimeMillis()) }
+    fun kickoffNow() {
+        apply { it.copy(kickoffEpochMs = System.currentTimeMillis()) }
+        // Also start the game (idempotent — reuses existing history record)
+        viewModelScope.launch { gameRepository.startGame(eventId) }
+    }
 
     fun nudgeKickoff(deltaMinutes: Int) = apply {
         it.copy(kickoffEpochMs = (it.kickoffEpochMs ?: scheduledKickoffMs) + deltaMinutes * 60_000L)

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/teams/TeamsScreen.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/teams/TeamsScreen.kt
@@ -1,5 +1,7 @@
 package dev.convocados.wear.ui.screen.teams
 
+import android.content.Intent
+import android.provider.Settings
 import androidx.compose.foundation.layout.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -8,6 +10,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -21,40 +24,45 @@ import com.google.android.horologist.compose.layout.ScalingLazyColumnDefaults
 import com.google.android.horologist.compose.layout.ScreenScaffold
 import com.google.android.horologist.compose.layout.rememberColumnState
 import dev.convocados.wear.R
+import dev.convocados.wear.data.alarm.AlarmType
+import dev.convocados.wear.data.alarm.GameAlarm
 import dev.convocados.wear.data.local.entity.WearPlayerEntity
+import dev.convocados.wear.ui.screen.settings.GameSettingsViewModel
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+private val timeFormat = DateTimeFormatter.ofPattern("HH:mm")
 
 @OptIn(ExperimentalHorologistApi::class)
 @Composable
 fun TeamsScreen(
     eventId: String,
     viewModel: TeamsViewModel,
+    settingsViewModel: GameSettingsViewModel,
     onDone: () -> Unit = {},
-    onSettings: () -> Unit = {},
+    onKickoff: () -> Unit = {},
 ) {
-    LaunchedEffect(eventId) { viewModel.load(eventId) }
+    LaunchedEffect(eventId) {
+        viewModel.load(eventId)
+        settingsViewModel.load(eventId)
+    }
 
     val state by viewModel.uiState.collectAsState()
-    val columnState = rememberColumnState(
-        ScalingLazyColumnDefaults.responsive()
-    )
+    val settingsState by settingsViewModel.uiState.collectAsState()
+    val context = LocalContext.current
+    val columnState = rememberColumnState(ScalingLazyColumnDefaults.responsive())
 
-    // Edge over-scroll gestures: pull down at the top -> score; pull up at the bottom -> settings.
+    // Pull down at top -> back to score
     val pullThreshold = with(LocalDensity.current) { 72.dp.toPx() }
     var pulled by remember { mutableFloatStateOf(0f) }
-    val edgeNav = remember(onDone, onSettings) {
+    val edgeNav = remember(onDone) {
         object : NestedScrollConnection {
             override fun onPostScroll(consumed: Offset, available: Offset, source: NestedScrollSource): Offset {
-                when {
-                    available.y > 0f && !columnState.state.canScrollBackward -> {
-                        pulled += available.y
-                        if (pulled >= pullThreshold) { pulled = 0f; onDone() }
-                    }
-                    available.y < 0f && !columnState.state.canScrollForward -> {
-                        pulled += available.y
-                        if (pulled <= -pullThreshold) { pulled = 0f; onSettings() }
-                    }
-                    else -> pulled = 0f
-                }
+                if (available.y > 0f && !columnState.state.canScrollBackward) {
+                    pulled += available.y
+                    if (pulled >= pullThreshold) { pulled = 0f; onDone() }
+                } else if (available.y < 0f) pulled = 0f
                 return Offset.Zero
             }
         }
@@ -72,7 +80,7 @@ fun TeamsScreen(
                     columnState = columnState,
                     modifier = Modifier.fillMaxSize().nestedScroll(edgeNav),
                 ) {
-                    // Header
+                    // ── Teams section ──────────────────────────────────
                     item {
                         ListHeader {
                             Text(
@@ -83,7 +91,6 @@ fun TeamsScreen(
                         }
                     }
 
-                    // Team 1 header and players
                     item {
                         Text(
                             text = state.teamOneName,
@@ -104,17 +111,15 @@ fun TeamsScreen(
                     }
 
                     items(state.teamOnePlayers, key = { "t1-${it.id}" }) { player ->
-                        PlayerChip(
-                            player = player,
-                            targetTeam = "2",
-                            onMove = { viewModel.movePlayerToTeamTwo(player) },
-                        )
+                        if (state.isReadOnly) {
+                            ReadOnlyPlayerChip(player)
+                        } else {
+                            PlayerChip(player = player, targetTeam = "2", onMove = { viewModel.movePlayerToTeamTwo(player) })
+                        }
                     }
 
-                    // Spacer
                     item { Spacer(modifier = Modifier.height(6.dp)) }
 
-                    // Team 2 header and players
                     item {
                         Text(
                             text = state.teamTwoName,
@@ -135,14 +140,13 @@ fun TeamsScreen(
                     }
 
                     items(state.teamTwoPlayers, key = { "t2-${it.id}" }) { player ->
-                        PlayerChip(
-                            player = player,
-                            targetTeam = "1",
-                            onMove = { viewModel.movePlayerToTeamOne(player) },
-                        )
+                        if (state.isReadOnly) {
+                            ReadOnlyPlayerChip(player)
+                        } else {
+                            PlayerChip(player = player, targetTeam = "1", onMove = { viewModel.movePlayerToTeamOne(player) })
+                        }
                     }
 
-                    // Unassigned players
                     if (state.unassigned.isNotEmpty()) {
                         item { Spacer(modifier = Modifier.height(6.dp)) }
                         item {
@@ -162,7 +166,6 @@ fun TeamsScreen(
                         }
                     }
 
-                    // Bench players (read-only)
                     if (state.bench.isNotEmpty()) {
                         item { Spacer(modifier = Modifier.height(6.dp)) }
                         item {
@@ -184,7 +187,6 @@ fun TeamsScreen(
                         }
                     }
 
-                    // Saving indicator
                     if (state.isSaving) {
                         item {
                             Text(
@@ -195,7 +197,6 @@ fun TeamsScreen(
                         }
                     }
 
-                    // Error message
                     state.error?.let { error ->
                         item {
                             Text(
@@ -210,9 +211,97 @@ fun TeamsScreen(
                         }
                     }
 
+                    // ── Game Settings section ─────────────────────────
+                    item { Spacer(modifier = Modifier.height(12.dp)) }
+                    item {
+                        ListHeader { Text("Game settings", color = MaterialTheme.colorScheme.primary) }
+                    }
+
+                    // Kickoff
+                    item {
+                        val time = Instant.ofEpochMilli(settingsState.kickoffEpochMs)
+                            .atZone(ZoneId.systemDefault()).format(timeFormat)
+                        Text(
+                            text = "Kickoff $time" + if (settingsState.isKickoffOverridden) " (set)" else "",
+                            style = MaterialTheme.typography.labelMedium,
+                            modifier = Modifier.fillMaxWidth(),
+                            textAlign = TextAlign.Center,
+                        )
+                    }
+                    item {
+                        Button(
+                            onClick = {
+                                settingsViewModel.kickoffNow()
+                                onKickoff()
+                            },
+                            modifier = Modifier.fillMaxWidth(),
+                        ) { Text("Kick off now") }
+                    }
+                    item {
+                        Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                            CompactButton(onClick = { settingsViewModel.nudgeKickoff(-1) }) { Text("−1m") }
+                            CompactButton(onClick = { settingsViewModel.nudgeKickoff(1) }) { Text("+1m") }
+                            if (settingsState.isKickoffOverridden) {
+                                CompactButton(onClick = { settingsViewModel.resetKickoff() }) { Text("Reset") }
+                            }
+                        }
+                    }
+
+                    // Exact-alarm permission
+                    if (!settingsState.canScheduleExact) {
+                        item {
+                            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                                Text(
+                                    text = "Alarms may be delayed. Allow exact alarms for on-time buzzes.",
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.error,
+                                    textAlign = TextAlign.Center,
+                                )
+                                CompactButton(onClick = {
+                                    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
+                                        runCatching {
+                                            context.startActivity(
+                                                Intent(Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM)
+                                                    .setData(android.net.Uri.parse("package:${context.packageName}"))
+                                                    .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+                                            )
+                                        }
+                                    }
+                                }) { Text("Allow") }
+                            }
+                        }
+                    }
+
+                    // Alarms
+                    item {
+                        Text(
+                            text = "Vibration alarms",
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                    }
+
+                    items(settingsState.alarms, key = { it.id }) { alarm ->
+                        AlarmRow(
+                            alarm = alarm,
+                            onToggle = { settingsViewModel.toggleAlarm(alarm.id) },
+                            onMinus = { settingsViewModel.changeMinute(alarm.id, -1) },
+                            onPlus = { settingsViewModel.changeMinute(alarm.id, 1) },
+                            onRemove = { settingsViewModel.removeAlarm(alarm.id) },
+                        )
+                    }
+
+                    item {
+                        Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                            CompactButton(onClick = { settingsViewModel.addRecurring() }) { Text("+ Every") }
+                            CompactButton(onClick = { settingsViewModel.addSingle() }) { Text("+ Once") }
+                        }
+                    }
+
                     // Done button
                     item {
-                        Spacer(modifier = Modifier.height(4.dp))
+                        Spacer(modifier = Modifier.height(8.dp))
                         CompactButton(onClick = onDone) {
                             Text(stringResource(R.string.done))
                         }
@@ -224,63 +313,54 @@ fun TeamsScreen(
 }
 
 @Composable
-private fun PlayerChip(
-    player: WearPlayerEntity,
-    targetTeam: String,
-    onMove: () -> Unit,
-) {
-    Button(
-        onClick = onMove,
-        modifier = Modifier.fillMaxWidth(),
-        label = {
-            Text(
-                text = player.name,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
-        },
-        secondaryLabel = {
-            Text(
-                text = stringResource(R.string.move_to_team, targetTeam),
-                style = MaterialTheme.typography.labelSmall,
-            )
-        },
+private fun ReadOnlyPlayerChip(player: WearPlayerEntity) {
+    Text(
+        text = player.name,
+        style = MaterialTheme.typography.labelMedium,
+        color = MaterialTheme.colorScheme.onSurface,
+        modifier = Modifier.fillMaxWidth().padding(vertical = 2.dp),
+        textAlign = TextAlign.Center,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
     )
 }
 
 @Composable
-private fun UnassignedPlayerChip(
-    player: WearPlayerEntity,
-    onMoveToOne: () -> Unit,
-    onMoveToTwo: () -> Unit,
-) {
-    Column(
+private fun PlayerChip(player: WearPlayerEntity, targetTeam: String, onMove: () -> Unit) {
+    Button(
+        onClick = onMove,
         modifier = Modifier.fillMaxWidth(),
-        horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
+        label = { Text(text = player.name, maxLines = 1, overflow = TextOverflow.Ellipsis) },
+        secondaryLabel = { Text(text = stringResource(R.string.move_to_team, targetTeam), style = MaterialTheme.typography.labelSmall) },
+    )
+}
+
+@Composable
+private fun UnassignedPlayerChip(player: WearPlayerEntity, onMoveToOne: () -> Unit, onMoveToTwo: () -> Unit) {
+    Column(modifier = Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
+        Text(text = player.name, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurface, maxLines = 1, overflow = TextOverflow.Ellipsis)
+        Row(horizontalArrangement = Arrangement.spacedBy(4.dp), modifier = Modifier.padding(top = 2.dp)) {
+            CompactButton(onClick = onMoveToOne) { Text(text = stringResource(R.string.move_to_team, "1"), style = MaterialTheme.typography.labelSmall) }
+            CompactButton(onClick = onMoveToTwo) { Text(text = stringResource(R.string.move_to_team, "2"), style = MaterialTheme.typography.labelSmall) }
+        }
+    }
+}
+
+@Composable
+private fun AlarmRow(alarm: GameAlarm, onToggle: () -> Unit, onMinus: () -> Unit, onPlus: () -> Unit, onRemove: () -> Unit) {
+    val label = if (alarm.type == AlarmType.RECURRING) "Every ${alarm.minute}m" else "At ${alarm.minute}m"
+    val dots = "•".repeat(alarm.pulses)
+    Column(modifier = Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
         Text(
-            text = player.name,
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurface,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
+            text = "$label  $dots",
+            style = MaterialTheme.typography.labelMedium,
+            color = if (alarm.enabled) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onSurfaceVariant,
         )
-        Row(
-            horizontalArrangement = Arrangement.spacedBy(4.dp),
-            modifier = Modifier.padding(top = 2.dp),
-        ) {
-            CompactButton(onClick = onMoveToOne) {
-                Text(
-                    text = stringResource(R.string.move_to_team, "1"),
-                    style = MaterialTheme.typography.labelSmall,
-                )
-            }
-            CompactButton(onClick = onMoveToTwo) {
-                Text(
-                    text = stringResource(R.string.move_to_team, "2"),
-                    style = MaterialTheme.typography.labelSmall,
-                )
-            }
+        Row(horizontalArrangement = Arrangement.spacedBy(4.dp), modifier = Modifier.padding(top = 2.dp)) {
+            CompactButton(onClick = onMinus) { Text("−") }
+            CompactButton(onClick = onPlus) { Text("+") }
+            CompactButton(onClick = onToggle) { Text(if (alarm.enabled) "On" else "Off") }
+            CompactButton(onClick = onRemove) { Text("✕") }
         }
     }
 }

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/teams/TeamsViewModel.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/teams/TeamsViewModel.kt
@@ -5,10 +5,13 @@ import androidx.lifecycle.viewModelScope
 import androidx.work.WorkManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dev.convocados.wear.data.local.entity.WearPlayerEntity
+import dev.convocados.wear.data.repository.WearGameRepository
 import dev.convocados.wear.data.repository.WearTeamRepository
 import dev.convocados.wear.data.sync.ScoreSyncWorker
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
 import javax.inject.Inject
 
 data class TeamsUiState(
@@ -21,12 +24,23 @@ data class TeamsUiState(
     val isLoading: Boolean = true,
     val isSaving: Boolean = false,
     val saved: Boolean = false,
+    val isReadOnly: Boolean = false, // true when showing snapshot from active game
     val error: String? = null,
 )
+
+@Serializable
+private data class SnapshotTeam(
+    val team: String = "",
+    val players: List<SnapshotPlayer> = emptyList(),
+)
+
+@Serializable
+private data class SnapshotPlayer(val name: String, val order: Int = 0)
 
 @HiltViewModel
 class TeamsViewModel @Inject constructor(
     private val repository: WearTeamRepository,
+    private val gameRepository: WearGameRepository,
     private val workManager: WorkManager,
 ) : ViewModel() {
 
@@ -34,6 +48,7 @@ class TeamsViewModel @Inject constructor(
     val uiState: StateFlow<TeamsUiState> = _uiState.asStateFlow()
 
     private var eventId: String = ""
+    private val json = Json { ignoreUnknownKeys = true }
 
     fun load(eventId: String) {
         if (this.eventId == eventId && !_uiState.value.isLoading) return
@@ -42,25 +57,73 @@ class TeamsViewModel @Inject constructor(
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true) }
 
-            // Refresh from API first
-            repository.refreshTeams(eventId)
+            // Check if there's an active (editable) history with a teams snapshot
+            val activeHistory = gameRepository.getLatestEditableHistory(eventId)
+            val snapshot = activeHistory?.teamsSnapshot
 
-            // Then observe local cache
-            repository.observePlayers(eventId).collect { players ->
-                _uiState.update { state ->
-                    state.copy(
-                        teamOnePlayers = players.filter { it.teamAssignment == "teamOne" }.sortedBy { it.order },
-                        teamTwoPlayers = players.filter { it.teamAssignment == "teamTwo" }.sortedBy { it.order },
-                        unassigned = players.filter { it.teamAssignment == "unassigned" }.sortedBy { it.order },
-                        bench = players.filter { it.teamAssignment == "bench" }.sortedBy { it.order },
-                        isLoading = false,
-                    )
-                }
+            if (snapshot != null) {
+                // Show snapshot teams from the active game (read-only)
+                showSnapshotTeams(snapshot, activeHistory.teamOneName, activeHistory.teamTwoName)
+            } else {
+                // No active game — show live roster (editable for upcoming game)
+                showLiveRoster(eventId)
             }
         }
     }
 
+    private fun showSnapshotTeams(snapshot: String, teamOneName: String, teamTwoName: String) {
+        val teams = try {
+            json.decodeFromString<List<SnapshotTeam>>(snapshot)
+        } catch (_: Exception) {
+            _uiState.update { it.copy(isLoading = false, isReadOnly = true) }
+            return
+        }
+
+        val teamOne = teams.getOrNull(0)
+        val teamTwo = teams.getOrNull(1)
+
+        _uiState.update {
+            it.copy(
+                teamOneName = teamOne?.team?.ifBlank { teamOneName } ?: teamOneName,
+                teamTwoName = teamTwo?.team?.ifBlank { teamTwoName } ?: teamTwoName,
+                teamOnePlayers = teamOne?.players?.mapIndexed { i, p ->
+                    WearPlayerEntity(id = "snap-t1-$i", eventId = eventId, name = p.name, order = p.order, teamAssignment = "teamOne")
+                } ?: emptyList(),
+                teamTwoPlayers = teamTwo?.players?.mapIndexed { i, p ->
+                    WearPlayerEntity(id = "snap-t2-$i", eventId = eventId, name = p.name, order = p.order, teamAssignment = "teamTwo")
+                } ?: emptyList(),
+                unassigned = emptyList(),
+                bench = emptyList(),
+                isLoading = false,
+                isReadOnly = true,
+            )
+        }
+    }
+
+    private fun showLiveRoster(eventId: String) {
+        viewModelScope.launch {
+            // Observe local cache immediately
+            launch {
+                repository.observePlayers(eventId).collect { players ->
+                    _uiState.update { state ->
+                        state.copy(
+                            teamOnePlayers = players.filter { it.teamAssignment == "teamOne" }.sortedBy { it.order },
+                            teamTwoPlayers = players.filter { it.teamAssignment == "teamTwo" }.sortedBy { it.order },
+                            unassigned = players.filter { it.teamAssignment == "unassigned" }.sortedBy { it.order },
+                            bench = players.filter { it.teamAssignment == "bench" }.sortedBy { it.order },
+                            isLoading = false,
+                            isReadOnly = false,
+                        )
+                    }
+                }
+            }
+            // Non-blocking refresh from API
+            launch { repository.refreshTeams(eventId) }
+        }
+    }
+
     fun movePlayerToTeamOne(player: WearPlayerEntity) {
+        if (_uiState.value.isReadOnly) return
         val current = _uiState.value
         val optimisticState = current.copy(
             teamOnePlayers = (current.teamOnePlayers + player.copy(teamAssignment = "teamOne")).sortedBy { it.order },
@@ -70,14 +133,11 @@ class TeamsViewModel @Inject constructor(
             error = null,
         )
         _uiState.value = optimisticState
-
-        val teamOneIds = optimisticState.teamOnePlayers.map { it.id }
-        val teamTwoIds = optimisticState.teamTwoPlayers.map { it.id }
-
-        syncRoster(teamOneIds, teamTwoIds)
+        syncRoster(optimisticState.teamOnePlayers.map { it.id }, optimisticState.teamTwoPlayers.map { it.id })
     }
 
     fun movePlayerToTeamTwo(player: WearPlayerEntity) {
+        if (_uiState.value.isReadOnly) return
         val current = _uiState.value
         val optimisticState = current.copy(
             teamTwoPlayers = (current.teamTwoPlayers + player.copy(teamAssignment = "teamTwo")).sortedBy { it.order },
@@ -87,14 +147,11 @@ class TeamsViewModel @Inject constructor(
             error = null,
         )
         _uiState.value = optimisticState
-
-        val teamOneIds = optimisticState.teamOnePlayers.map { it.id }
-        val teamTwoIds = optimisticState.teamTwoPlayers.map { it.id }
-
-        syncRoster(teamOneIds, teamTwoIds)
+        syncRoster(optimisticState.teamOnePlayers.map { it.id }, optimisticState.teamTwoPlayers.map { it.id })
     }
 
     fun movePlayerToUnassigned(player: WearPlayerEntity) {
+        if (_uiState.value.isReadOnly) return
         val current = _uiState.value
         val optimisticState = current.copy(
             unassigned = (current.unassigned + player.copy(teamAssignment = "unassigned")).sortedBy { it.order },
@@ -104,11 +161,7 @@ class TeamsViewModel @Inject constructor(
             error = null,
         )
         _uiState.value = optimisticState
-
-        val teamOneIds = optimisticState.teamOnePlayers.map { it.id }
-        val teamTwoIds = optimisticState.teamTwoPlayers.map { it.id }
-
-        syncRoster(teamOneIds, teamTwoIds)
+        syncRoster(optimisticState.teamOnePlayers.map { it.id }, optimisticState.teamTwoPlayers.map { it.id })
     }
 
     private fun syncRoster(teamOneIds: List<String>, teamTwoIds: List<String>) {


### PR DESCRIPTION
## Summary

Fixes 7 WearOS regression bugs discovered during live game testing.

### Changes

| Issue | Fix |
|-------|-----|
| Session keeps expiring | Only clear tokens on explicit 401/403 from refresh endpoint; keep tokens on network errors |
| Settings animation goes sideways | Merged Settings into Teams screen as single scrollable page |
| Teams empty | Pre-fetch teams during game list sync + show cached data immediately (non-blocking refresh) |
| Kick off now doesn't start timer | `kickoffNow()` also calls idempotent `startGame()` then navigates back to Score |
| Screen turns off, need to reopen app | Ambient mode (always-on) with simplified white-on-black score + clock |
| Alarms not working | Remove `onCleared()` alarm cancellation; alarms survive ViewModel destruction |
| Stale history + wrong teams | Filter history by `editable=1`; show `teamsSnapshot` from active game (read-only) |

### Data model fix

The root cause of the stale data issue: the watch conflated "live team roster" (for next week) with "teams that played in the current game session." Now:
- ScoreScreen only shows editable history (active games)
- TeamsScreen shows the `teamsSnapshot` from the active history (read-only) or the live roster (editable) if no game is in progress

### Testing

- Build compiles with `./gradlew :wear:compileDebugKotlin` ✓
- Installed on SM-R870 device via wireless ADB
- Exact alarm permission granted via `adb shell appops`

Closes #402