### PR TITLE
feat(android): court finder with Playtomic integration

### DIFF
--- a/android-app/app/src/main/java/dev/convocados/data/api/ConvocadosApi.kt
+++ b/android-app/app/src/main/java/dev/convocados/data/api/ConvocadosApi.kt
@@ -199,6 +199,31 @@ class ConvocadosApi @Inject constructor(private val client: ApiClient) {
 
     suspend fun updateFollowPreferences(eventId: String, overrides: FollowOverridesRequest): FollowStateResponse =
         client.put("/api/events/$eventId/follow", overrides)
+
+    // ── Court Finder ──────────────────────────────────────────────────────
+    suspend fun fetchCourtAlternatives(
+        eventId: String,
+        radius: Int = 10000,
+        startTime: String? = null,
+        endTime: String? = null,
+        includeBooked: Boolean = true,
+    ): CourtAlternativesResponse {
+        val params = buildString {
+            append("?radius=$radius&includeBooked=$includeBooked")
+            if (startTime != null) append("&startTime=$startTime")
+            if (endTime != null) append("&endTime=$endTime")
+        }
+        return client.get("/api/events/$eventId/court-alternatives$params")
+    }
+
+    suspend fun fetchCourtWatches(): CourtWatchesResponse =
+        client.get("/api/court-watches")
+
+    suspend fun createCourtWatch(request: CreateCourtWatchRequest): OkResponse =
+        client.post("/api/court-watches", request)
+
+    suspend fun deleteCourtWatch(id: String): OkResponse =
+        client.delete("/api/court-watches/$id")
 }
 
 // ── Request bodies ────────────────────────────────────────────────────────────

--- a/android-app/app/src/main/java/dev/convocados/data/api/Models.kt
+++ b/android-app/app/src/main/java/dev/convocados/data/api/Models.kt
@@ -414,6 +414,59 @@ data class FollowStateResponse(
     val muteEventDetails: Boolean? = null,
 )
 
+// ── Court Finder ────────────────────────────────────────────────────────────
+
+@Serializable
+data class CourtAlternative(
+    val tenantId: String,
+    val tenantName: String,
+    val resourceName: String,
+    val slotTime: String,
+    val price: Double,
+    val currency: String = "EUR",
+    val status: String = "available",
+    val playtomicUrl: String = "",
+    val distanceKm: Double = 0.0,
+    val coordinate: CourtCoordinate? = null,
+)
+
+@Serializable
+data class CourtCoordinate(val lat: Double, val lng: Double)
+
+@Serializable
+data class CourtAlternativesResponse(val alternatives: List<CourtAlternative> = emptyList())
+
+@Serializable
+data class CourtWatch(
+    val id: String,
+    val sport: String = "",
+    val tenantId: String = "",
+    val tenantName: String = "",
+    val resourceId: String = "",
+    val resourceName: String = "",
+    val dayOfWeek: Int = 1,
+    val startTime: String = "",
+    val endTime: String = "",
+    val timezone: String = "",
+    val createdAt: String = "",
+)
+
+@Serializable
+data class CourtWatchesResponse(val watches: List<CourtWatch> = emptyList())
+
+@Serializable
+data class CreateCourtWatchRequest(
+    val sport: String,
+    val tenantId: String,
+    val tenantName: String,
+    val resourceId: String,
+    val resourceName: String,
+    val dayOfWeek: Int,
+    val startTime: String,
+    val endTime: String,
+    val timezone: String,
+)
+
 // ── Payment Nudge / Balance ─────────────────────────────────────────────────
 
 @Serializable

--- a/android-app/app/src/main/java/dev/convocados/ui/navigation/AppNavigation.kt
+++ b/android-app/app/src/main/java/dev/convocados/ui/navigation/AppNavigation.kt
@@ -40,6 +40,8 @@ import dev.convocados.ui.screen.history.HistoryDetailScreen
 import dev.convocados.ui.screen.history.EventHistoryScreen
 import dev.convocados.ui.screen.history.EventHistoryScreen
 import dev.convocados.ui.screen.map.MapPickerScreen
