### PR TITLE
feat: invite players by email (notify if registered, email invite if not)

### DIFF
--- a/android-app/app/src/main/java/dev/convocados/data/api/ConvocadosApi.kt
+++ b/android-app/app/src/main/java/dev/convocados/data/api/ConvocadosApi.kt
@@ -33,8 +33,8 @@ class ConvocadosApi @Inject constructor(private val client: ApiClient) {
         client.get("/api/events/$id/post-game-status")
 
     // ── Players ───────────────────────────────────────────────────────────
-    suspend fun addPlayer(eventId: String, name: String, linkToAccount: Boolean = true): OkResponse =
-        client.post("/api/events/$eventId/players", AddPlayerRequest(name, linkToAccount))
+    suspend fun addPlayer(eventId: String, name: String, linkToAccount: Boolean = true, email: String? = null): OkResponse =
+        client.post("/api/events/$eventId/players", AddPlayerRequest(name, linkToAccount, email))
 
     suspend fun removePlayer(eventId: String, playerId: String): RemovePlayerResponse =
         client.delete("/api/events/$eventId/players", RemovePlayerRequest(playerId))
@@ -243,7 +243,7 @@ data class CreateEventRequest(
     val recurrenceInterval: Int? = null,
 )
 
-@Serializable data class AddPlayerRequest(val name: String, val linkToAccount: Boolean = true)
+@Serializable data class AddPlayerRequest(val name: String, val linkToAccount: Boolean = true, val email: String? = null)
 @Serializable data class RemovePlayerRequest(val playerId: String)
 @Serializable data class ClaimPlayerRequest(val playerId: String)
 @Serializable data class TitleRequest(val title: String)

--- a/android-app/app/src/main/java/dev/convocados/data/repository/EventRepository.kt
+++ b/android-app/app/src/main/java/dev/convocados/data/repository/EventRepository.kt
@@ -78,8 +78,8 @@ class EventRepository @Inject constructor(
         }
     }
 
