### PR TITLE
feat: bulk mark-all-paid, payment deep link, auto-pay-on-join

### DIFF
--- a/android-app/app/src/main/java/dev/convocados/data/api/ConvocadosApi.kt
+++ b/android-app/app/src/main/java/dev/convocados/data/api/ConvocadosApi.kt
@@ -121,6 +121,10 @@ class ConvocadosApi @Inject constructor(private val client: ApiClient) {
     suspend fun markPaymentSent(eventId: String, playerName: String): OkResponse =
         client.put("/api/events/$eventId/payments", PaymentUpdateRequest(playerName, "sent"))
 
+    /** Bulk mark all pending/sent as paid (owner/admin only). */
+    suspend fun bulkMarkAllPaid(eventId: String): OkResponse =
+        client.put("/api/events/$eventId/payments/bulk")
+
     // ── Balance / Payment Nudge ───────────────────────────────────────────
     suspend fun fetchBalance(eventId: String): BalanceResponse =
         client.get("/api/events/$eventId/balance")

--- a/android-app/app/src/main/java/dev/convocados/data/datastore/SettingsStore.kt
+++ b/android-app/app/src/main/java/dev/convocados/data/datastore/SettingsStore.kt
@@ -3,6 +3,7 @@ package dev.convocados.data.datastore
 import android.content.Context
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.os.LocaleListCompat
+import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
@@ -20,6 +21,7 @@ class SettingsStore @Inject constructor(@ApplicationContext private val context:
 
     private val LOCALE_KEY = stringPreferencesKey("locale")
     private val THEME_KEY = stringPreferencesKey("theme_mode")
+    private val AUTO_PAY_ON_JOIN_KEY = booleanPreferencesKey("auto_pay_on_join")
 
     val locale: Flow<String> = context.dataStore.data.map { it[LOCALE_KEY] ?: "en" }
 
@@ -45,5 +47,11 @@ class SettingsStore @Inject constructor(@ApplicationContext private val context:
                 ThemeMode.System -> "system"
             }
         }
+    }
+
+    val autoPayOnJoin: Flow<Boolean> = context.dataStore.data.map { it[AUTO_PAY_ON_JOIN_KEY] ?: false }
+
+    suspend fun setAutoPayOnJoin(enabled: Boolean) {
+        context.dataStore.edit { it[AUTO_PAY_ON_JOIN_KEY] = enabled }
     }
 }