+import dev.convocados.ui.screen.courts.CourtAlternativesScreen
+import dev.convocados.ui.screen.courts.CourtWatchesScreen
 
 data class BottomNavItem(val route: String, val label: String, val icon: @Composable () -> Unit)
 
@@ -126,6 +128,7 @@ fun AppNavigation(isAuthenticated: Boolean, deepLink: String? = null) {
                             }
                         },
                         onNotificationPrefs = { navController.navigate(Route.NotificationPrefs.route) },
+                        onCourtWatches = { navController.navigate(Route.CourtWatches.route) },
                     )
                 }
                 composable(Route.CreateEvent.route) {
@@ -167,6 +170,7 @@ fun AppNavigation(isAuthenticated: Boolean, deepLink: String? = null) {
                         onUserClick = { navController.navigate(Route.UserProfile.create(it)) },
                         onHistoryClick = { historyId -> navController.navigate(Route.HistoryDetail.create(eventId, historyId)) },
                         onAllHistory = { navController.navigate(Route.EventHistory.create(eventId)) },
+                        onCourtAlternatives = { navController.navigate(Route.CourtAlternatives.create(eventId)) },
                         sharedTransitionScope = this@SharedTransitionLayout,
                         animatedVisibilityScope = this@composable,
                     )
@@ -260,6 +264,19 @@ fun AppNavigation(isAuthenticated: Boolean, deepLink: String? = null) {
                         onBack = { navController.popBackStack() },
                         onHistoryClick = { historyId -> navController.navigate(Route.HistoryDetail.create(eventId, historyId)) },
                     )
+                }
+                composable(
+                    Route.CourtAlternatives().route,
+                    arguments = listOf(navArgument("eventId") { type = NavType.StringType }),
+                ) { entry ->
+                    val eventId = entry.arguments?.getString("eventId") ?: return@composable
+                    CourtAlternativesScreen(
+                        eventId = eventId,
+                        onBack = { navController.popBackStack() },
+                    )
+                }
+                composable(Route.CourtWatches.route) {
+                    CourtWatchesScreen(onBack = { navController.popBackStack() })
                 }
             }
         }

--- a/android-app/app/src/main/java/dev/convocados/ui/navigation/Route.kt
+++ b/android-app/app/src/main/java/dev/convocados/ui/navigation/Route.kt
@@ -36,4 +36,8 @@ sealed class Route(val route: String) {
     data class EventHistory(val id: String = "{eventId}") : Route("event/{eventId}/history") {
         companion object { fun create(id: String) = "event/$id/history" }
     }
+    data class CourtAlternatives(val id: String = "{eventId}") : Route("event/{eventId}/courts") {
+        companion object { fun create(id: String) = "event/$id/courts" }
+    }
+    data object CourtWatches : Route("court-watches")
 }

