### PR TITLE
fix: exclude sender from push notifications on their own actions

### DIFF
--- a/src/pages/api/events/[id]/datetime.ts
+++ b/src/pages/api/events/[id]/datetime.ts
@@ -91,7 +91,7 @@ export const PUT: APIRoute = async ({ params, request }) => {
       params: { title: event.title },
       url,
       spotsLeft,
-    });
+    }, session?.user?.id);
 
     // Drain notification queue before responding so push is sent immediately.
     if (!process.env.VITEST) {

--- a/src/pages/api/events/[id]/players.ts
+++ b/src/pages/api/events/[id]/players.ts
@@ -204,7 +204,7 @@ export const POST: APIRoute = async ({ params, request }) => {
   const proto = request.headers.get("x-forwarded-proto") ?? "https";
   const origin = `${proto}://${host}`;
   const session = await getSession(request);
-  const senderClientId = request.headers.get("x-client-id") ?? session?.user?.id ?? undefined;
+  const senderClientId = session?.user?.id ?? request.headers.get("x-client-id") ?? undefined;
   const event = await prisma.event.findUnique({
     where: { id: eventId },
     include: { players: { orderBy: { order: "asc" } } },
@@ -407,7 +407,7 @@ export const DELETE: APIRoute = async ({ params, request }) => {
   const origin = `${proto}://${host}`;
   const { playerId } = await request.json();
   const session = await getSession(request);
-  const senderClientId = request.headers.get("x-client-id") ?? session?.user?.id ?? undefined;
+  const senderClientId = session?.user?.id ?? request.headers.get("x-client-id") ?? undefined;
 
   const event = await prisma.event.findUnique({
     where: { id: eventId },

--- a/src/pages/api/events/[id]/switch-court.ts
+++ b/src/pages/api/events/[id]/switch-court.ts
@@ -17,7 +17,7 @@ export const POST: APIRoute = async ({ params, request }) => {
   });
   if (!event) return Response.json({ error: "Not found." }, { status: 404 });
 
-  const { isOwner, isAdmin } = await checkOwnership(request, event.ownerId, undefined, params.id);
+  const { isOwner, isAdmin, session } = await checkOwnership(request, event.ownerId, undefined, params.id);
   if (!isOwner && !isAdmin) {
     return Response.json({ error: "Only event owner or admins can switch courts." }, { status: 403 });
   }
@@ -56,7 +56,7 @@ export const POST: APIRoute = async ({ params, request }) => {
     params: { title: event.title },
     url: `/events/${event.id}`,
     spotsLeft,
-  });
+  }, session?.user?.id);
 
   if (!process.env.VITEST) {
     await drainNotificationQueue().catch((err) => {


### PR DESCRIPTION
Fixes sender exclusion from push notifications. The web app sends X-Client-Id (random UUID from localStorage) which was prioritized over session user ID. Swapped priority order and added sender exclusion to switch-court and datetime endpoints.