### PR TITLE
fix(android): show generated teams in event detail

### DIFF
--- a/android-app/app/src/main/java/dev/convocados/data/local/AppDatabase.kt
+++ b/android-app/app/src/main/java/dev/convocados/data/local/AppDatabase.kt
@@ -19,7 +19,7 @@ import dev.convocados.data.local.entity.UserProfileEntity
         PlayerEntity::class,
         GameHistoryEntity::class
     ],
-    version = 3,
+    version = 4,
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {

--- a/android-app/app/src/main/java/dev/convocados/data/local/entity/EventDetailEntities.kt
+++ b/android-app/app/src/main/java/dev/convocados/data/local/entity/EventDetailEntities.kt
@@ -7,6 +7,11 @@ import androidx.room.PrimaryKey
 import dev.convocados.data.api.EventDetail
 import dev.convocados.data.api.GameHistory
 import dev.convocados.data.api.Player
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+/** Shared Json for (de)serializing nested entity payloads like team results. */
+internal val EntityJson = Json { ignoreUnknownKeys = true }
 
 @Entity(tableName = "event_details")
 data class EventDetailEntity(
@@ -21,6 +26,8 @@ data class EventDetailEntity(
     val locked: Boolean,
     val teamOneName: String,
     val teamTwoName: String,
+    /** JSON-encoded List<TeamResult> of the generated teams, or null if none. */
+    val teamResultsJson: String? = null,
 )
 
 @Entity(
@@ -76,7 +83,8 @@ fun EventDetail.toEntity() = EventDetailEntity(
     isAdmin = isAdmin,
     locked = locked,
     teamOneName = teamOneName,
-    teamTwoName = teamTwoName
+    teamTwoName = teamTwoName,
+    teamResultsJson = teamResults?.let { EntityJson.encodeToString(it) },
 )
 
 fun Player.toEntity(eventId: String) = PlayerEntity(

--- a/android-app/app/src/main/java/dev/convocados/data/repository/EventRepository.kt
+++ b/android-app/app/src/main/java/dev/convocados/data/repository/EventRepository.kt
@@ -8,6 +8,7 @@ import dev.convocados.data.api.OkResponse
 import dev.convocados.data.api.PaginatedHistory
 import dev.convocados.data.api.Player
 import dev.convocados.data.api.RemovePlayerResponse
+import dev.convocados.data.api.TeamResult
 import dev.convocados.data.api.UndoData
 import dev.convocados.data.local.dao.EventDao
 import dev.convocados.data.local.dao.EventDetailDao
@@ -16,6 +17,8 @@ import dev.convocados.data.local.entity.GameHistoryEntity
 import dev.convocados.data.local.entity.PlayerEntity
 import dev.convocados.data.local.entity.toEntity
 import dev.convocados.data.local.entity.toSummary
+import dev.convocados.data.local.entity.EntityJson
+import kotlinx.serialization.decodeFromString
 import dev.convocados.data.api.MyGamesResponse
 import dev.convocados.ui.UiEventManager
 import kotlinx.coroutines.flow.Flow
@@ -123,7 +126,10 @@ class EventRepository @Inject constructor(
         id = id, title = title, location = location, dateTime = dateTime,
         maxPlayers = maxPlayers, sport = sport, ownerId = ownerId,
         isAdmin = isAdmin, locked = locked, teamOneName = teamOneName, teamTwoName = teamTwoName,
-        players = players.map { it.toDomain() }
+        players = players.map { it.toDomain() },
+        teamResults = teamResultsJson?.let {
+            runCatching { EntityJson.decodeFromString<List<TeamResult>>(it) }.getOrNull()
+        },
     )
 
     private fun PlayerEntity.toDomain() = Player(

--- a/android-app/app/src/test/java/dev/convocados/data/local/entity/EventDetailMappingTest.kt
+++ b/android-app/app/src/test/java/dev/convocados/data/local/entity/EventDetailMappingTest.kt
@@ -1,0 +1,42 @@
+package dev.convocados.data.local.entity
+
+import dev.convocados.data.api.EventDetail
+import dev.convocados.data.api.TeamMember
+import dev.convocados.data.api.TeamResult
+import kotlinx.serialization.decodeFromString
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class EventDetailMappingTest {
+
+    private fun event(teams: List<TeamResult>?) = EventDetail(
+        id = "e1", title = "Game", location = "Pitch", dateTime = "2024-01-01T10:00:00Z",
+        maxPlayers = 10, ownerId = "u1", isAdmin = true, teamResults = teams,
+    )
+
+    @Test
+    fun `toEntity serializes generated teams to JSON`() {
+        val teams = listOf(
+            TeamResult(id = "t1", name = "Ninjas", members = listOf(TeamMember("m1", "Ana", 0), TeamMember("m2", "Beto", 1))),
+            TeamResult(id = "t2", name = "Gunas", members = listOf(TeamMember("m3", "Caio", 0))),
+        )
+        val entity = event(teams).toEntity()
+        assertNotNull(entity.teamResultsJson)
+
+        // Round-trips back to the same teams (this is what EventRepository.toDomain does).
+        val restored = EntityJson.decodeFromString<List<TeamResult>>(entity.teamResultsJson!!)
+        assertEquals(teams, restored)
+        assertEquals("Ninjas", restored[0].name)
+        assertEquals(2, restored[0].members.size)
+    }
+
+    @Test
+    fun `toEntity leaves teamResultsJson null when no teams`() {
+        assertNull(event(null).toEntity().teamResultsJson)
+        assertNull(event(emptyList()).toEntity().teamResultsJson?.let {
+            EntityJson.decodeFromString<List<TeamResult>>(it).ifEmpty { null }
+        })
+    }
+}


### PR DESCRIPTION
## Problem
The Android `TeamsCard` (added earlier to render the two generated teams) never appeared. Root cause: the Room cache **dropped `EventDetail.teamResults`** — the entity mapping persisted `teamOneName`/`teamTwoName` but not the actual generated teams + members. The screen's event flow comes from Room → `toDomain`, so `event.teamResults` was always `null` and `TeamsCard` was never rendered (only `CreateTeamsCard` showed).

## Fix
- Persist `teamResults` as a JSON column on `EventDetailEntity` (serialize in `toEntity`, deserialize in `EventRepository.toDomain`).
- Bump Room DB version 3 → 4 (`fallbackToDestructiveMigration` already configured — it's a cache).
- Add `EventDetailMappingTest` covering the round-trip.

## Result
After **Randomize** or **Create teams**, `refreshEventDetail` now stores and restores the teams, so `TeamsCard` renders the two teams with their members (tap a member to move them, as before).

## Note
This is a follow-up to the earlier Android PRs (#421/#430), which are already merged & released — opening a fresh PR since those are closed.