-    suspend fun addPlayer(eventId: String, name: String, link: Boolean): Result<Unit> = try {
-        api.addPlayer(eventId, name, link)
+    suspend fun addPlayer(eventId: String, name: String, link: Boolean, email: String? = null): Result<Unit> = try {
+        api.addPlayer(eventId, name, link, email)
         refreshEventDetail(eventId)
         Result.success(Unit)
     } catch (e: Exception) {

--- a/android-app/app/src/main/java/dev/convocados/ui/screen/event/EventDetailScreen.kt
+++ b/android-app/app/src/main/java/dev/convocados/ui/screen/event/EventDetailScreen.kt
@@ -215,9 +215,9 @@ class EventDetailViewModel @Inject constructor(
         load(eventId)
     }
 
-    fun addPlayer(eventId: String, name: String, link: Boolean = true) {
+    fun addPlayer(eventId: String, name: String, link: Boolean = true, email: String? = null) {
         viewModelScope.launch {
-            repository.addPlayer(eventId, name, link)
+            repository.addPlayer(eventId, name, link, email)
                 .onSuccess {
                     // Auto-open payment dialog after join if preference is set
                     if (autoPayOnJoin.value && _state.value.balance?.callerBalance?.let { it.amount > 0 } == true) {
@@ -781,16 +781,30 @@ fun EventDetailScreen(
                             }
 
                             Column {
+                                var pickedEmail by remember { mutableStateOf<String?>(null) }
+                                // Pick a contact's email directly (ACTION_PICK on the Email table):
+                                // the picker grants temporary access to the chosen row, so we read
+                                // the name + email without the READ_CONTACTS permission.
                                 val contactPicker = rememberLauncherForActivityResult(
-                                    androidx.activity.result.contract.ActivityResultContracts.PickContact()
-                                ) { uri ->
-                                    uri?.let {
-                                        runCatching {
-                                            context.contentResolver.query(
-                                                it,
-                                                arrayOf(android.provider.ContactsContract.Contacts.DISPLAY_NAME),
-                                                null, null, null,
-                                            )?.use { c -> if (c.moveToFirst()) c.getString(0)?.let { name -> newPlayer = name } }
+                                    androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult()
+                                ) { result ->
+                                    if (result.resultCode == android.app.Activity.RESULT_OK) {
+                                        result.data?.data?.let { uri ->
+                                            runCatching {
+                                                context.contentResolver.query(
+                                                    uri,
+                                                    arrayOf(
+                                                        android.provider.ContactsContract.CommonDataKinds.Email.ADDRESS,
+                                                        android.provider.ContactsContract.CommonDataKinds.Email.DISPLAY_NAME,
+                                                    ),
+                                                    null, null, null,
+                                                )?.use { c ->
+                                                    if (c.moveToFirst()) {
+                                                        c.getString(1)?.takeIf { it.isNotBlank() }?.let { name -> newPlayer = name }
+                                                        pickedEmail = c.getString(0)?.takeIf { it.isNotBlank() }
+                                                    }
+                                                }
+                                            }
                                         }
                                     }
                                 }
@@ -799,15 +813,28 @@ fun EventDetailScreen(
                                         value = newPlayer, onValueChange = { newPlayer = it },
                                         placeholder = { Text(stringResource(R.string.add_player_placeholder)) }, singleLine = true,
                                         modifier = Modifier.weight(1f),
+                                        supportingText = pickedEmail?.let { { Text(stringResource(R.string.will_invite, it)) } },
                                         trailingIcon = {
-                                            IconButton(onClick = { contactPicker.launch(null) }) {
+                                            IconButton(onClick = {
+                                                contactPicker.launch(
+                                                    android.content.Intent(
+                                                        android.content.Intent.ACTION_PICK,
+                                                        android.provider.ContactsContract.CommonDataKinds.Email.CONTENT_URI,
+                                                    )
+                                                )
+                                            }) {
                                                 Icon(Icons.Default.Contacts, contentDescription = stringResource(R.string.add_from_contacts), tint = MaterialTheme.colorScheme.primary)
                                             }
                                         },
                                         colors = OutlinedTextFieldDefaults.colors(focusedTextColor = MaterialTheme.colorScheme.onSurface, unfocusedTextColor = MaterialTheme.colorScheme.onSurface, focusedBorderColor = MaterialTheme.colorScheme.primary, unfocusedBorderColor = MaterialTheme.colorScheme.outline, cursorColor = MaterialTheme.colorScheme.primary, focusedContainerColor = MaterialTheme.colorScheme.surfaceVariant, unfocusedContainerColor = MaterialTheme.colorScheme.surfaceVariant),
                                     )
                                     Button(
-                                        onClick = { viewModel.addPlayer(eventId, newPlayer.trim()); newPlayer = "" },
+                                        onClick = {
+                                            val em = pickedEmail
+                                            if (em != null) viewModel.addPlayer(eventId, newPlayer.trim(), link = false, email = em)
+                                            else viewModel.addPlayer(eventId, newPlayer.trim())
+                                            newPlayer = ""; pickedEmail = null
+                                        },
                                         enabled = newPlayer.isNotBlank(),
                                         colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primaryContainer),
                                     ) { Text(stringResource(R.string.add_button), color = MaterialTheme.colorScheme.onPrimaryContainer, fontWeight = FontWeight.Bold) }

--- a/android-app/app/src/main/res/values-de/strings.xml
+++ b/android-app/app/src/main/res/values-de/strings.xml
@@ -246,4 +246,5 @@
     <string name="teams_random">Zufällig</string>
     <string name="add_from_contacts">Aus Kontakten hinzufügen</string>
     <string name="no_archived_games">Keine archivierten Spiele</string>
+    <string name="will_invite">Lädt %1$s ein</string>
 </resources>

--- a/android-app/app/src/main/res/values-es/strings.xml
+++ b/android-app/app/src/main/res/values-es/strings.xml
@@ -246,4 +246,5 @@
     <string name="teams_random">Aleatorios</string>
     <string name="add_from_contacts">Añadir desde contactos</string>
     <string name="no_archived_games">No hay partidos archivados</string>
+    <string name="will_invite">Invitará a %1$s</string>
 </resources>

--- a/android-app/app/src/main/res/values-fr/strings.xml
+++ b/android-app/app/src/main/res/values-fr/strings.xml
@@ -246,4 +246,5 @@
     <string name="teams_random">Aléatoires</string>
     <string name="add_from_contacts">Ajouter depuis les contacts</string>
     <string name="no_archived_games">Aucun match archivé</string>
+    <string name="will_invite">Invitera %1$s</string>
 </resources>

--- a/android-app/app/src/main/res/values-it/strings.xml
+++ b/android-app/app/src/main/res/values-it/strings.xml
@@ -246,4 +246,5 @@
     <string name="teams_random">Casuali</string>
     <string name="add_from_contacts">Aggiungi dai contatti</string>
     <string name="no_archived_games">Nessuna partita archiviata</string>
+    <string name="will_invite">Inviterà %1$s</string>
 </resources>

--- a/android-app/app/src/main/res/values-pt/strings.xml
+++ b/android-app/app/src/main/res/values-pt/strings.xml
@@ -246,4 +246,5 @@
     <string name="teams_random">Aleatórias</string>
     <string name="add_from_contacts">Adicionar dos contactos</string>
     <string name="no_archived_games">Sem jogos arquivados</string>
+    <string name="will_invite">Vai convidar %1$s</string>
 </resources>

--- a/android-app/app/src/main/res/values/strings.xml
+++ b/android-app/app/src/main/res/values/strings.xml
@@ -264,4 +264,5 @@
     <string name="teams_random">Random</string>
     <string name="add_from_contacts">Add from contacts</string>
     <string name="no_archived_games">No archived games</string>
+    <string name="will_invite">Will invite %1$s</string>
 </resources>

--- a/src/components/EventPage.tsx
+++ b/src/components/EventPage.tsx
@@ -193,7 +193,7 @@ export default function EventPage({ eventId }: { eventId: string }) {
 
   // ── Player CRUD ─────────────────────────────────────────────────────────────
 
-  const addPlayer = async (name: string, linkToAccount = false) => {
+  const addPlayer = async (name: string, linkToAccount = false, email?: string) => {
     if (!name.trim()) return;
     setPlayerError(null);
     const trimmed = name.trim().slice(0, 50);
@@ -208,7 +208,7 @@ export default function EventPage({ eventId }: { eventId: string }) {
     const res = await fetch(`/api/events/${eventId}/players`, {
       method: "POST",
       headers: { "Content-Type": "application/json", "X-Client-Id": clientIdRef.current },
-      body: JSON.stringify({ name: trimmed, linkToAccount }),
+      body: JSON.stringify({ name: trimmed, linkToAccount, ...(email ? { email: email.trim() } : {}) }),
     });
     const json = await res.json();
     if (!res.ok) {
@@ -579,7 +579,7 @@ export default function EventPage({ eventId }: { eventId: string }) {
               availableSuggestions={availableSuggestions}
               playerError={playerError}
               onPlayerErrorChange={setPlayerError}
-              onAddPlayer={addPlayer}
+              onAddPlayer={(name, email) => addPlayer(name, false, email)}
               onRemovePlayer={removePlayer}
               onReorderPlayers={reorderPlayers}
               onResetPlayerOrder={resetPlayerOrder}

--- a/src/components/event/PlayerList.tsx
+++ b/src/components/event/PlayerList.tsx
@@ -30,7 +30,7 @@ interface Props {
   availableSuggestions: PlayerSuggestion[];
   playerError: string | null;
   onPlayerErrorChange: (error: string | null) => void;
-  onAddPlayer: (name: string) => Promise<void>;
+  onAddPlayer: (name: string, email?: string) => Promise<void>;
   onRemovePlayer: (playerId: string) => Promise<void>;
   onReorderPlayers: (playerIds: string[]) => Promise<void>;
   onResetPlayerOrder: () => Promise<void>;
@@ -48,6 +48,7 @@ export function PlayerList({
   const t = useT();
   const theme = useTheme();
   const [playerInput, setPlayerInput] = useState("");
+  const [inviteEmail, setInviteEmail] = useState("");
 
   // ── Player reorder drag state ──────────────────────────────────────────────
   const [dragPlayer, setDragPlayer] = useState<{ id: string; index: number } | null>(null);
@@ -164,8 +165,9 @@ export function PlayerList({
                   if (hasPartialMatch) return;
                   e.preventDefault();
                   e.stopPropagation();
-                  onAddPlayer(trimmed);
+                  onAddPlayer(trimmed, inviteEmail.trim() || undefined);
                   setPlayerInput("");
+                  setInviteEmail("");
                 }
               }}
               onPaste={(e) => {
@@ -182,7 +184,7 @@ export function PlayerList({
                   <InputAdornment position="end">
                     <IconButton color="primary" edge="end"
                       disabled={!playerInput.trim()}
-                      onClick={() => { onAddPlayer(playerInput); setPlayerInput(""); }}>
+                      onClick={() => { onAddPlayer(playerInput, inviteEmail.trim() || undefined); setPlayerInput(""); setInviteEmail(""); }}>
                       <PersonAddIcon />
                     </IconButton>
                   </InputAdornment>
@@ -219,6 +221,20 @@ export function PlayerList({
             );
           }}
           noOptionsText={t("noSuggestions")}
+        />
+
+        {/* Optional: notify a registered player or email an invite to register */}
+        <TextField
+          type="email"
+          size="small"
+          variant="outlined"
+          fullWidth
+          value={inviteEmail}
+          onChange={(e) => setInviteEmail(e.target.value)}
+          placeholder={t("inviteByEmailPlaceholder")}
+          helperText={t("inviteByEmailHelper")}
+          inputProps={{ inputMode: "email", maxLength: 120 }}
+          sx={{ mt: 1 }}
         />
 
         {/* Recent players — quick-add chips */}

--- a/src/lib/email.server.ts
+++ b/src/lib/email.server.ts
@@ -166,6 +166,39 @@ export async function sendGameInvite(to: string, data: GameInviteData) {
   if (result.error) throw new Error(`Failed to send game invite: ${result.error.message}`);
 }
 
+export interface PlayerInviteData {
+  eventTitle: string;
+  dateTime: string;
+  location: string;
+  eventUrl: string;
+  /** Who added them, for context (optional). */
+  inviterName?: string | null;
+}
+
+/**
+ * Sent when someone adds a player by email and that email is NOT yet a
+ * registered Convocados account — invites them to register and claim their spot.
+ */
+export async function sendPlayerInviteToRegister(to: string, data: PlayerInviteData) {
+  const resend = await getResend();
+  const when = new Date(data.dateTime).toLocaleString("en-GB", { dateStyle: "medium", timeStyle: "short" });
+  const inviter = data.inviterName ? `${data.inviterName} added you to` : "You've been added to";
+  const signupUrl = `${getAppUrl()}/auth/signup?email=${encodeURIComponent(to)}`;
+  const result = await resend.emails.send({
+    from: EMAIL_FROM,
+    to,
+    subject: `You're in: ${data.eventTitle} — join Convocados`,
+    html: emailTemplate({
+      heading: `${inviter} ${data.eventTitle}`,
+      body: `📍 ${data.location}<br/>🕐 ${when}<br/><br/>Create a free Convocados account to confirm your spot, see the team and get reminders.`,
+      buttonText: "Join Convocados",
+      buttonUrl: signupUrl,
+      footnote: `Or just view the game: <a href="${data.eventUrl}" style="color:#1b6b4a;">${data.eventTitle}</a>`,
+    }),
+  });
+  if (result.error) throw new Error(`Failed to send player invite: ${result.error.message}`);
+}
+
 export interface ReminderData {
   eventTitle: string;
   dateTime: string;

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -64,6 +64,8 @@ const de: TranslationKeys = {
   copyLink: "Link kopieren",
   players: "Spieler",
   addPlayerPlaceholder: "Spieler hinzufügen",
+  inviteByEmailPlaceholder: "Per E-Mail einladen (optional)",
+  inviteByEmailHelper: "Benachrichtigt sie, wenn sie bei Convocados sind, sonst per E-Mail-Einladung",
   addPlayerHelper: "Enter drücken zum Hinzufügen, oder eine zeilengetrennte Liste einfügen",
   randomizeTeams: "Teams auslosen",
   teamsOutOfSync: "Die Spieler haben sich seit der letzten Auslosung geändert. Erwäge eine neue Auslosung.",

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -72,6 +72,8 @@ const en = {
   copyLink: "Copy link",
   players: "Players",
   addPlayerPlaceholder: "Add player name",
+  inviteByEmailPlaceholder: "Invite by email (optional)",
+  inviteByEmailHelper: "Notifies them if they're on Convocados, otherwise emails an invite to join",
   addPlayerHelper: "Press Enter to add, or paste a newline-separated list",
   randomizeTeams: "Randomize teams",
   teamsOutOfSync: "Players have changed since teams were last randomized. Consider re-randomizing.",

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -64,6 +64,8 @@ const es: TranslationKeys = {
   copyLink: "Copiar enlace",
   players: "Jugadores",
   addPlayerPlaceholder: "Agregar jugador",
+  inviteByEmailPlaceholder: "Invitar por correo (opcional)",
+  inviteByEmailHelper: "Les notifica si están en Convocados; si no, envía una invitación por correo",
   addPlayerHelper: "Presiona Enter para agregar, o pega una lista separada por líneas",
   randomizeTeams: "Sortear equipos",
   teamsOutOfSync: "Los jugadores han cambiado desde el último sorteo. Considera sortear de nuevo.",

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -64,6 +64,8 @@ const fr: TranslationKeys = {
   copyLink: "Copier le lien",
   players: "Joueurs",
   addPlayerPlaceholder: "Ajouter un joueur",
+  inviteByEmailPlaceholder: "Inviter par e-mail (optionnel)",
+  inviteByEmailHelper: "Les notifie s'ils sont sur Convocados, sinon envoie une invitation par e-mail",
   addPlayerHelper: "Appuie sur Entrée pour ajouter, ou colle une liste séparée par des lignes",
   randomizeTeams: "Tirer les équipes au sort",
   teamsOutOfSync: "Les joueurs ont changé depuis le dernier tirage. Pense à retirer au sort.",

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -64,6 +64,8 @@ const it: TranslationKeys = {
   copyLink: "Copia link",
   players: "Giocatori",
   addPlayerPlaceholder: "Aggiungi giocatore",
+  inviteByEmailPlaceholder: "Invita via email (opzionale)",
+  inviteByEmailHelper: "Li notifica se sono su Convocados, altrimenti invia un invito via email",
   addPlayerHelper: "Premi Invio per aggiungere, o incolla una lista separata da righe",
   randomizeTeams: "Sorteggia squadre",
   teamsOutOfSync: "I giocatori sono cambiati dall'ultimo sorteggio. Considera di sorteggiare di nuovo.",

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -73,6 +73,8 @@ const pt: TranslationKeys = {
   copyLink: "Copiar link",
   players: "Jogadores",
   addPlayerPlaceholder: "Adicionar jogador",
+  inviteByEmailPlaceholder: "Convidar por email (opcional)",
+  inviteByEmailHelper: "Notifica-os se estiverem no Convocados, senão envia um convite por email",
   addPlayerHelper: "Prima Enter para adicionar, ou cola uma lista separada por linhas",
   randomizeTeams: "Sortear equipas",
   teamsOutOfSync: "Os jogadores mudaram desde o último sorteio. Considera sortear novamente.",

--- a/src/pages/api/events/[id]/players.ts
+++ b/src/pages/api/events/[id]/players.ts
@@ -2,7 +2,8 @@ import { Prisma } from "@prisma/client";
 import type { APIRoute } from "astro";
 import { prisma } from "../../../../lib/db.server";
 import { enqueueNotification, drainNotificationQueue } from "../../../../lib/notificationQueue.server";
-import { sendGameInvite, sendPlayerJoinedOwnerNotification } from "../../../../lib/email.server";
+import { sendGameInvite, sendPlayerJoinedOwnerNotification, sendPlayerInviteToRegister } from "../../../../lib/email.server";
+import { sendPushToUser } from "../../../../lib/push.server";
 import { getNotificationPrefs, wantsGameInviteEmail } from "../../../../lib/notificationPrefs.server";
 import { fireWebhooks } from "../../../../lib/webhook.server";
 import { getSession, checkOwnership } from "../../../../lib/auth.helpers.server";
@@ -211,9 +212,15 @@ export const POST: APIRoute = async ({ params, request }) => {
   });
   if (!event) return Response.json({ error: "Not found." }, { status: 404 });
 
-  const { name, linkToAccount } = await request.json();
+  const { name, linkToAccount, email } = await request.json();
   const trimmed = String(name ?? "").trim().slice(0, 50);
   if (!trimmed) return Response.json({ error: "Player name is required." }, { status: 400 });
+
+  // Optional email — used to notify a registered user or invite an unregistered
+  // one to join Convocados. Validated loosely; ignored if malformed.
+  const normalizedEmail = typeof email === "string" && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.trim())
+    ? email.trim().toLowerCase()
+    : null;
 
   // Bench cap: max bench size equals maxPlayers (total players = 2 * maxPlayers)
   const maxTotal = event.maxPlayers * 2;
@@ -248,6 +255,28 @@ export const POST: APIRoute = async ({ params, request }) => {
       if (alreadyInEvent === 0) {
         linkedUserId = candidateId;
       }
+    }
+  }
+
+  // Email-based invite resolution. If an email was supplied, decide whether the
+  // invitee is already a Convocados user (→ notify) or not (→ email invite).
+  let notifyRegisteredUserId: string | null = null;
+  let inviteUnregisteredEmail: string | null = null;
+  if (normalizedEmail) {
+    const invited = await prisma.user.findUnique({
+      where: { email: normalizedEmail },
+      select: { id: true },
+    });
+    if (invited) {
+      // Link the new player record to their account (if not already in the event)
+      // so the game shows up for them, and flag them for a push notification.
+      const alreadyInEvent = await prisma.player.count({ where: { eventId, userId: invited.id } });
+      if (alreadyInEvent === 0 && !linkedUserId) {
+        linkedUserId = invited.id;
+      }
+      notifyRegisteredUserId = invited.id;
+    } else {
+      inviteUnregisteredEmail = normalizedEmail;
     }
   }
 
@@ -394,7 +423,37 @@ export const POST: APIRoute = async ({ params, request }) => {
 
   logEvent(eventId, "player_added", session?.user?.name ?? trimmed, session?.user?.id ?? null, { playerName: trimmed }).catch(() => {});
 
-  return Response.json({ ok: true });
+  // ── Invite-by-email: notify a registered user, or email an unregistered one ──
+  let inviteResult: "notified" | "emailed" | null = null;
+  const inviterName = session?.user?.name ?? null;
+  if (notifyRegisteredUserId && notifyRegisteredUserId !== session?.user?.id) {
+    try {
+      await sendPushToUser(
+        notifyRegisteredUserId,
+        event.title,
+        inviterName ? `${inviterName} added you to the game` : "You've been added to the game",
+        url,
+      );
+      inviteResult = "notified";
+    } catch (err) {
+      log.error({ eventId, err }, "Failed to send invite push");
+    }
+  } else if (inviteUnregisteredEmail) {
+    try {
+      await sendPlayerInviteToRegister(inviteUnregisteredEmail, {
+        eventTitle: event.title,
+        dateTime: event.dateTime.toISOString(),
+        location: event.location,
+        eventUrl: url,
+        inviterName,
+      });
+      inviteResult = "emailed";
+    } catch (err) {
+      log.error({ eventId, err }, "Failed to send invite email");
+    }
+  }
+
+  return Response.json({ ok: true, invited: inviteResult });
 };
 
 export const DELETE: APIRoute = async ({ params, request }) => {

--- a/src/test/invite-by-email.test.ts
+++ b/src/test/invite-by-email.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { prisma } from "~/lib/db.server";
+import { POST } from "~/pages/api/events/[id]/players";
+import { getSession } from "~/lib/auth.helpers.server";
+import { resetRateLimitStore } from "~/lib/rateLimit.server";
+import { resetApiRateLimitStore } from "~/lib/apiRateLimit.server";
+import { sendPushToUser } from "~/lib/push.server";
+import { sendPlayerInviteToRegister } from "~/lib/email.server";
+
+vi.mock("~/lib/auth.helpers.server", () => ({ getSession: vi.fn() }));
+vi.mock("~/lib/push.server", () => ({ sendPushToUser: vi.fn().mockResolvedValue(undefined) }));
+// Keep the other email exports working; only stub the network senders we assert on.
+vi.mock("~/lib/email.server", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("~/lib/email.server")>();
+  return {
+    ...actual,
+    sendPlayerInviteToRegister: vi.fn().mockResolvedValue(undefined),
+    sendGameInvite: vi.fn().mockResolvedValue(undefined),
+    sendPlayerJoinedOwnerNotification: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+const mockGetSession = vi.mocked(getSession);
+const mockPush = vi.mocked(sendPushToUser);
+const mockInviteEmail = vi.mocked(sendPlayerInviteToRegister);
+
+function ctx(eventId: string, body: unknown, session: { user: { id: string; name: string } } | null) {
+  mockGetSession.mockResolvedValue(session as any);
+  return {
+    params: { id: eventId },
+    request: new Request(`http://localhost/api/events/${eventId}/players`, {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-client-id": "test-client" },
+      body: JSON.stringify(body),
+    }),
+  } as any;
+}
+
+async function seedEvent(ownerId: string | null = null) {
+  return prisma.event.create({
+    data: { title: "Pickup Game", location: "Pitch", dateTime: new Date(Date.now() + 86400_000), maxPlayers: 10, ownerId },
+  });
+}
+
+beforeEach(async () => {
+  await prisma.playerRating.deleteMany();
+  await prisma.teamResult.deleteMany();
+  await prisma.player.deleteMany();
+  await prisma.eventFollow.deleteMany();
+  await prisma.event.deleteMany();
+  await prisma.user.deleteMany();
+  resetRateLimitStore();
+  resetApiRateLimitStore();
+  vi.clearAllMocks();
+});
+
+describe("POST /api/events/[id]/players — invite by email", () => {
+  it("notifies a registered user (push) and links the player to their account", async () => {
+    const owner = await prisma.user.create({ data: { id: "u-owner", name: "Owner", email: "owner@t.com", emailVerified: true } });
+    const friend = await prisma.user.create({ data: { id: "u-friend", name: "Friend", email: "friend@t.com", emailVerified: true } });
+    const event = await seedEvent(owner.id);
+
+    const res = await POST(ctx(event.id, { name: "Friend Smith", email: "friend@t.com" }, { user: { id: owner.id, name: "Owner" } }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ ok: true, invited: "notified" });
+
+    expect(mockPush).toHaveBeenCalledWith(friend.id, "Pickup Game", expect.stringContaining("added you"), expect.any(String));
+    expect(mockInviteEmail).not.toHaveBeenCalled();
+
+    const player = await prisma.player.findFirst({ where: { eventId: event.id, name: "Friend Smith" } });
+    expect(player?.userId).toBe(friend.id);
+  });
+
+  it("emails an invite to register when the email is not a registered user", async () => {
+    const owner = await prisma.user.create({ data: { id: "u-owner", name: "Owner", email: "owner@t.com", emailVerified: true } });
+    const event = await seedEvent(owner.id);
+
+    const res = await POST(ctx(event.id, { name: "New Guy", email: "newguy@example.com" }, { user: { id: owner.id, name: "Owner" } }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ ok: true, invited: "emailed" });
+
+    expect(mockInviteEmail).toHaveBeenCalledWith(
+      "newguy@example.com",
+      expect.objectContaining({ eventTitle: "Pickup Game", inviterName: "Owner" }),
+    );
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("ignores a malformed email (no notify, no invite) but still adds the player", async () => {
+    const event = await seedEvent();
+    const res = await POST(ctx(event.id, { name: "Plain", email: "not-an-email" }, null));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ ok: true, invited: null });
+    expect(mockPush).not.toHaveBeenCalled();
+    expect(mockInviteEmail).not.toHaveBeenCalled();
+    expect(await prisma.player.count({ where: { eventId: event.id } })).toBe(1);
+  });
+
+  it("does not notify when the adder invites themselves by email", async () => {
+    const self = await prisma.user.create({ data: { id: "u-self", name: "Self", email: "self@t.com", emailVerified: true } });
+    const event = await seedEvent(self.id);
+    const res = await POST(ctx(event.id, { name: "Self", email: "self@t.com" }, { user: { id: self.id, name: "Self" } }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ ok: true, invited: null });
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What
When a player is added **with an email**, the backend resolves it:
- **Registered Convocados user** → **push notification** ("{inviter} added you to the game") + the player record is linked to their account so the game shows up for them.
- **Not registered** → **email invitation** to join Convocados (signup CTA), via a new `sendPlayerInviteToRegister` template.
- Self-invite / malformed email → no-op (player still added).

Response now includes `{ invited: 'notified' | 'emailed' | null }`.

## Works on both clients
- **Android**: the contact picker now reads the contact's **email** (`ACTION_PICK` on the Email table — permission-free) and adds with `link=false` + email; shows a "Will invite …" hint. `addPlayer` threaded through API → repository → ViewModel.
- **Web**: new optional **"Invite by email"** field in the add-player UI (`PlayerList`/`EventPage`), localized across all 6 locales.

## Tests
- `src/test/invite-by-email.test.ts`: notifies registered user (+links), emails unregistered, ignores malformed email, no self-notify.
- Android `:app:compileDebugKotlin` + unit tests pass; web typecheck + i18n-sync pass.

## Notes
- Push reuses existing `sendPushToUser` (FCM + web-push), so notifications reach both the Android app and web. Registered invitees also get the existing game-invite email per their prefs.