--- a/android-app/app/src/main/java/dev/convocados/ui/screen/courts/CourtAlternativesScreen.kt
+++ b/android-app/app/src/main/java/dev/convocados/ui/screen/courts/CourtAlternativesScreen.kt
@@ -1,0 +1,242 @@
+package dev.convocados.ui.screen.courts
+
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Notifications
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dev.convocados.data.api.*
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+data class CourtAlternativesState(
+    val loading: Boolean = false,
+    val alternatives: List<CourtAlternative> = emptyList(),
+    val startTime: String = "19:00",
+    val endTime: String = "21:00",
+    val error: String? = null,
+    val watchCreated: Boolean = false,
+    val sport: String = "",
+    val timezone: String = "",
+)
+
+@HiltViewModel
+class CourtAlternativesViewModel @Inject constructor(
+    private val api: ConvocadosApi,
+) : ViewModel() {
+    private val _state = MutableStateFlow(CourtAlternativesState())
+    val state: StateFlow<CourtAlternativesState> = _state
+
+    fun load(eventId: String) {
+        val s = _state.value
+        _state.value = s.copy(loading = true, error = null)
+        viewModelScope.launch {
+            // Fetch event for sport/timezone if not yet loaded
+            if (s.sport.isBlank()) {
+                runCatching { api.fetchEvent(eventId) }.onSuccess { event ->
+                    _state.value = _state.value.copy(sport = event.sport, timezone = event.timezone)
+                }
+            }
+            runCatching {
+                api.fetchCourtAlternatives(
+                    eventId = eventId,
+                    startTime = _state.value.startTime,
+                    endTime = _state.value.endTime,
+                )
+            }.onSuccess { resp ->
+                _state.value = _state.value.copy(loading = false, alternatives = resp.alternatives)
+            }.onFailure { e ->
+                _state.value = _state.value.copy(loading = false, error = e.message)
+            }
+        }
+    }
+
+    fun setStartTime(time: String) { _state.value = _state.value.copy(startTime = time) }
+    fun setEndTime(time: String) { _state.value = _state.value.copy(endTime = time) }
+
+    fun createWatch(alt: CourtAlternative, dayOfWeek: Int) {
+        viewModelScope.launch {
+            val s = _state.value
+            runCatching {
+                api.createCourtWatch(CreateCourtWatchRequest(
+                    sport = s.sport,
+                    tenantId = alt.tenantId,
+                    tenantName = alt.tenantName,
+                    resourceId = "",
+                    resourceName = alt.resourceName,
+                    dayOfWeek = dayOfWeek,
+                    startTime = s.startTime,
+                    endTime = s.endTime,
+                    timezone = s.timezone,
+                ))
+            }.onSuccess {
+                _state.value = _state.value.copy(watchCreated = true)
+            }
+        }
+    }
+
+    fun dismissWatchCreated() { _state.value = _state.value.copy(watchCreated = false) }
+}
+
+val PLAYTOMIC_SPORTS = setOf("padel", "football-5v5", "futsal", "tennis-singles", "tennis-doubles", "football-7v7")
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CourtAlternativesScreen(
+    eventId: String,
+    onBack: () -> Unit,
+    viewModel: CourtAlternativesViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsState()
+    val context = LocalContext.current
+    var selectedSlot by remember { mutableStateOf<CourtAlternative?>(null) }
+
+    LaunchedEffect(eventId) { viewModel.load(eventId) }
+
+    val snackbarHostState = remember { SnackbarHostState() }
+    LaunchedEffect(state.watchCreated) {
+        if (state.watchCreated) {
+            snackbarHostState.showSnackbar("Watch created! You'll be notified when it's free.")
+            viewModel.dismissWatchCreated()
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Court Alternatives") },
+                navigationIcon = { IconButton(onClick = onBack) { Icon(Icons.AutoMirrored.Filled.ArrowBack, "Back") } },
+            )
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+    ) { padding ->
+        Column(
+            Modifier.fillMaxSize().padding(padding).verticalScroll(rememberScrollState()).padding(16.dp)
+        ) {
+            // Time filter
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedTextField(
+                    value = state.startTime,
+                    onValueChange = { viewModel.setStartTime(it) },
+                    label = { Text("From") },
+                    modifier = Modifier.weight(1f),
+                    singleLine = true,
+                )
+                OutlinedTextField(
+                    value = state.endTime,
+                    onValueChange = { viewModel.setEndTime(it) },
+                    label = { Text("To") },
+                    modifier = Modifier.weight(1f),
+                    singleLine = true,
+                )
+                FilledTonalButton(onClick = { viewModel.load(eventId) }) { Text("Search") }
+            }
+
+            Spacer(Modifier.height(16.dp))
+
+            when {
+                state.loading -> Box(Modifier.fillMaxWidth(), Alignment.Center) {
+                    CircularProgressIndicator()
+                }
+                state.error != null -> Text(state.error!!, color = MaterialTheme.colorScheme.error)
+                state.alternatives.isEmpty() -> Text("No courts found for this time range.", color = MaterialTheme.colorScheme.outline)
+                else -> {
+                    // Group by club
+                    val grouped = state.alternatives.groupBy { it.tenantName }
+                    grouped.forEach { (clubName, slots) ->
+                        Text(
+                            clubName,
+                            fontWeight = FontWeight.Bold,
+                            fontSize = 16.sp,
+                            modifier = Modifier.padding(top = 12.dp, bottom = 4.dp),
+                        )
+                        if (slots.firstOrNull()?.distanceKm?.let { it > 0 } == true) {
+                            Text(
+                                "📍 ${String.format("%.1f", slots.first().distanceKm)} km",
+                                fontSize = 12.sp,
+                                color = MaterialTheme.colorScheme.outline,
+                            )
+                        }
+                        Row(
+                            Modifier.horizontalScroll(rememberScrollState()),
+                            horizontalArrangement = Arrangement.spacedBy(6.dp),
+                        ) {
+                            slots.forEach { slot ->
+                                val isBooked = slot.status == "booked"
+                                val timeLabel = slot.slotTime.substringAfter("T").take(5)
+                                val priceLabel = "${slot.currency} ${String.format("%.0f", slot.price)}"
+
+                                if (isBooked) {
+                                    // Greyed chip with bell icon
+                                    AssistChip(
+                                        onClick = {
+                                            viewModel.createWatch(slot, 1)
+                                        },
+                                        label = { Text("$timeLabel · $priceLabel", fontSize = 12.sp) },
+                                        trailingIcon = {
+                                            Icon(
+                                                Icons.Default.Notifications,
+                                                "Notify when free",
+                                                modifier = Modifier.size(16.dp),
+                                            )
+                                        },
+                                        colors = AssistChipDefaults.assistChipColors(
+                                            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                                            labelColor = MaterialTheme.colorScheme.outline,
+                                        ),
+                                    )
+                                } else {
+                                    AssistChip(
+                                        onClick = { selectedSlot = slot },
+                                        label = { Text("$timeLabel · $priceLabel", fontSize = 12.sp) },
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Slot action dialog
+    selectedSlot?.let { slot ->
+        AlertDialog(
+            onDismissRequest = { selectedSlot = null },
+            title = { Text("${slot.tenantName} — ${slot.resourceName}") },
+            text = {
+                val timeLabel = slot.slotTime.substringAfter("T").take(5)
+                Text("$timeLabel · ${slot.currency} ${String.format("%.0f", slot.price)}")
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    selectedSlot = null
+                    if (slot.playtomicUrl.isNotBlank()) {
+                        context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(slot.playtomicUrl)))
+                    }
+                }) { Text("Book on Playtomic", fontWeight = FontWeight.Bold) }
+            },
+            dismissButton = {
+                TextButton(onClick = { selectedSlot = null }) { Text("Cancel") }
+            },
+        )
+    }
+}

--- a/android-app/app/src/main/java/dev/convocados/ui/screen/courts/CourtWatchesScreen.kt
+++ b/android-app/app/src/main/java/dev/convocados/ui/screen/courts/CourtWatchesScreen.kt
@@ -1,0 +1,128 @@
+package dev.convocados.ui.screen.courts
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dev.convocados.data.api.ConvocadosApi
+import dev.convocados.data.api.CourtWatch
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+data class CourtWatchesState(
+    val loading: Boolean = true,
+    val watches: List<CourtWatch> = emptyList(),
+    val error: String? = null,
+)
+
+@HiltViewModel
+class CourtWatchesViewModel @Inject constructor(
+    private val api: ConvocadosApi,
+) : ViewModel() {
+    private val _state = MutableStateFlow(CourtWatchesState())
+    val state: StateFlow<CourtWatchesState> = _state
+
+    init { load() }
+
+    private fun load() {
+        viewModelScope.launch {
+            _state.value = _state.value.copy(loading = true)
+            runCatching { api.fetchCourtWatches() }
+                .onSuccess { _state.value = CourtWatchesState(loading = false, watches = it.watches) }
+                .onFailure { _state.value = CourtWatchesState(loading = false, error = it.message) }
+        }
+    }
+
+    fun deleteWatch(id: String) {
+        _state.value = _state.value.copy(watches = _state.value.watches.filter { it.id != id })
+        viewModelScope.launch {
+            runCatching { api.deleteCourtWatch(id) }
+                .onFailure { load() } // reload on failure to restore
+        }
+    }
+}
+
+private val DAY_NAMES = listOf("Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun")
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CourtWatchesScreen(
+    onBack: () -> Unit,
+    viewModel: CourtWatchesViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsState()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Court Watches") },
+                navigationIcon = { IconButton(onClick = onBack) { Icon(Icons.AutoMirrored.Filled.ArrowBack, "Back") } },
+            )
+        },
+    ) { padding ->
+        when {
+            state.loading -> Box(Modifier.fillMaxSize().padding(padding), Alignment.Center) {
+                CircularProgressIndicator()
+            }
+            state.error != null -> Box(Modifier.fillMaxSize().padding(padding), Alignment.Center) {
+                Text(state.error!!, color = MaterialTheme.colorScheme.error)
+            }
+            state.watches.isEmpty() -> Box(Modifier.fillMaxSize().padding(padding), Alignment.Center) {
+                Text("No court watches yet.\nCreate one from an event's Court Alternatives.", color = MaterialTheme.colorScheme.outline, modifier = Modifier.padding(32.dp))
+            }
+            else -> LazyColumn(Modifier.fillMaxSize().padding(padding), contentPadding = PaddingValues(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                items(state.watches, key = { it.id }) { watch ->
+                    SwipeToDismissBox(
+                        state = rememberSwipeToDismissBoxState(
+                            confirmValueChange = { value ->
+                                if (value == SwipeToDismissBoxValue.EndToStart) {
+                                    viewModel.deleteWatch(watch.id)
+                                    true
+                                } else false
+                            }
+                        ),
+                        backgroundContent = {
+                            Box(
+                                Modifier.fillMaxSize().background(MaterialTheme.colorScheme.errorContainer).padding(horizontal = 20.dp),
+                                contentAlignment = Alignment.CenterEnd,
+                            ) {
+                                Icon(Icons.Default.Delete, "Delete", tint = MaterialTheme.colorScheme.onErrorContainer)
+                            }
+                        },
+                        enableDismissFromStartToEnd = false,
+                    ) {
+                        Card(Modifier.fillMaxWidth()) {
+                            Column(Modifier.padding(16.dp)) {
+                                Text(watch.tenantName, fontWeight = FontWeight.Bold, fontSize = 15.sp)
+                                Text(watch.resourceName, fontSize = 13.sp, color = MaterialTheme.colorScheme.outline)
+                                Spacer(Modifier.height(4.dp))
+                                val dayLabel = DAY_NAMES.getOrElse(watch.dayOfWeek - 1) { "?" }
+                                Text(
+                                    "$dayLabel · ${watch.startTime}–${watch.endTime}",
+                                    fontSize = 13.sp,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/android-app/app/src/main/java/dev/convocados/ui/screen/event/EventDetailScreen.kt
+++ b/android-app/app/src/main/java/dev/convocados/ui/screen/event/EventDetailScreen.kt
@@ -35,6 +35,7 @@ import dev.convocados.data.api.*
 import dev.convocados.data.auth.TokenStore
 import dev.convocados.data.datastore.SettingsStore
 import dev.convocados.data.repository.EventRepository
+import dev.convocados.ui.screen.courts.PLAYTOMIC_SPORTS
 import dev.convocados.ui.screen.games.formatRelativeDate
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
@@ -393,6 +394,7 @@ fun EventDetailScreen(
     onUserClick: (String) -> Unit,
     onHistoryClick: (String) -> Unit = {},
     onAllHistory: () -> Unit = {},
+    onCourtAlternatives: () -> Unit = {},
     viewModel: EventDetailViewModel = hiltViewModel(),
     sharedTransitionScope: SharedTransitionScope,
     animatedVisibilityScope: AnimatedVisibilityScope,
@@ -541,6 +543,7 @@ fun EventDetailScreen(
                             if (activePlayers.size >= 2) AssistChip(onClick = { viewModel.randomize(eventId, event.balanced) }, label = { Text("\uD83C\uDFB2 Randomize") })
                             if (isOwner || event.isAdmin) AssistChip(onClick = onSettings, label = { Text("\u2699\uFE0F") })
                             AssistChip(onClick = onRankings, label = { Text("\uD83C\uDFC6 Rankings") })
+                            if (event.sport in PLAYTOMIC_SPORTS) AssistChip(onClick = onCourtAlternatives, label = { Text("\uD83C\uDFDF\uFE0F Courts") })
                             AssistChip(onClick = onNotificationPrefs, label = { Text("\uD83D\uDD14") })
                         }
 

--- a/android-app/app/src/main/java/dev/convocados/ui/screen/profile/ProfileScreen.kt
+++ b/android-app/app/src/main/java/dev/convocados/ui/screen/profile/ProfileScreen.kt
@@ -81,6 +81,7 @@ class ProfileViewModel @Inject constructor(
 fun ProfileScreen(
     onLogout: () -> Unit,
     onNotificationPrefs: () -> Unit,
+    onCourtWatches: () -> Unit = {},
     viewModel: ProfileViewModel = hiltViewModel(),
 ) {
     val user by viewModel.user.collectAsState()
@@ -110,6 +111,9 @@ fun ProfileScreen(
 
         // Notifications
         MenuItem(title = "\uD83D\uDD14 ${stringResource(R.string.notifications_title)}", subtitle = stringResource(R.string.notifications_subtitle), onClick = onNotificationPrefs)
+
+        // Court Watches
+        MenuItem(title = "\uD83C\uDFDF\uFE0F Court Watches", subtitle = "Notify when booked courts free up", onClick = onCourtWatches)
 
         // Language
         MenuItem(title = stringResource(R.string.language), subtitle = LOCALE_OPTIONS.find { it.code == locale }?.label ?: "English", onClick = { showLanguages = !showLanguages })

--- a/src/lib/openapi.ts
+++ b/src/lib/openapi.ts
@@ -806,6 +806,34 @@ export const openApiSpec = {
         },
       },
     },
+    "/api/court-watches": {
+      get: {
+        summary: "List court watches",
+        tags: ["Court Finder"],
+        responses: { "200": { description: "User's court watches" }, ...errorResponses },
+      },
+      post: {
+        summary: "Create a court watch",
+        tags: ["Court Finder"],
+        responses: { "201": { description: "Watch created" }, ...errorResponses },
+      },
+    },
+    "/api/court-watches/{id}": {
+      delete: {
+        summary: "Delete a court watch",
+        tags: ["Court Finder"],
+        parameters: [{ name: "id", in: "path", required: true, schema: { type: "string" } }],
+        responses: { "200": { description: "Watch deleted" }, ...errorResponses },
+      },
+    },
+    "/api/events/{id}/court-alternatives": {
+      get: {
+        summary: "Search court alternatives for an event",
+        tags: ["Court Finder"],
+        parameters: [eventIdParam],
+        responses: { "200": { description: "Court alternatives" }, ...errorResponses },
+      },
+    },
   },
   tags: [
     { name: "System", description: "Health and status" },


### PR DESCRIPTION
Implements the court finder feature on the Android app, consuming the existing backend APIs.

### Features
- **Court Alternatives screen** — search nearby Playtomic courts with time filter, results grouped by club with slot chips
- **Slot action dialog** — tap a chip to 'Book on Playtomic' (opens in Playtomic app/browser) or view details
- **Notify when free** — tap bell on booked courts to create a recurring court watch
- **Court Watches screen** — accessible from profile, lists watches with swipe-to-delete
- **Smart visibility** — Courts chip only shows on event detail for Playtomic-supported sports

### Technical
- API methods added to ConvocadosApi: fetchCourtAlternatives, fetchCourtWatches, createCourtWatch, deleteCourtWatch
- Models: CourtAlternative, CourtWatch, CourtWatchesResponse, CreateCourtWatchRequest
- Navigation routes registered in AppNavigation + Route sealed class
- OpenAPI spec updated with court-watches and court-alternatives endpoints
- Feature parity manifest updated: android: true