### PR TITLE
fix: iOS add-to-home-screen banner opens the share sheet

### DIFF
--- a/src/components/ResponsiveLayout.tsx
+++ b/src/components/ResponsiveLayout.tsx
@@ -26,6 +26,7 @@ import { useThemeMode } from "./ThemeModeProvider";
 import { useLocale } from "~/lib/useT";
 import type { Locale } from "~/lib/i18n";
 import { useSession, signOut } from "~/lib/auth.client";
+import { shareForHomeScreen } from "~/lib/pwaInstall";
 
 const LOCALE_OPTIONS: { code: Locale; label: string }[] = [
   { code: "en", label: "English" },
@@ -205,6 +206,13 @@ function InstallBanner() {
     deferredPromptRef.current = null;
   };
 
+  const handleIosShare = async () => {
+    // iOS has no programmatic A2HS; open the native share sheet, which holds
+    // the "Add to Home Screen" action. Falls back to the on-screen hint when
+    // the Web Share API is unavailable.
+    await shareForHomeScreen(navigator, window.location.href, document.title);
+  };
+
   const handleDismiss = () => {
     setShowBanner(false);
     setShowIos(false);
@@ -231,7 +239,10 @@ function InstallBanner() {
         borderTop: `1px solid ${theme.palette.divider}`,
       }}>
         <GetAppIcon sx={{ color: theme.palette.primary.main, fontSize: 32 }} />
-        <Box sx={{ flex: 1, minWidth: 0 }}>
+        <Box
+          sx={{ flex: 1, minWidth: 0, cursor: showIos ? "pointer" : "default" }}
+          onClick={showIos ? handleIosShare : undefined}
+        >
           <Typography variant="body2" fontWeight={700}>
             {t("installApp")}
           </Typography>
@@ -240,7 +251,14 @@ function InstallBanner() {
           </Typography>
         </Box>
         {showIos ? (
-          <IosShareIcon sx={{ color: theme.palette.text.secondary, fontSize: 20, flexShrink: 0 }} />
+          <IconButton
+            size="small"
+            onClick={handleIosShare}
+            aria-label={t("installApp")}
+            sx={{ color: theme.palette.primary.main, flexShrink: 0 }}
+          >
+            <IosShareIcon fontSize="small" />
+          </IconButton>
         ) : (
           <Button
             size="small"

--- a/src/lib/pwaInstall.ts
+++ b/src/lib/pwaInstall.ts
@@ -1,0 +1,39 @@
+/**
+ * PWA install helpers.
+ *
+ * iOS Safari exposes no programmatic "Add to Home Screen" (A2HS) API and never
+ * fires `beforeinstallprompt`. The closest we can do from a web page is open the
+ * native share sheet via the Web Share API — that sheet contains the
+ * "Add to Home Screen" action. This helper performs that best-effort trigger.
+ */
+
+export interface ShareCapableNavigator {
+  share?: (data: { title?: string; text?: string; url?: string }) => Promise<void>;
+}
+
+export type ShareOutcome = "shared" | "unsupported" | "cancelled";
+
+/**
+ * Opens the native share sheet so the user can tap "Add to Home Screen".
+ *
+ * @returns
+ *  - `"shared"` when the share sheet was successfully invoked,
+ *  - `"cancelled"` when the user dismissed it or the share failed,
+ *  - `"unsupported"` when the Web Share API is unavailable (caller should fall
+ *    back to showing manual instructions).
+ */
+export async function shareForHomeScreen(
+  nav: ShareCapableNavigator,
+  url: string,
+  title: string,
+): Promise<ShareOutcome> {
+  if (typeof nav?.share !== "function") return "unsupported";
+  try {
+    await nav.share({ title, url });
+    return "shared";
+  } catch {
+    // User cancelled the share sheet or the share was rejected — not an error
+    // we need to surface, the banner simply stays put.
+    return "cancelled";
+  }
+}

--- a/src/test/pwa-install.test.ts
+++ b/src/test/pwa-install.test.ts
@@ -1,4 +1,27 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { shareForHomeScreen } from "~/lib/pwaInstall";
+
+// ── iOS "Add to Home Screen" share trigger ──────────────────────────────────
+
+describe("shareForHomeScreen", () => {
+  it("invokes the Web Share API with the page url and title", async () => {
+    const share = vi.fn().mockResolvedValue(undefined);
+    const outcome = await shareForHomeScreen({ share }, "https://convocados.app/", "Convocados");
+    expect(outcome).toBe("shared");
+    expect(share).toHaveBeenCalledWith({ title: "Convocados", url: "https://convocados.app/" });
+  });
+
+  it("returns 'cancelled' when the user dismisses the share sheet", async () => {
+    const share = vi.fn().mockRejectedValue(new DOMException("Abort", "AbortError"));
+    const outcome = await shareForHomeScreen({ share }, "https://convocados.app/", "Convocados");
+    expect(outcome).toBe("cancelled");
+  });
+
+  it("returns 'unsupported' when the Web Share API is unavailable", async () => {
+    const outcome = await shareForHomeScreen({}, "https://convocados.app/", "Convocados");
+    expect(outcome).toBe("unsupported");
+  });
+});
 
 // ── i18n key tests ──────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

On iPhone, tapping the "Install / Add to Home Screen" banner did nothing — the iOS branch rendered a static share icon with no click handler.

iOS Safari has no programmatic Add-to-Home-Screen API and never fires `beforeinstallprompt`. The closest achievable behavior is opening the native iOS share sheet via the Web Share API, which contains the **Add to Home Screen** action.

## Changes

- **`src/lib/pwaInstall.ts`** (new): `shareForHomeScreen()` helper calling `navigator.share({ title, url })`, returning `shared` / `cancelled` / `unsupported` for graceful degradation.
- **`src/components/ResponsiveLayout.tsx`**: iOS banner trailing icon is now an interactive `IconButton`, and the banner text area is tappable — both open the share sheet. The on-screen hint remains as a fallback for iOS < 16.4 (no Web Share).
- **`src/test/pwa-install.test.ts`**: tests covering all three share outcomes.

## Tested

- `npm run typecheck` ✅
- `npx vitest run src/test/pwa-install.test.ts` ✅ (13 tests)
- `eslint` on changed files ✅ (0 errors)

## Not verified

- On-device behavior on a physical iPhone (no device available). On iOS 16.4+ the tap opens the share sheet; on older iOS it returns `unsupported` and the user follows the visible hint.