### PR TITLE
fix(ci): correct release keystore path so APK build jobs sign & publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -230,7 +230,7 @@ jobs:
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
         run: |
-          printenv ANDROID_KEYSTORE | base64 -d > app/release-keystore.jks
+          printenv ANDROID_KEYSTORE | base64 -d > release-keystore.jks
           {
             echo "storeFile=release-keystore.jks"
             echo "storePassword=$KEYSTORE_PASSWORD"
@@ -330,7 +330,7 @@ jobs:
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
         run: |
-          printenv ANDROID_KEYSTORE | base64 -d > app/release-keystore.jks
+          printenv ANDROID_KEYSTORE | base64 -d > release-keystore.jks
           {
             echo "storeFile=release-keystore.jks"
             echo "storePassword=$KEYSTORE_PASSWORD"


### PR DESCRIPTION
## Problem
The `Build Android APK` and `Build Wear OS APK` jobs in `release.yml` failed with:
`SigningConfig "release" is missing required property "storeFile".`

They wrote the keystore to `app/release-keystore.jks`, but the `keystore.properties` they generate sets `storeFile=release-keystore.jks`, which Gradle resolves via `rootProject.file(...)` at the **android-app root**. The file was never found → unsigned package → `packageRelease` failed. (The `publish-play-store` job already used the correct path, which is why Play Store publishing succeeded while the APK-attach jobs failed.)

## Fix
Write the keystore to `release-keystore.jks` (android-app root) in both APK build jobs, matching Gradle and the publish job.

## Verified locally
`:app:bundleRelease` and `:wear:bundleRelease` both produce **signed** AABs (lintVitalRelease passes).