### PR TITLE
feat: Wear OS auto-navigate + auth enforcement on score/team updates

### DIFF
--- a/android-app/app/src/main/java/dev/convocados/ui/screen/event/EventDetailScreen.kt
+++ b/android-app/app/src/main/java/dev/convocados/ui/screen/event/EventDetailScreen.kt
@@ -243,6 +243,10 @@ class EventDetailViewModel @Inject constructor(
                     delay(3000)
                     _state.value = _state.value.copy(teamMoveUndo = null)
                 }
+                .onFailure { e ->
+                    val msg = parseApiErrorMessage(e) ?: "Failed to update teams"
+                    _state.value = _state.value.copy(error = msg)
+                }
         }
     }
 
@@ -273,6 +277,10 @@ class EventDetailViewModel @Inject constructor(
         viewModelScope.launch {
             runCatching { api.updateScore(eventId, historyId, s1, s2) }
                 .onSuccess { repository.refreshEventDetail(eventId) }
+                .onFailure { e ->
+                    val msg = parseApiErrorMessage(e) ?: "Failed to update score"
+                    _state.value = _state.value.copy(error = msg)
+                }
         }
     }
 
@@ -288,6 +296,12 @@ class EventDetailViewModel @Inject constructor(
 
     suspend fun fetchCalendarIcs(eventId: String): String? =
         runCatching { client.fetchCalendarIcs(eventId) }.getOrNull()
+}
+
+private fun parseApiErrorMessage(e: Throwable): String? {
+    val body = e.message ?: return null
+    val match = Regex(""""error"\s*:\s*"([^"]+)"""").find(body)
+    return match?.groupValues?.get(1)
 }
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalSharedTransitionApi::class)

--- a/android-app/app/src/main/java/dev/convocados/ui/screen/history/HistoryDetailScreen.kt
+++ b/android-app/app/src/main/java/dev/convocados/ui/screen/history/HistoryDetailScreen.kt
@@ -46,6 +46,8 @@ class HistoryDetailViewModel @Inject constructor(private val api: ConvocadosApi)
     val payments: StateFlow<List<PaymentEntry>> = _payments
     private val _saving = MutableStateFlow(false)
     val saving: StateFlow<Boolean> = _saving