--- a/android-app/app/src/main/java/dev/convocados/ui/navigation/AppNavigation.kt
+++ b/android-app/app/src/main/java/dev/convocados/ui/navigation/AppNavigation.kt
@@ -146,12 +146,17 @@ fun AppNavigation(isAuthenticated: Boolean, deepLink: String? = null) {
                     )
                 }
                 composable(
-                    Route.EventDetail().route,
-                    arguments = listOf(navArgument("eventId") { type = NavType.StringType }),
+                    Route.EventDetail().route + "?action={action}",
+                    arguments = listOf(
+                        navArgument("eventId") { type = NavType.StringType },
+                        navArgument("action") { type = NavType.StringType; defaultValue = "" },
+                    ),
                 ) { entry ->
                     val eventId = entry.arguments?.getString("eventId") ?: return@composable
+                    val autoOpenPay = entry.arguments?.getString("action") == "pay"
                     EventDetailScreen(
                         eventId = eventId,
+                        autoOpenPay = autoOpenPay,
                         onBack = { navController.popBackStack() },
                         onSettings = { navController.navigate(Route.EventSettings.create(eventId)) },
                         onRankings = { navController.navigate(Route.EventRankings.create(eventId)) },
@@ -265,8 +270,12 @@ private fun deepLinkToRoute(url: String): String? {
     // Handle paths like /events/{id} or full URLs
     val path = url.removePrefix("https://convocados.cabeda.dev")
         .removePrefix("http://localhost:4321")
-    val eventMatch = Regex("/events?/([^/]+)").find(path)
-    if (eventMatch != null) return Route.EventDetail.create(eventMatch.groupValues[1])
+    val eventMatch = Regex("/events?/([^/?]+)").find(path)
+    if (eventMatch != null) {
+        val id = eventMatch.groupValues[1]
+        val actionPay = url.contains("action=pay")
+        return Route.EventDetail.create(id) + if (actionPay) "?action=pay" else ""
+    }
     if (path == "/games" || url == "games") return Route.Games.route
     if (path == "/create" || url == "create") return Route.CreateEvent.route
     return null

--- a/android-app/app/src/main/java/dev/convocados/ui/screen/event/EventDetailScreen.kt
+++ b/android-app/app/src/main/java/dev/convocados/ui/screen/event/EventDetailScreen.kt
@@ -33,6 +33,7 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dev.convocados.data.api.*
 import dev.convocados.data.auth.TokenStore
+import dev.convocados.data.datastore.SettingsStore
 import dev.convocados.data.repository.EventRepository
 import dev.convocados.ui.screen.games.formatRelativeDate
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -87,6 +88,7 @@ class EventDetailViewModel @Inject constructor(
     private val api: ConvocadosApi,
     private val tokenStore: TokenStore,
     private val client: ApiClient,
+    private val settingsStore: SettingsStore,
 ) : ViewModel() {
     private val _eventId = MutableStateFlow<String?>(null)
 
@@ -111,6 +113,13 @@ class EventDetailViewModel @Inject constructor(
             locked = if (e?.locked == true) s.locked else false
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), EventScreenState(locked = true))
+
+    val autoPayOnJoin: StateFlow<Boolean> = settingsStore.autoPayOnJoin
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
+
+    fun setAutoPayOnJoin(enabled: Boolean) {
+        viewModelScope.launch { settingsStore.setAutoPayOnJoin(enabled) }
+    }
 
     private val _user = MutableStateFlow<UserProfile?>(null)
     val user: StateFlow<UserProfile?> = _user
@@ -194,6 +203,12 @@ class EventDetailViewModel @Inject constructor(
     fun addPlayer(eventId: String, name: String, link: Boolean = true) {
         viewModelScope.launch {
             repository.addPlayer(eventId, name, link)
+                .onSuccess {
+                    // Auto-open payment dialog after join if preference is set
+                    if (autoPayOnJoin.value && _state.value.balance?.callerBalance?.let { it.amount > 0 } == true) {
+                        _state.value = _state.value.copy(showPaymentNudge = true)
+                    }
+                }
                 .onFailure { e ->
                     if (e is ApiException && e.code == 402) {
                         // Parse the PAYMENT_GATE response
@@ -367,6 +382,7 @@ private fun parseApiErrorMessage(e: Throwable): String? {
 @Composable
 fun EventDetailScreen(
     eventId: String,
+    autoOpenPay: Boolean = false,
     onBack: () -> Unit,
     onSettings: () -> Unit,
     onRankings: () -> Unit,
@@ -407,6 +423,13 @@ fun EventDetailScreen(
     }
 
     LaunchedEffect(eventId) { viewModel.load(eventId) }
+
+    // Auto-open payment dialog from ?action=pay deep link
+    LaunchedEffect(autoOpenPay, state.balance) {
+        if (autoOpenPay && state.balance?.callerBalance != null && state.balance!!.callerBalance!!.amount > 0) {
+            viewModel.showPaymentNudge()
+        }
+    }
 
     // Notification preferences bottom sheet
     if (state.showNotificationSheet) {
@@ -817,6 +840,7 @@ fun EventDetailScreen(
     // ── Payment Nudge Dialog ──────────────────────────────────────────────
     if (state.showPaymentNudge && user?.name != null) {
         val callerBalance = state.balance?.callerBalance
+        val autoPayPref by viewModel.autoPayOnJoin.collectAsStateWithLifecycle()
         AlertDialog(
             onDismissRequest = { viewModel.dismissPaymentNudge() },
             title = { Text("Settle up before you play") },
@@ -835,6 +859,19 @@ fun EventDetailScreen(
                             )
                         }
                     }
+                    Spacer(Modifier.height(16.dp))
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Text(
+                            "Always show payment when I join",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.weight(1f),
+                        )
+                        Switch(
+                            checked = autoPayPref,
+                            onCheckedChange = { viewModel.setAutoPayOnJoin(it) },
+                        )
+                    }
                 }
             },
             confirmButton = {
@@ -843,7 +880,7 @@ fun EventDetailScreen(
                     colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.tertiary),
                 ) {
                     Text(
-                        if (callerBalance != null) "Pay €${"%.2f".format(callerBalance.amount)} & join" else "Pay & join",
+                        if (callerBalance != null) "Pay €${"%.2f".format(callerBalance.amount)} & join" else "I've sent it ✓",
                         color = MaterialTheme.colorScheme.onTertiary,
                     )
                 }

--- a/android-app/app/src/main/java/dev/convocados/ui/screen/payments/PaymentsScreen.kt
+++ b/android-app/app/src/main/java/dev/convocados/ui/screen/payments/PaymentsScreen.kt
@@ -51,6 +51,12 @@ class PaymentsViewModel @Inject constructor(private val api: ConvocadosApi) : Vi
             runCatching { api.setCostOverride(eventId, playerName, amount) }.onSuccess { load(eventId) }
         }
     }
+
+    fun bulkMarkAllPaid(eventId: String) {
+        viewModelScope.launch {
+            runCatching { api.bulkMarkAllPaid(eventId) }.onSuccess { load(eventId) }
+        }
+    }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -76,6 +82,18 @@ fun PaymentsScreen(eventId: String, onBack: () -> Unit, viewModel: PaymentsViewM
                     SummaryCard("Paid", "${d.summary.paidCount}", MaterialTheme.colorScheme.onSurface, Modifier.weight(1f))
                     SummaryCard("Pending", "${d.summary.pendingCount}", MaterialTheme.colorScheme.tertiary, Modifier.weight(1f))
                     d.totalAmount?.let { SummaryCard("Total", "${d.currency ?: "€"}$it", MaterialTheme.colorScheme.onSurface, Modifier.weight(1f)) }
+                }
+            }
+            // Bulk mark all as paid
+            if (d.payments.any { it.status != "paid" }) {
+                item {
+                    Button(
+                        onClick = { viewModel.bulkMarkAllPaid(eventId) },
+                        modifier = Modifier.fillMaxWidth(),
+                        colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primaryContainer),
+                    ) {
+                        Text("✓ Mark all as paid", color = MaterialTheme.colorScheme.onPrimaryContainer, fontWeight = FontWeight.SemiBold)
+                    }
                 }
             }
             if (d.payments.isEmpty()) {

--- a/src/components/EventPage.tsx
+++ b/src/components/EventPage.tsx
@@ -37,6 +37,13 @@ export default function EventPage({ eventId }: { eventId: string }) {
   const locale = detectLocale();
   const { data: session } = useSession();
 
+  // Detect ?action=pay from payment reminder deep link
+  const [autoOpenPay] = useState(() => {
+    if (typeof window === "undefined") return false;
+    const params = new URLSearchParams(window.location.search);
+    return params.get("action") === "pay";
+  });
+
   // ── UI state ────────────────────────────────────────────────────────────────
   const [playerError, setPlayerError] = useState<string | null>(null);
   const [confirmOpen, setConfirmOpen] = useState(false);
@@ -570,6 +577,7 @@ export default function EventPage({ eventId }: { eventId: string }) {
                 maxPlayers={event.maxPlayers}
                 onJoin={addPlayer}
                 onLeave={removePlayer}
+                autoOpenPay={autoOpenPay}
               />
             )}
 

--- a/src/components/PaymentSection.tsx
+++ b/src/components/PaymentSection.tsx
@@ -170,6 +170,12 @@ export function PaymentSection({
     onPaymentChange?.();
   };
 
+  const handleBulkMarkPaid = async () => {
+    await fetch(`/api/events/${eventId}/payments/bulk`, { method: "PUT" });
+    fetchCost();
+    onPaymentChange?.();
+  };
+
   const handleCopy = async (text: string, id: string) => {
     await navigator.clipboard.writeText(text);
     setCopiedId(id);
@@ -593,6 +599,19 @@ export function PaymentSection({
                     />
                   ))}
                 </Box>
+
+                {/* Bulk mark all as paid */}
+                {canEdit && costData.payments.some((p) => p.status !== "paid") && (
+                  <Button
+                    size="small"
+                    variant="outlined"
+                    color="success"
+                    onClick={handleBulkMarkPaid}
+                    startIcon={<CheckIcon />}
+                  >
+                    {t("bulkMarkAllPaid")}
+                  </Button>
+                )}
 
                 {/* Legend */}
                 <Box sx={{ display: "flex", gap: 1.5, flexWrap: "wrap" }}>

--- a/src/components/event/QuickJoin.tsx
+++ b/src/components/event/QuickJoin.tsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect, useCallback } from "react";
 import {
   Paper, Typography, Box, Stack, Chip, Button, alpha, useTheme,
   Dialog, DialogTitle, DialogContent, DialogActions, Alert,
+  FormControlLabel, Switch,
 } from "@mui/material";
 import PersonAddIcon from "@mui/icons-material/PersonAdd";
 import EmojiPeopleIcon from "@mui/icons-material/EmojiPeople";
@@ -26,15 +27,18 @@ interface Props {
   maxPlayers: number;
   onJoin: (name: string, linkToAccount?: boolean) => Promise<void>;
   onLeave: (id: string) => Promise<void>;
+  autoOpenPay?: boolean;
 }
 
-export function QuickJoin({ eventId, userName, players, maxPlayers, onJoin, onLeave }: Props) {
+export function QuickJoin({ eventId, userName, players, maxPlayers, onJoin, onLeave, autoOpenPay }: Props) {
   const t = useT();
   const theme = useTheme();
   const [joining, setJoining] = useState(false);
   const [balanceData, setBalanceData] = useState<BalanceData | null>(null);
   const [showInterstitial, setShowInterstitial] = useState(false);
   const [blocked, setBlocked] = useState(false);
+  const [autoPayOnJoin, setAutoPayOnJoin] = useState(false);
+  const [autoOpenTriggered, setAutoOpenTriggered] = useState(false);
 
   const joined = players.find((p) => p.name.toLowerCase() === userName.toLowerCase());
   const isOnBench = joined ? players.indexOf(joined) >= maxPlayers : false;
@@ -47,6 +51,23 @@ export function QuickJoin({ eventId, userName, players, maxPlayers, onJoin, onLe
   }, [eventId]);
 
   useEffect(() => { fetchBalance(); }, [fetchBalance]);
+
+  // Auto-open payment sheet from ?action=pay deep link
+  useEffect(() => {
+    if (autoOpenPay && balanceData && !autoOpenTriggered) {
+      setAutoOpenTriggered(true);
+      if (balanceData.callerBalance && balanceData.callerBalance.amount > 0) {
+        setShowInterstitial(true);
+      }
+    }
+  }, [autoOpenPay, balanceData, autoOpenTriggered]);
+
+  // Load auto-pay-on-join preference from localStorage
+  useEffect(() => {
+    try {
+      setAutoPayOnJoin(localStorage.getItem("autoPayOnJoin") === "true");
+    } catch { /* ignore */ }
+  }, []);
 
   const balance = balanceData?.callerBalance;
   const hasDebt = balance && balance.amount > 0;
@@ -67,6 +88,10 @@ export function QuickJoin({ eventId, userName, players, maxPlayers, onJoin, onLe
     setJoining(true);
     try {
       await onJoin(userName, true);
+      // Auto-open payment sheet after join if user opted in
+      if (autoPayOnJoin && hasDebt) {
+        setTimeout(() => setShowInterstitial(true), 300);
+      }
     } catch (err: unknown) {
       // Check if it's a 402 PAYMENT_GATE response
       if (err && typeof err === "object" && "code" in err && (err as { code: string }).code === "PAYMENT_GATE") {
@@ -221,6 +246,21 @@ export function QuickJoin({ eventId, userName, players, maxPlayers, onJoin, onLe
           >
             {t("paymentNudgeJoinLater")}
           </Button>
+          <FormControlLabel
+            control={
+              <Switch
+                size="small"
+                checked={autoPayOnJoin}
+                onChange={(e) => {
+                  const val = e.target.checked;
+                  setAutoPayOnJoin(val);
+                  try { localStorage.setItem("autoPayOnJoin", String(val)); } catch {}
+                }}
+              />
+            }
+            label={<Typography variant="caption" color="text.secondary">{t("autoPayOnJoinLabel")}</Typography>}
+            sx={{ mt: 1 }}
+          />
         </DialogActions>
       </Dialog>
     </>

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -389,6 +389,8 @@ const de: TranslationKeys = {
   paymentNudgeStreak: "🔥 {count} Spiele bezahlt in Folge",
   paymentNudgeSentConfirmation: "Als gesendet markiert — der Organisator wird bestätigen",
   paymentNudgeSettleUp: "Ausgleichen",
+  bulkMarkAllPaid: "Alle als bezahlt markieren",
+  autoPayOnJoinLabel: "Zahlung beim Beitritt anzeigen",
   paymentEnforcementOff: "Aus",
   paymentEnforcementNudge: "Erinnerung",
   paymentEnforcementSoftGate: "Bestätigung erforderlich",

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -437,6 +437,8 @@ const en = {
   paymentNudgeStreak: "🔥 {count} game paid streak",
   paymentNudgeSentConfirmation: "Marked as sent — the organizer will confirm receipt",
   paymentNudgeSettleUp: "Settle up",
+  bulkMarkAllPaid: "Mark all as paid",
+  autoPayOnJoinLabel: "Always show payment when I join",
   paymentEnforcementOff: "Off",
   paymentEnforcementNudge: "Nudge",
   paymentEnforcementSoftGate: "Require acknowledgment",

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -389,6 +389,8 @@ const es: TranslationKeys = {
   paymentNudgeStreak: "🔥 {count} partidos pagados seguidos",
   paymentNudgeSentConfirmation: "Marcado como enviado — el organizador confirmará",
   paymentNudgeSettleUp: "Liquidar",
+  bulkMarkAllPaid: "Marcar todos como pagado",
+  autoPayOnJoinLabel: "Mostrar pago al unirse",
   paymentEnforcementOff: "Desactivado",
   paymentEnforcementNudge: "Recordatorio",
   paymentEnforcementSoftGate: "Requerir confirmación",

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -389,6 +389,8 @@ const fr: TranslationKeys = {
   paymentNudgeStreak: "🔥 {count} matchs payés d'affilée",
   paymentNudgeSentConfirmation: "Marqué comme envoyé — l'organisateur confirmera",
   paymentNudgeSettleUp: "Régler",
+  bulkMarkAllPaid: "Tout marquer comme payé",
+  autoPayOnJoinLabel: "Afficher le paiement en rejoignant",
   paymentEnforcementOff: "Désactivé",
   paymentEnforcementNudge: "Rappel",
   paymentEnforcementSoftGate: "Exiger confirmation",

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -389,6 +389,8 @@ const it: TranslationKeys = {
   paymentNudgeStreak: "🔥 {count} partite pagate di fila",
   paymentNudgeSentConfirmation: "Segnato come inviato — l'organizzatore confermerà",
   paymentNudgeSettleUp: "Saldare",
+  bulkMarkAllPaid: "Segna tutti come pagato",
+  autoPayOnJoinLabel: "Mostra pagamento all'iscrizione",
   paymentEnforcementOff: "Disattivato",
   paymentEnforcementNudge: "Promemoria",
   paymentEnforcementSoftGate: "Richiedere conferma",

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -438,6 +438,8 @@ const pt: TranslationKeys = {
   paymentNudgeStreak: "🔥 {count} jogos pagos seguidos",
   paymentNudgeSentConfirmation: "Marcado como enviado — o organizador vai confirmar",
   paymentNudgeSettleUp: "Acertar",
+  bulkMarkAllPaid: "Marcar todos como pago",
+  autoPayOnJoinLabel: "Mostrar pagamento ao entrar",
   paymentEnforcementOff: "Desligado",
   paymentEnforcementNudge: "Lembrete",
   paymentEnforcementSoftGate: "Exigir confirmação",

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -276,6 +276,14 @@ export const openApiSpec = {
         responses: { "200": { description: "Payment updated" }, ...errorResponses },
       },
     },
+    "/api/events/{id}/payments/bulk": {
+      put: {
+        summary: "Bulk mark all pending/sent payments as paid",
+        tags: ["Payments"],
+        parameters: [eventIdParam],
+        responses: { "200": { description: "All payments marked as paid" }, ...errorResponses },
+      },
+    },
     "/api/events/{id}/balance": {
       get: {
         summary: "Get outstanding balance and enforcement info for the caller",

--- a/src/pages/api/cron/reminders.ts
+++ b/src/pages/api/cron/reminders.ts
@@ -116,7 +116,7 @@ export const POST: APIRoute = async ({ request }) => {
             const wantsPush = wantsPaymentReminderPush(effective);
             if (!wantsEmail && !wantsPush) return;
 
-            const eventUrl = `${APP_URL}/events/${pp.eventId}`;
+            const eventUrl = `${APP_URL}/events/${pp.eventId}?action=pay`;
             const pushBody = `💸 You owe ${pp.amount.toFixed(2)} ${pp.currency} for ${pp.eventTitle}`;
 
             if (wantsEmail) {

--- a/src/pages/api/events/[id]/payments/bulk.ts
+++ b/src/pages/api/events/[id]/payments/bulk.ts
@@ -1,0 +1,32 @@
+import type { APIRoute } from "astro";
+import { prisma } from "~/lib/db.server";
+import { checkOwnership } from "~/lib/auth.helpers.server";
+import { rateLimitResponse } from "~/lib/apiRateLimit.server";
+
+/** PUT — bulk mark all pending/sent payments as paid. Owner/Admin only. */
+export const PUT: APIRoute = async ({ params, request }) => {
+  const limited = await rateLimitResponse(request, "write");
+  if (limited) return limited;
+
+  const eventId = params.id ?? "";
+  const event = await prisma.event.findUnique({ where: { id: eventId } });
+  if (!event) return Response.json({ error: "Not found." }, { status: 404 });
+
+  const { isOwner, isAdmin } = await checkOwnership(request, event.ownerId, undefined, eventId);
+  if (event.ownerId && !isOwner && !isAdmin) {
+    return Response.json({ error: "Only the event owner can do this." }, { status: 403 });
+  }
+
+  const eventCost = await prisma.eventCost.findUnique({ where: { eventId } });
+  if (!eventCost) return Response.json({ error: "No cost set for this event." }, { status: 404 });
+
+  const result = await prisma.playerPayment.updateMany({
+    where: {
+      eventCostId: eventCost.id,
+      status: { in: ["pending", "sent"] },
+    },
+    data: { status: "paid", paidAt: new Date() },
+  });
+
+  return Response.json({ ok: true, updated: result.count });
+};

--- a/src/test/bulk-payments.test.ts
+++ b/src/test/bulk-payments.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { prisma } from "~/lib/db.server";
+import { PUT } from "~/pages/api/events/[id]/payments/bulk";
+import { checkOwnership } from "~/lib/auth.helpers.server";
+import { resetApiRateLimitStore } from "~/lib/apiRateLimit.server";
+
+vi.mock("~/lib/auth.helpers.server", () => ({
+  getSession: vi.fn(),
+  checkOwnership: vi.fn(),
+}));
+
+vi.mock("~/lib/eventLog.server", () => ({
+  logEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+const mockCheckOwnership = vi.mocked(checkOwnership);
+
+beforeEach(async () => {
+  await prisma.playerPayment.deleteMany();
+  await prisma.eventCost.deleteMany();
+  await prisma.player.deleteMany();
+  await prisma.event.deleteMany();
+  await prisma.user.deleteMany();
+  resetApiRateLimitStore();
+  vi.clearAllMocks();
+  mockCheckOwnership.mockResolvedValue({ isOwner: true, isAdmin: false, session: null } as any);
+});
+
+describe("PUT /api/events/[id]/payments/bulk", () => {
+  it("marks all pending and sent payments as paid", async () => {
+    const owner = await prisma.user.create({ data: { id: "u1", name: "Owner", email: "o@t.com", emailVerified: true } });
+    const event = await prisma.event.create({
+      data: { id: "evt-1", title: "Game", dateTime: new Date(), ownerId: owner.id, maxPlayers: 10, location: "Field" },
+    });
+    const cost = await prisma.eventCost.create({ data: { eventId: event.id, totalAmount: 50, currency: "EUR" } });
+    await prisma.playerPayment.createMany({
+      data: [
+        { eventCostId: cost.id, playerName: "A", amount: 5, status: "pending" },
+        { eventCostId: cost.id, playerName: "B", amount: 5, status: "sent" },
+        { eventCostId: cost.id, playerName: "C", amount: 5, status: "paid", paidAt: new Date() },
+      ],
+    });
+
+    const req = new Request("http://localhost/api/events/evt-1/payments/bulk", { method: "PUT" });
+    const res = await PUT({ params: { id: "evt-1" }, request: req } as any);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.updated).toBe(2); // A and B, not C (already paid)
+
+    const payments = await prisma.playerPayment.findMany({ where: { eventCostId: cost.id } });
+    expect(payments.every((p) => p.status === "paid")).toBe(true);
+    expect(payments.every((p) => p.paidAt !== null)).toBe(true);
+  });
+
+  it("returns 403 for non-owner/admin", async () => {
+    const owner = await prisma.user.create({ data: { id: "u1", name: "Owner", email: "o@t.com", emailVerified: true } });
+    const event = await prisma.event.create({
+      data: { id: "evt-1", title: "Game", dateTime: new Date(), ownerId: owner.id, maxPlayers: 10, location: "Field" },
+    });
+    await prisma.eventCost.create({ data: { eventId: event.id, totalAmount: 50, currency: "EUR" } });
+
+    mockCheckOwnership.mockResolvedValue({ isOwner: false, isAdmin: false, session: null } as any);
+
+    const req = new Request("http://localhost/api/events/evt-1/payments/bulk", { method: "PUT" });
+    const res = await PUT({ params: { id: "evt-1" }, request: req } as any);
+
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 404 when no cost set", async () => {
+    await prisma.event.create({
+      data: { id: "evt-1", title: "Game", dateTime: new Date(), maxPlayers: 10, location: "Field" },
+    });
+
+    const req = new Request("http://localhost/api/events/evt-1/payments/bulk", { method: "PUT" });
+    const res = await PUT({ params: { id: "evt-1" }, request: req } as any);
+
+    expect(res.status).toBe(404);
+  });
+});


### PR DESCRIPTION
## Summary

Three payment flow improvements to reduce friction for players and admin work for organizers. Implemented on both web and Android.

### 1. Bulk 'mark all as paid' button

- **Web**: New endpoint `PUT /api/events/[id]/payments/bulk` + green button in PaymentSection
- **Android**: `bulkMarkAllPaid()` in ConvocadosApi + button in PaymentsScreen

### 2. Payment reminder deep link (`?action=pay`)

- **Web**: Push notifications include `?action=pay` → EventPage auto-opens payment dialog
- **Android**: `deepLinkToRoute()` parses `?action=pay` → passes `autoOpenPay` to EventDetailScreen → auto-shows payment nudge dialog

### 3. Auto-pay on join opt-in

- **Web**: localStorage toggle in payment dialog; joining auto-opens payment sheet
- **Android**: DataStore `autoPayOnJoin` preference in SettingsStore; toggle in payment nudge dialog; `addPlayer` auto-shows nudge after successful join

### Testing

- 3 new integration tests for bulk endpoint
- API contract test passes (OpenAPI spec updated)
- All 2300 web tests pass

### Files changed

**Web:**
- `src/pages/api/events/[id]/payments/bulk.ts` — new bulk endpoint
- `src/pages/api/cron/reminders.ts` — `?action=pay` in push URL
- `src/components/EventPage.tsx` — detect `?action=pay`
- `src/components/event/QuickJoin.tsx` — autoOpenPay + auto-pay toggle
- `src/components/PaymentSection.tsx` — bulk button
- `src/lib/openapi.ts` — bulk endpoint spec
- `src/lib/i18n/*.ts` — 2 new keys × 6 locales

**Android:**
- `ConvocadosApi.kt` — `bulkMarkAllPaid()`
- `AppNavigation.kt` — `?action=pay` deep link parsing
- `EventDetailScreen.kt` — `autoOpenPay`, auto-pay-on-join, toggle in dialog
- `PaymentsScreen.kt` — bulk mark-all-paid button + ViewModel method
- `SettingsStore.kt` — `autoPayOnJoin` DataStore preference