+    private val _error = MutableStateFlow<String?>(null)
+    val error: StateFlow<String?> = _error
 
     fun load(eventId: String, historyId: String) {
         viewModelScope.launch {
@@ -93,9 +95,13 @@ class HistoryDetailViewModel @Inject constructor(private val api: ConvocadosApi)
     fun updateScore(eventId: String, historyId: String, scoreOne: Int, scoreTwo: Int) {
         viewModelScope.launch {
             _saving.value = true
-            runCatching { api.updateScore(eventId, historyId, scoreOne, scoreTwo) }.onSuccess {
-                _history.value = it
-            }
+            runCatching { api.updateScore(eventId, historyId, scoreOne, scoreTwo) }
+                .onSuccess { _history.value = it }
+                .onFailure { e ->
+                    val body = e.message ?: ""
+                    val match = Regex(""""error"\s*:\s*"([^"]+)"""").find(body)
+                    _error.value = match?.groupValues?.get(1) ?: "Failed to update score"
+                }
             _saving.value = false
         }
     }

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/games/GamesScreen.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/games/GamesScreen.kt
@@ -2,6 +2,7 @@ package dev.convocados.wear.ui.screen.games
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -34,6 +35,16 @@ fun GamesScreen(
     onQuickGame: () -> Unit = {},
 ) {
     val state by viewModel.uiState.collectAsState()
+
+    // Auto-navigate to the scorable suggested game on first load
+    val autoNavId = state.autoNavigateEventId
+    LaunchedEffect(autoNavId) {
+        if (autoNavId != null) {
+            onGameSelected(autoNavId)
+            viewModel.consumeAutoNavigate()
+        }
+    }
+
     val columnState = rememberColumnState(
         ScalingLazyColumnDefaults.responsive()
     )

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/games/GamesViewModel.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/games/GamesViewModel.kt
@@ -26,6 +26,7 @@ data class GamesUiState(
     val games: List<WearGameEntity> = emptyList(),
     val pastGames: List<WearGameEntity> = emptyList(),
     val suggestedGameId: String? = null,
+    val autoNavigateEventId: String? = null,
     val isLoading: Boolean = true,
     val isOffline: Boolean = false,
     val pendingSyncCount: Int = 0,
@@ -44,6 +45,8 @@ class GamesViewModel @Inject constructor(
 
     private val _uiState = MutableStateFlow(GamesUiState())
     val uiState: StateFlow<GamesUiState> = _uiState.asStateFlow()
+
+    private var hasAutoNavigated = false
 
     @Volatile
     var tickProvider: () -> Flow<Instant> = { tickFlow() }
@@ -77,6 +80,10 @@ class GamesViewModel @Inject constructor(
                     games = sorted,
                     pastGames = archived,
                     suggestedGameId = suggested?.id,
+                    autoNavigateEventId = if (!hasAutoNavigated && suggested != null && suggested.id in scorable) {
+                        hasAutoNavigated = true
+                        suggested.id
+                    } else _uiState.value.autoNavigateEventId,
                     isLoading = false,
                     pendingSyncCount = pending,
                     canScoreGameIds = scorable,
@@ -103,6 +110,10 @@ class GamesViewModel @Inject constructor(
 
     fun togglePastGames() {
         _uiState.update { it.copy(showPastGames = !it.showPastGames, visiblePastCount = 5) }
+    }
+
+    fun consumeAutoNavigate() {
+        _uiState.update { it.copy(autoNavigateEventId = null) }
     }
 
     fun loadMorePast() {

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/score/ScoreViewModel.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/score/ScoreViewModel.kt
@@ -163,6 +163,13 @@ internal fun startErrorMessage(e: Throwable?): String? = when {
     e == null -> null
     e is ApiException && e.code == 400 -> "Assign teams first"
     e is ApiException && e.code == 401 -> "Session expired — sign in again"
+    e is ApiException && e.code == 403 -> parseApiError(e.message) ?: "Not authorized"
     e is ApiException -> "Couldn't start (${e.code})"
     else -> "Couldn't start — check connection"
+}
+
+private fun parseApiError(body: String?): String? {
+    if (body == null) return null
+    val match = Regex(""""error"\s*:\s*"([^"]+)"""").find(body)
+    return match?.groupValues?.get(1)
 }

--- a/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/teams/TeamsViewModel.kt
+++ b/android-app/wear/src/main/java/dev/convocados/wear/ui/screen/teams/TeamsViewModel.kt
@@ -172,9 +172,19 @@ class TeamsViewModel @Inject constructor(
                 it.copy(
                     isSaving = false,
                     saved = result.isSuccess,
-                    error = result.exceptionOrNull()?.message,
+                    error = result.exceptionOrNull()?.let { e -> parseTeamError(e) },
                 )
             }
         }
+    }
+
+    private fun parseTeamError(e: Throwable): String {
+        if (e is dev.convocados.wear.data.api.ApiException) {
+            val match = Regex(""""error"\s*:\s*"([^"]+)"""").find(e.message ?: "")
+            if (match != null) return match.groupValues[1]
+            if (e.code == 401) return "Session expired — sign in again"
+            if (e.code == 403) return "Not authorized to update teams"
+        }
+        return e.message ?: "Failed to update teams"
     }
 }

--- a/android-app/wear/src/test/java/dev/convocados/wear/ui/screen/games/GamesViewModelTest.kt
+++ b/android-app/wear/src/test/java/dev/convocados/wear/ui/screen/games/GamesViewModelTest.kt
@@ -233,6 +233,94 @@ class GamesViewModelTest {
         assertEquals(10, viewModel.uiState.value.visiblePastCount)
     }
 
+    @Test
+    fun `autoNavigateEventId is set when suggested game is scorable`() = runTest {
+        val now = Instant.now()
+        val scorableGame = makeGame("scorable", now.plus(30, ChronoUnit.MINUTES))
+
+        coEvery { repository.observeGames() } returns flowOf(listOf(scorableGame))
+        coEvery { repository.observeArchivedGames() } returns flowOf(emptyList())
+        coEvery { scoreRepository.observePendingCount() } returns flowOf(0)
+        coEvery { repository.refreshGames() } returns Result.success(Unit)
+
+        val viewModel = makeViewModel()
+        advanceUntilIdle()
+
+        viewModel.uiState.test {
+            val state = awaitItem()
+            assertEquals("scorable", state.autoNavigateEventId)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `autoNavigateEventId is null when suggested game is not scorable`() = runTest {
+        val now = Instant.now()
+        val futureGame = makeGame("future", now.plus(180, ChronoUnit.MINUTES))
+
+        coEvery { repository.observeGames() } returns flowOf(listOf(futureGame))
+        coEvery { repository.observeArchivedGames() } returns flowOf(emptyList())
+        coEvery { scoreRepository.observePendingCount() } returns flowOf(0)
+        coEvery { repository.refreshGames() } returns Result.success(Unit)
+
+        val viewModel = makeViewModel()
+        advanceUntilIdle()
+
+        viewModel.uiState.test {
+            val state = awaitItem()
+            assertNull(state.autoNavigateEventId)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `consumeAutoNavigate clears autoNavigateEventId`() = runTest {
+        val now = Instant.now()
+        val scorableGame = makeGame("scorable", now.plus(30, ChronoUnit.MINUTES))
+
+        coEvery { repository.observeGames() } returns flowOf(listOf(scorableGame))
+        coEvery { repository.observeArchivedGames() } returns flowOf(emptyList())
+        coEvery { scoreRepository.observePendingCount() } returns flowOf(0)
+        coEvery { repository.refreshGames() } returns Result.success(Unit)
+
+        val viewModel = makeViewModel()
+        advanceUntilIdle()
+
+        viewModel.consumeAutoNavigate()
+
+        viewModel.uiState.test {
+            val state = awaitItem()
+            assertNull(state.autoNavigateEventId)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `autoNavigateEventId does not re-fire after consume`() = runTest {
+        val now = Instant.now()
+        val scorableGame = makeGame("scorable", now.plus(30, ChronoUnit.MINUTES))
+
+        coEvery { repository.observeGames() } returns flowOf(listOf(scorableGame))
+        coEvery { repository.observeArchivedGames() } returns flowOf(emptyList())
+        coEvery { scoreRepository.observePendingCount() } returns flowOf(0)
+        coEvery { repository.refreshGames() } returns Result.success(Unit)
+
+        val viewModel = makeViewModel()
+        advanceUntilIdle()
+
+        viewModel.consumeAutoNavigate()
+
+        // Trigger another refresh cycle
+        viewModel.refresh()
+        advanceUntilIdle()
+
+        viewModel.uiState.test {
+            val state = awaitItem()
+            assertNull(state.autoNavigateEventId)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
     private fun makeGame(
         id: String,
         time: Instant = Instant.now(),

--- a/src/components/EventPage.tsx
+++ b/src/components/EventPage.tsx
@@ -287,12 +287,16 @@ export default function EventPage({ eventId }: { eventId: string }) {
   const handleTeamChange = async (matches: Imatch[]) => {
     setLocalMatches(matches);
     isDraggingRef.current = true;
-    await fetch(`/api/events/${eventId}/teams`, {
+    const res = await fetch(`/api/events/${eventId}/teams`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ matches }),
     });
     isDraggingRef.current = false;
+    if (!res.ok) {
+      const json = await res.json().catch(() => ({}));
+      setSnackbar(json.error || "Failed to update teams");
+    }
     fetchEvent();
   };
 

--- a/src/pages/api/events/[id]/teams.ts
+++ b/src/pages/api/events/[id]/teams.ts
@@ -1,6 +1,7 @@
 import type { APIRoute } from "astro";
 import { prisma } from "../../../../lib/db.server";
 import { authenticateRequest } from "../../../../lib/authenticate.server";
+import { checkOwnership, getSession } from "../../../../lib/auth.helpers.server";
 import { rateLimitResponse } from "../../../../lib/apiRateLimit.server";
 
 
@@ -100,6 +101,11 @@ export const PUT: APIRoute = async ({ params, request }) => {
 
 	if (!params.id) return Response.json({ error: "Missing event id" }, { status: 400 });
 
+	const session = await getSession(request);
+	if (!session?.user) {
+		return Response.json({ error: "You must be logged in to update teams." }, { status: 401 });
+	}
+
 	const eventId = params.id;
 
 	const event = await prisma.event.findUnique({
@@ -110,6 +116,13 @@ export const PUT: APIRoute = async ({ params, request }) => {
 	});
 
 	if (!event) return Response.json({ error: "Not found." }, { status: 404 });
+
+	const { isOwner, isAdmin } = await checkOwnership(request, event.ownerId, session, eventId);
+	const isPlayer = event.players.some((p) => p.userId === session.user.id);
+
+	if (!isOwner && !isAdmin && !isPlayer) {
+		return Response.json({ error: "You must be the event owner, an admin, or a player in this game to update teams." }, { status: 403 });
+	}
 
 	interface MatchInput { team: string; players: { name: string; order: number }[] }
 	let body: { matches: MatchInput[] };

--- a/src/pages/api/watch/events.ts
+++ b/src/pages/api/watch/events.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from "astro";
 import { prisma } from "../../../lib/db.server";
-import { getSession } from "../../../lib/auth.helpers.server";
+import { getSession, checkOwnership } from "../../../lib/auth.helpers.server";
 
 /** How many minutes before/after the event dateTime we consider it "happening now" */
 const HAPPENING_WINDOW_MS = 90 * 60 * 1000; // 90 minutes
@@ -38,6 +38,16 @@ export const POST: APIRoute = async ({ request }) => {
 
   if (!event) {
     return Response.json({ error: "Event not found." }, { status: 404 });
+  }
+
+  // Check that the user is the owner, admin, or a player in this event
+  const { isOwner, isAdmin } = await checkOwnership(request, event.ownerId, session, eventId);
+  const isPlayer = await prisma.player.findFirst({
+    where: { eventId, userId: session.user.id, archivedAt: null },
+  });
+
+  if (!isOwner && !isAdmin && !isPlayer) {
+    return Response.json({ error: "You must be the event owner, an admin, or a player in this game to start scoring." }, { status: 403 });
   }
 
   if (event.teamResults.length < 2) {

--- a/src/test/api.test.ts
+++ b/src/test/api.test.ts
@@ -3,6 +3,14 @@ import { prisma } from "~/lib/db.server";
 import { resetRateLimitStore } from "~/lib/rateLimit.server";
 import { resetApiRateLimitStore } from "~/lib/apiRateLimit.server";
 
+// Mock auth helpers — default to unauthenticated, tests override as needed
+const mockGetSession = vi.fn().mockResolvedValue(null);
+vi.mock("~/lib/auth.helpers.server", () => ({
+  getSession: (...args: any[]) => mockGetSession(...args),
+  checkOwnership: vi.fn().mockResolvedValue({ isOwner: true, isAdmin: false, session: null }),
+  checkEventAdmin: vi.fn().mockResolvedValue(false),
+}));
+
 // Import route handlers directly — they're plain async functions
 import { POST as createEvent } from "~/pages/api/events/index";
 import { GET as getEvent } from "~/pages/api/events/[id]/index";
@@ -374,6 +382,10 @@ describe("POST /api/events/[id]/randomize", () => {
 // ─── PUT /api/events/[id]/teams ──────────────────────────────────────────────
 
 describe("PUT /api/events/[id]/teams", () => {
+  beforeEach(() => {
+    mockGetSession.mockResolvedValue({ user: { id: "test-user-1", name: "Test User" } });
+  });
+
   it("saves team assignments", async () => {
     const id = await seedEvent();
     await prisma.player.createMany({


### PR DESCRIPTION
## Changes

### Wear OS: Auto-navigate to scorable game on launch
- On app open, if a game is within the scoring window (≤1h to start or already started), auto-navigates directly to the ScoreScreen
- Swipe-right goes back to the games list (natural Wear OS gesture)
- One-shot: does not re-fire after user returns to list

### Auth enforcement on score/team update APIs
- **PUT /api/events/[id]/teams** (legacy): was completely unprotected — now requires session + owner/admin/player
- **POST /api/watch/events**: was session-only — now also requires owner/admin/player role
- Clear error messages: "You must be the event owner, an admin, or a player in this game to update teams/start scoring"

### Client-side error handling
- **Web**: shows snackbar on team update failure
- **Android phone**: surfaces score/team update 403 errors in UI
- **Wear OS**: parses and displays human-readable 403 messages from API