### PR TITLE
feat: seamless add-by-identity + invite-email security mitigations

### DIFF
--- a/android-app/app/src/main/java/dev/convocados/data/api/ConvocadosApi.kt
+++ b/android-app/app/src/main/java/dev/convocados/data/api/ConvocadosApi.kt
@@ -33,7 +33,7 @@ class ConvocadosApi @Inject constructor(private val client: ApiClient) {
         client.get("/api/events/$id/post-game-status")
 
     // ── Players ───────────────────────────────────────────────────────────
-    suspend fun addPlayer(eventId: String, name: String, linkToAccount: Boolean = true, email: String? = null): OkResponse =
+    suspend fun addPlayer(eventId: String, name: String, linkToAccount: Boolean = true, email: String? = null): AddPlayerResponse =
         client.post("/api/events/$eventId/players", AddPlayerRequest(name, linkToAccount, email))
 
     suspend fun removePlayer(eventId: String, playerId: String): RemovePlayerResponse =

--- a/android-app/app/src/main/java/dev/convocados/data/api/Models.kt
+++ b/android-app/app/src/main/java/dev/convocados/data/api/Models.kt
@@ -363,6 +363,9 @@ data class PublicStats(
 data class OkResponse(val ok: Boolean = true)
 
 @Serializable
+data class AddPlayerResponse(val ok: Boolean = true, val invited: String? = null, val resolvedName: String? = null)
+
+@Serializable
 data class ArchiveRequest(val archive: Boolean)
 
 // ── MVP Voting ──────────────────────────────────────────────────────────────

--- a/android-app/app/src/main/java/dev/convocados/data/repository/EventRepository.kt
+++ b/android-app/app/src/main/java/dev/convocados/data/repository/EventRepository.kt
@@ -81,10 +81,10 @@ class EventRepository @Inject constructor(
         }
     }
 
-    suspend fun addPlayer(eventId: String, name: String, link: Boolean, email: String? = null): Result<Unit> = try {
-        api.addPlayer(eventId, name, link, email)
+    suspend fun addPlayer(eventId: String, name: String, link: Boolean, email: String? = null): Result<String?> = try {
+        val response = api.addPlayer(eventId, name, link, email)
         refreshEventDetail(eventId)
-        Result.success(Unit)
+        Result.success(response.resolvedName)
     } catch (e: Exception) {
         Result.failure(e)
     }

--- a/android-app/app/src/main/java/dev/convocados/ui/screen/event/EventDetailScreen.kt
+++ b/android-app/app/src/main/java/dev/convocados/ui/screen/event/EventDetailScreen.kt
@@ -88,6 +88,8 @@ data class EventScreenState(
     val balance: BalanceResponse? = null,
     val paymentGateBlocked: Boolean = false,
     val showPaymentNudge: Boolean = false,
+    // Contact-pick auto-add
+    val addedPlayerName: String? = null,
 )
 
 data class TeamMoveUndo(
@@ -218,7 +220,8 @@ class EventDetailViewModel @Inject constructor(
     fun addPlayer(eventId: String, name: String, link: Boolean = true, email: String? = null) {
         viewModelScope.launch {
             repository.addPlayer(eventId, name, link, email)
-                .onSuccess {
+                .onSuccess { resolvedName ->
+                    _state.value = _state.value.copy(addedPlayerName = resolvedName ?: name)
                     // Auto-open payment dialog after join if preference is set
                     if (autoPayOnJoin.value && _state.value.balance?.callerBalance?.let { it.amount > 0 } == true) {
                         _state.value = _state.value.copy(showPaymentNudge = true)
@@ -242,6 +245,10 @@ class EventDetailViewModel @Inject constructor(
                     }
                 }
         }
+    }
+
+    fun dismissAddedPlayerSnackbar() {
+        _state.value = _state.value.copy(addedPlayerName = null)
     }
 
     fun fetchBalance(eventId: String) {
@@ -436,6 +443,15 @@ fun EventDetailScreen(
         if (result == SnackbarResult.ActionPerformed) {
             viewModel.undoTeamMove(eventId)
         }
+    }
+
+    LaunchedEffect(state.addedPlayerName) {
+        val name = state.addedPlayerName ?: return@LaunchedEffect
+        snackbarHostState.showSnackbar(
+            message = context.getString(R.string.added_player_confirm, name),
+            duration = SnackbarDuration.Short,
+        )
+        viewModel.dismissAddedPlayerSnackbar()
     }
 
     LaunchedEffect(eventId) { viewModel.load(eventId) }
@@ -800,8 +816,16 @@ fun EventDetailScreen(
                                                     null, null, null,
                                                 )?.use { c ->
                                                     if (c.moveToFirst()) {
-                                                        c.getString(1)?.takeIf { it.isNotBlank() }?.let { name -> newPlayer = name }
-                                                        pickedEmail = c.getString(0)?.takeIf { it.isNotBlank() }
+                                                        val contactName = c.getString(1)?.takeIf { it.isNotBlank() } ?: ""
+                                                        val contactEmail = c.getString(0)?.takeIf { it.isNotBlank() }
+                                                        if (contactEmail != null) {
+                                                            // Auto-add immediately (zero taps)
+                                                            viewModel.addPlayer(eventId, contactName, link = false, email = contactEmail)
+                                                            newPlayer = ""
+                                                        } else {
+                                                            // No email — just prefill name
+                                                            newPlayer = contactName
+                                                        }
                                                     }
                                                 }
                                             }

--- a/android-app/app/src/main/res/values/strings.xml
+++ b/android-app/app/src/main/res/values/strings.xml
@@ -138,6 +138,7 @@
     <string name="vs">VS</string>
     <string name="linked">Linked</string>
     <string name="player_moved">%1$s moved</string>
+    <string name="added_player_confirm">Added %1$s ✓</string>
     <string name="undo">Undo</string>
     <string name="add_score">+ Score</string>
     <string name="player_games_count">%1$s (%2$d games)</string>

--- a/android-app/app/src/test/java/dev/convocados/ui/screen/event/EventDetailViewModelTest.kt
+++ b/android-app/app/src/test/java/dev/convocados/ui/screen/event/EventDetailViewModelTest.kt
@@ -93,7 +93,7 @@ class EventDetailViewModelTest {
         coEvery { repository.getEventDetail(eventId) } returns flowOf(mockEvent)
         coEvery { repository.getPlayers(eventId) } returns flowOf(emptyList())
         coEvery { repository.getHistory(eventId) } returns flowOf(emptyList())
-        coEvery { repository.addPlayer(eventId, "New Player", true) } coAnswers { Result.success(Unit) }
+        coEvery { repository.addPlayer(eventId, "New Player", true) } coAnswers { Result.success(null as String?) }
 
         val viewModel = EventDetailViewModel(repository, api, tokenStore, client, settingsStore)
         viewModel.addPlayer(eventId, "New Player")

--- a/prisma/migrations/20260612000000_add_invited_by_user_id/migration.sql
+++ b/prisma/migrations/20260612000000_add_invited_by_user_id/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Player" ADD COLUMN "invitedByUserId" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -201,15 +201,16 @@ model MvpVote {
 }
 
 model Player {
-  id         String    @id @default(cuid())
-  name       String
-  order      Int       @default(0)
-  eventId    String
-  event      Event     @relation(fields: [eventId], references: [id], onDelete: Cascade)
-  userId     String?
-  user       User?     @relation("PlayerUser", fields: [userId], references: [id], onDelete: SetNull)
-  archivedAt DateTime?
-  createdAt  DateTime  @default(now())
+  id              String    @id @default(cuid())
+  name            String
+  order           Int       @default(0)
+  eventId         String
+  event           Event     @relation(fields: [eventId], references: [id], onDelete: Cascade)
+  userId          String?
+  user            User?     @relation("PlayerUser", fields: [userId], references: [id], onDelete: SetNull)
+  invitedByUserId String?
+  archivedAt      DateTime?
+  createdAt       DateTime  @default(now())
 
   @@unique([eventId, name])
   @@index([userId])

--- a/src/components/EventPage.tsx
+++ b/src/components/EventPage.tsx
@@ -194,16 +194,18 @@ export default function EventPage({ eventId }: { eventId: string }) {
   // ── Player CRUD ─────────────────────────────────────────────────────────────
 
   const addPlayer = async (name: string, linkToAccount = false, email?: string) => {
-    if (!name.trim()) return;
+    if (!name.trim() && !email?.trim()) return;
     setPlayerError(null);
     const trimmed = name.trim().slice(0, 50);
 
-    // Optimistic update
-    setEvent((current) => {
-      if (!current) return current;
-      const optimisticPlayer: Player = { id: `temp-${Date.now()}`, name: trimmed, userId: null };
-      return { ...current, players: [...current.players, optimisticPlayer] };
-    });
+    // Optimistic update (only if we have a name to show)
+    if (trimmed) {
+      setEvent((current) => {
+        if (!current) return current;
+        const optimisticPlayer: Player = { id: `temp-${Date.now()}`, name: trimmed, userId: null };
+        return { ...current, players: [...current.players, optimisticPlayer] };
+      });
+    }
 
     const res = await fetch(`/api/events/${eventId}/players`, {
       method: "POST",
@@ -216,7 +218,11 @@ export default function EventPage({ eventId }: { eventId: string }) {
       fetchEvent(); // revert optimistic update
       return;
     }
-    addKnownName(trimmed);
+    const resolvedName: string | undefined = json.resolvedName;
+    if (resolvedName && resolvedName !== trimmed && trimmed) {
+      setSnackbar(`Added ${resolvedName} ✓`);
+    }
+    addKnownName(resolvedName ?? trimmed);
     fetchEvent();
   };
 

--- a/src/components/event/PlayerList.tsx
+++ b/src/components/event/PlayerList.tsx
@@ -148,21 +148,25 @@ export function PlayerList({
             <TextField
               {...params}
               variant="outlined"
-              placeholder={t("addPlayerPlaceholder")}
+              placeholder={inviteEmail.trim() ? t("addPlayerPlaceholderOptional") : t("addPlayerPlaceholder")}
               helperText={t("addPlayerHelper")}
               fullWidth
               inputProps={{ ...params.inputProps, maxLength: 50 }}
               onKeyDown={(e) => {
-                if (e.key === "Enter" && playerInput.trim()) {
+                if (e.key === "Enter") {
                   const trimmed = playerInput.trim();
-                  const hasExactMatch = availableSuggestions.some(
-                    (s) => s.name.toLowerCase() === trimmed.toLowerCase()
-                  );
-                  if (hasExactMatch) return;
-                  const hasPartialMatch = availableSuggestions.some(
-                    (s) => matchesWithName(s.name, trimmed)
-                  );
-                  if (hasPartialMatch) return;
+                  // Allow submission with empty name when email is provided
+                  if (!trimmed && !inviteEmail.trim()) return;
+                  if (trimmed) {
+                    const hasExactMatch = availableSuggestions.some(
+                      (s) => s.name.toLowerCase() === trimmed.toLowerCase()
+                    );
+                    if (hasExactMatch) return;
+                    const hasPartialMatch = availableSuggestions.some(
+                      (s) => matchesWithName(s.name, trimmed)
+                    );
+                    if (hasPartialMatch) return;
+                  }
                   e.preventDefault();
                   e.stopPropagation();
                   onAddPlayer(trimmed, inviteEmail.trim() || undefined);
@@ -183,8 +187,8 @@ export function PlayerList({
                 endAdornment: (
                   <InputAdornment position="end">
                     <IconButton color="primary" edge="end"
-                      disabled={!playerInput.trim()}
-                      onClick={() => { onAddPlayer(playerInput, inviteEmail.trim() || undefined); setPlayerInput(""); setInviteEmail(""); }}>
+                      disabled={!playerInput.trim() && !inviteEmail.trim()}
+                      onClick={() => { onAddPlayer(playerInput.trim(), inviteEmail.trim() || undefined); setPlayerInput(""); setInviteEmail(""); }}>
                       <PersonAddIcon />
                     </IconButton>
                   </InputAdornment>

--- a/src/lib/email.server.ts
+++ b/src/lib/email.server.ts
@@ -184,6 +184,7 @@ export async function sendPlayerInviteToRegister(to: string, data: PlayerInviteD
   const when = new Date(data.dateTime).toLocaleString("en-GB", { dateStyle: "medium", timeStyle: "short" });
   const inviter = data.inviterName ? `${data.inviterName} added you to` : "You've been added to";
   const signupUrl = `${getAppUrl()}/auth/signup?email=${encodeURIComponent(to)}`;
+  const inviterLabel = data.inviterName ?? "Someone";
   const result = await resend.emails.send({
     from: EMAIL_FROM,
     to,
@@ -193,7 +194,7 @@ export async function sendPlayerInviteToRegister(to: string, data: PlayerInviteD
       body: `📍 ${data.location}<br/>🕐 ${when}<br/><br/>Create a free Convocados account to confirm your spot, see the team and get reminders.`,
       buttonText: "Join Convocados",
       buttonUrl: signupUrl,
-      footnote: `Or just view the game: <a href="${data.eventUrl}" style="color:#1b6b4a;">${data.eventTitle}</a>`,
+      footnote: `Or just view the game: <a href="${data.eventUrl}" style="color:#1b6b4a;">${data.eventTitle}</a><br/><br/>Didn't expect this? This is a one-time invite from ${inviterLabel}. You won't receive further emails unless you create an account. <a href="mailto:abuse@convocados.cabeda.dev" style="color:#1b6b4a;">Report abuse</a>`,
     }),
   });
   if (result.error) throw new Error(`Failed to send player invite: ${result.error.message}`);

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -64,6 +64,7 @@ const de: TranslationKeys = {
   copyLink: "Link kopieren",
   players: "Spieler",
   addPlayerPlaceholder: "Spieler hinzufügen",
+  addPlayerPlaceholderOptional: "Leer lassen, um den Convocados-Namen zu verwenden",
   inviteByEmailPlaceholder: "Per E-Mail einladen (optional)",
   inviteByEmailHelper: "Benachrichtigt sie, wenn sie bei Convocados sind, sonst per E-Mail-Einladung",
   addPlayerHelper: "Enter drücken zum Hinzufügen, oder eine zeilengetrennte Liste einfügen",

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -72,6 +72,7 @@ const en = {
   copyLink: "Copy link",
   players: "Players",
   addPlayerPlaceholder: "Add player name",
+  addPlayerPlaceholderOptional: "Leave blank to use their Convocados name",
   inviteByEmailPlaceholder: "Invite by email (optional)",
   inviteByEmailHelper: "Notifies them if they're on Convocados, otherwise emails an invite to join",
   addPlayerHelper: "Press Enter to add, or paste a newline-separated list",

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -64,6 +64,7 @@ const es: TranslationKeys = {
   copyLink: "Copiar enlace",
   players: "Jugadores",
   addPlayerPlaceholder: "Agregar jugador",
+  addPlayerPlaceholderOptional: "Deja en blanco para usar su nombre de Convocados",
   inviteByEmailPlaceholder: "Invitar por correo (opcional)",
   inviteByEmailHelper: "Les notifica si están en Convocados; si no, envía una invitación por correo",
   addPlayerHelper: "Presiona Enter para agregar, o pega una lista separada por líneas",

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -64,6 +64,7 @@ const fr: TranslationKeys = {
   copyLink: "Copier le lien",
   players: "Joueurs",
   addPlayerPlaceholder: "Ajouter un joueur",
+  addPlayerPlaceholderOptional: "Laisser vide pour utiliser le nom Convocados",
   inviteByEmailPlaceholder: "Inviter par e-mail (optionnel)",
   inviteByEmailHelper: "Les notifie s'ils sont sur Convocados, sinon envoie une invitation par e-mail",
   addPlayerHelper: "Appuie sur Entrée pour ajouter, ou colle une liste séparée par des lignes",

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -64,6 +64,7 @@ const it: TranslationKeys = {
   copyLink: "Copia link",
   players: "Giocatori",
   addPlayerPlaceholder: "Aggiungi giocatore",
+  addPlayerPlaceholderOptional: "Lascia vuoto per usare il nome Convocados",
   inviteByEmailPlaceholder: "Invita via email (opzionale)",
   inviteByEmailHelper: "Li notifica se sono su Convocados, altrimenti invia un invito via email",
   addPlayerHelper: "Premi Invio per aggiungere, o incolla una lista separata da righe",

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -73,6 +73,7 @@ const pt: TranslationKeys = {
   copyLink: "Copiar link",
   players: "Jogadores",
   addPlayerPlaceholder: "Adicionar jogador",
+  addPlayerPlaceholderOptional: "Deixa em branco para usar o nome Convocados",
   inviteByEmailPlaceholder: "Convidar por email (opcional)",
   inviteByEmailHelper: "Notifica-os se estiverem no Convocados, senão envia um convite por email",
   addPlayerHelper: "Prima Enter para adicionar, ou cola uma lista separada por linhas",

--- a/src/pages/api/events/[id]/players.ts
+++ b/src/pages/api/events/[id]/players.ts
@@ -196,6 +196,60 @@ async function tryBalancedSwap(eventId: string, promotedName: string, promotedTe
   });
 }
 
+// ── Invite email rate-limit stores ────────────────────────────────────────────
+// Per-event: max 10 unique invite emails per event per 24h
+// Per-sender: max 20 invite emails per authenticated user per 24h across all events
+interface InviteRateEntry { emails: Set<string>; expiresAt: number }
+const invitePerEventStore = new Map<string, InviteRateEntry>();
+const invitePerSenderStore = new Map<string, InviteRateEntry>();
+const INVITE_WINDOW_MS = 24 * 60 * 60 * 1000;
+const MAX_INVITES_PER_EVENT = 10;
+const MAX_INVITES_PER_SENDER = 20;
+
+function canSendInviteEmail(eventId: string, senderId: string, email: string): boolean {
+  const now = Date.now();
+  // Per-event check
+  let eventEntry = invitePerEventStore.get(eventId);
+  if (!eventEntry || eventEntry.expiresAt < now) {
+    eventEntry = { emails: new Set(), expiresAt: now + INVITE_WINDOW_MS };
+    invitePerEventStore.set(eventId, eventEntry);
+  }
+  if (eventEntry.emails.size >= MAX_INVITES_PER_EVENT && !eventEntry.emails.has(email)) return false;
+
+  // Per-sender check
+  let senderEntry = invitePerSenderStore.get(senderId);
+  if (!senderEntry || senderEntry.expiresAt < now) {
+    senderEntry = { emails: new Set(), expiresAt: now + INVITE_WINDOW_MS };
+    invitePerSenderStore.set(senderId, senderEntry);
+  }
+  if (senderEntry.emails.size >= MAX_INVITES_PER_SENDER && !senderEntry.emails.has(email)) return false;
+
+  return true;
+}
+
+function recordInviteEmail(eventId: string, senderId: string, email: string): void {
+  const now = Date.now();
+  let eventEntry = invitePerEventStore.get(eventId);
+  if (!eventEntry || eventEntry.expiresAt < now) {
+    eventEntry = { emails: new Set(), expiresAt: now + INVITE_WINDOW_MS };
+    invitePerEventStore.set(eventId, eventEntry);
+  }
+  eventEntry.emails.add(email);
+
+  let senderEntry = invitePerSenderStore.get(senderId);
+  if (!senderEntry || senderEntry.expiresAt < now) {
+    senderEntry = { emails: new Set(), expiresAt: now + INVITE_WINDOW_MS };
+    invitePerSenderStore.set(senderId, senderEntry);
+  }
+  senderEntry.emails.add(email);
+}
+
+/** Reset invite rate-limit stores. Used in tests. */
+export function resetInviteRateLimitStores(): void {
+  invitePerEventStore.clear();
+  invitePerSenderStore.clear();
+}
+
 export const POST: APIRoute = async ({ params, request }) => {
   const limited = await rateLimitResponse(request, "write");
   if (limited) return limited;
@@ -213,14 +267,37 @@ export const POST: APIRoute = async ({ params, request }) => {
   if (!event) return Response.json({ error: "Not found." }, { status: 404 });
 
   const { name, linkToAccount, email } = await request.json();
-  const trimmed = String(name ?? "").trim().slice(0, 50);
-  if (!trimmed) return Response.json({ error: "Player name is required." }, { status: 400 });
 
   // Optional email — used to notify a registered user or invite an unregistered
   // one to join Convocados. Validated loosely; ignored if malformed.
   const normalizedEmail = typeof email === "string" && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.trim())
     ? email.trim().toLowerCase()
     : null;
+
+  // ── Resolve user by email (needed before name validation) ──────────────────
+  let resolvedUser: { id: string; name: string } | null = null;
+  if (normalizedEmail) {
+    const found = await prisma.user.findUnique({
+      where: { email: normalizedEmail },
+      select: { id: true, name: true },
+    });
+    if (found) resolvedUser = found;
+  }
+
+  // ── Name resolution ────────────────────────────────────────────────────────
+  // If email resolves to a registered user, always use User.name
+  let trimmed: string;
+  if (resolvedUser) {
+    trimmed = resolvedUser.name.trim().slice(0, 50);
+  } else {
+    trimmed = String(name ?? "").trim().slice(0, 50);
+    if (!trimmed) {
+      if (normalizedEmail) {
+        return Response.json({ error: "Player name is required (email does not match a registered user)." }, { status: 400 });
+      }
+      return Response.json({ error: "Player name is required." }, { status: 400 });
+    }
+  }
 
   // Bench cap: max bench size equals maxPlayers (total players = 2 * maxPlayers)
   const maxTotal = event.maxPlayers * 2;
@@ -233,14 +310,16 @@ export const POST: APIRoute = async ({ params, request }) => {
 
   // Resolve the userId to link, in priority order:
   //   1. Explicit linkToAccount: true from an authenticated client (QuickJoin flow)
-  //   2. Auto-link: name matches exactly one registered user account
-  //      (accent + case insensitive), and that user has no player in this event yet
-  // The auto-link prevents anonymous duplicate records (e.g. an owner adding a
-  // player by typing a known user's name) and is a no-op when the name is unique
-  // to the event's anonymous players.
+  //   2. Email resolved to a registered user
+  //   3. Auto-link: name matches exactly one registered user account
   let linkedUserId: string | null = null;
   if (linkToAccount === true && session?.user) {
     linkedUserId = session.user.id;
+  } else if (resolvedUser) {
+    const alreadyInEvent = await prisma.player.count({ where: { eventId, userId: resolvedUser.id } });
+    if (alreadyInEvent === 0) {
+      linkedUserId = resolvedUser.id;
+    }
   } else {
     const target = normalizeForMatch(trimmed);
     const allUsers = await prisma.user.findMany({
@@ -258,23 +337,12 @@ export const POST: APIRoute = async ({ params, request }) => {
     }
   }
 
-  // Email-based invite resolution. If an email was supplied, decide whether the
-  // invitee is already a Convocados user (→ notify) or not (→ email invite).
+  // Email-based invite resolution
   let notifyRegisteredUserId: string | null = null;
   let inviteUnregisteredEmail: string | null = null;
   if (normalizedEmail) {
-    const invited = await prisma.user.findUnique({
-      where: { email: normalizedEmail },
-      select: { id: true },
-    });
-    if (invited) {
-      // Link the new player record to their account (if not already in the event)
-      // so the game shows up for them, and flag them for a push notification.
-      const alreadyInEvent = await prisma.player.count({ where: { eventId, userId: invited.id } });
-      if (alreadyInEvent === 0 && !linkedUserId) {
-        linkedUserId = invited.id;
-      }
-      notifyRegisteredUserId = invited.id;
+    if (resolvedUser) {
+      notifyRegisteredUserId = resolvedUser.id;
     } else {
       inviteUnregisteredEmail = normalizedEmail;
     }
@@ -287,7 +355,6 @@ export const POST: APIRoute = async ({ params, request }) => {
     const threshold = event.paymentGateThreshold ?? 0;
 
     if (event.paymentEnforcementLevel === "hard_gate") {
-      // Gate uses pending-only balance (sent clears the gate per ADR 0006)
       const gateAmount = await getGateBalance(eventId, trimmed);
       if (gateAmount > threshold) {
         return Response.json({
@@ -300,10 +367,10 @@ export const POST: APIRoute = async ({ params, request }) => {
         }, { status: 402 });
       }
     }
-
-    // soft_gate and nudge: include balance info in the response but don't block
-    // (the client-side interstitial handles them)
   }
+
+  // Audit trail: who invited this player
+  const invitedByUserId = (session?.user && linkToAccount !== true) ? session.user.id : null;
 
   try {
     const nextOrder = event.players.length;
@@ -313,10 +380,32 @@ export const POST: APIRoute = async ({ params, request }) => {
         eventId,
         order: nextOrder,
         userId: linkedUserId,
+        invitedByUserId,
       },
     });
   } catch (e) {
     if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === "P2002") {
+      // ── P2002 merge logic ──────────────────────────────────────────────
+      if (resolvedUser) {
+        const existing = await prisma.player.findUnique({
+          where: { eventId_name: { eventId, name: trimmed } },
+          select: { id: true, userId: true },
+        });
+        if (existing) {
+          if (!existing.userId) {
+            // Merge: link existing unlinked player to the resolved user
+            await prisma.player.update({
+              where: { id: existing.id },
+              data: { userId: resolvedUser.id },
+            });
+            return Response.json({ ok: true, invited: null, resolvedName: trimmed });
+          } else if (existing.userId === resolvedUser.id) {
+            return Response.json({ error: `"${trimmed}" is already in the list.` }, { status: 409 });
+          } else {
+            return Response.json({ error: `"${trimmed}" is already linked to a different account.` }, { status: 409 });
+          }
+        }
+      }
       return Response.json({ error: `"${trimmed}" is already in the list.` }, { status: 409 });
     }
     throw e;
@@ -331,25 +420,24 @@ export const POST: APIRoute = async ({ params, request }) => {
     });
   }
 
-  // Auto-add player to ranking system with default ELO (upsert to avoid overwriting existing ratings)
+  // Auto-add player to ranking system with default ELO
   await prisma.playerRating.upsert({
     where: { eventId_name: { eventId, name: trimmed } },
     create: { eventId, name: trimmed, rating: 1000 },
     update: {},
   });
 
-  // spotsLeft after adding: if going to bench, active count unchanged
+  // spotsLeft after adding
   const activeBefore = Math.min(event.players.length, event.maxPlayers);
   const isOnBench = event.players.length >= event.maxPlayers;
   const spotsLeft = isOnBench ? 0 : Math.max(0, event.maxPlayers - activeBefore - 1);
   const url = `${origin}/events/${eventId}`;
 
-  // Auto-sync teams: if player is active (not bench), add to smaller team
+  // Auto-sync teams
   if (!isOnBench) {
     await addPlayerToTeams(eventId, trimmed);
   }
 
-  // Validate teams: ensure no bench players are in teams
   await validateTeams(eventId, event.maxPlayers);
 
   if (isOnBench) {
@@ -358,8 +446,6 @@ export const POST: APIRoute = async ({ params, request }) => {
     await enqueueNotification(eventId, "player_joined", { title: event.title, key: "notifyPlayerJoined", params: { name: trimmed }, url, spotsLeft }, senderClientId);
   }
 
-  // Drain notification queue before responding so push is sent immediately.
-  // Must be awaited — fire-and-forget gets killed when the response completes.
   if (!process.env.VITEST) {
     await drainNotificationQueue().catch((err) => {
       log.error({ eventId, err }, "Failed to drain notification queue");
@@ -384,12 +470,12 @@ export const POST: APIRoute = async ({ params, request }) => {
           });
         }
       } catch (_err) {
-        // Non-blocking — don't fail the join if email fails
+        // Non-blocking
       }
     }
   }
 
-  // Notify the event owner when someone joins (skip if owner is the one joining)
+  // Notify the event owner when someone joins
   if (event.ownerId && event.ownerId !== session?.user?.id) {
     try {
       const owner = await prisma.user.findUnique({ where: { id: event.ownerId }, select: { email: true, id: true } });
@@ -409,7 +495,7 @@ export const POST: APIRoute = async ({ params, request }) => {
     }
   }
 
-  // Fire webhooks (non-blocking)
+  // Fire webhooks
   const webhookData = { playerName: trimmed, isActive: !isOnBench, spotsLeft };
   fireWebhooks(eventId, "player_joined", webhookData).catch(() => {});
   if (spotsLeft === 0) {
@@ -417,16 +503,16 @@ export const POST: APIRoute = async ({ params, request }) => {
     await enqueueNotification(eventId, "game_full", { title: event.title, key: "notifyGameFullAlert", params: { name: trimmed }, url, spotsLeft: 0 }, senderClientId);
   }
 
-  // Recalculate payment shares if a cost is set
   await syncPaymentsForEvent(eventId);
-
 
   logEvent(eventId, "player_added", session?.user?.name ?? trimmed, session?.user?.id ?? null, { playerName: trimmed }).catch(() => {});
 
-  // ── Invite-by-email: notify a registered user, or email an unregistered one ──
+  // ── Invite-by-email: notify or email (auth-gated + rate-limited) ───────────
   let inviteResult: "notified" | "emailed" | null = null;
   const inviterName = session?.user?.name ?? null;
-  if (notifyRegisteredUserId && notifyRegisteredUserId !== session?.user?.id) {
+  const isAuthenticated = !!session?.user;
+
+  if (isAuthenticated && notifyRegisteredUserId && notifyRegisteredUserId !== session?.user?.id) {
     try {
       await sendPushToUser(
         notifyRegisteredUserId,
@@ -438,22 +524,27 @@ export const POST: APIRoute = async ({ params, request }) => {
     } catch (err) {
       log.error({ eventId, err }, "Failed to send invite push");
     }
-  } else if (inviteUnregisteredEmail) {
-    try {
-      await sendPlayerInviteToRegister(inviteUnregisteredEmail, {
-        eventTitle: event.title,
-        dateTime: event.dateTime.toISOString(),
-        location: event.location,
-        eventUrl: url,
-        inviterName,
-      });
-      inviteResult = "emailed";
-    } catch (err) {
-      log.error({ eventId, err }, "Failed to send invite email");
+  } else if (isAuthenticated && inviteUnregisteredEmail) {
+    // Rate-limit check: only send if under per-event and per-sender limits
+    const senderId = session!.user!.id;
+    if (canSendInviteEmail(eventId, senderId, inviteUnregisteredEmail)) {
+      try {
+        await sendPlayerInviteToRegister(inviteUnregisteredEmail, {
+          eventTitle: event.title,
+          dateTime: event.dateTime.toISOString(),
+          location: event.location,
+          eventUrl: url,
+          inviterName,
+        });
+        recordInviteEmail(eventId, senderId, inviteUnregisteredEmail);
+        inviteResult = "emailed";
+      } catch (err) {
+        log.error({ eventId, err }, "Failed to send invite email");
+      }
     }
   }
 
-  return Response.json({ ok: true, invited: inviteResult });
+  return Response.json({ ok: true, invited: inviteResult, resolvedName: trimmed });
 };
 
 export const DELETE: APIRoute = async ({ params, request }) => {

--- a/src/test/invite-by-email.test.ts
+++ b/src/test/invite-by-email.test.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { prisma } from "~/lib/db.server";
-import { POST } from "~/pages/api/events/[id]/players";
+import { POST, resetInviteRateLimitStores } from "~/pages/api/events/[id]/players";
 import { getSession } from "~/lib/auth.helpers.server";
 import { resetRateLimitStore } from "~/lib/rateLimit.server";
 import { resetApiRateLimitStore } from "~/lib/apiRateLimit.server";
 import { sendPushToUser } from "~/lib/push.server";
 import { sendPlayerInviteToRegister } from "~/lib/email.server";
 
-vi.mock("~/lib/auth.helpers.server", () => ({ getSession: vi.fn() }));
+vi.mock("~/lib/auth.helpers.server", () => ({ getSession: vi.fn(), checkOwnership: vi.fn() }));
 vi.mock("~/lib/push.server", () => ({ sendPushToUser: vi.fn().mockResolvedValue(undefined) }));
 // Keep the other email exports working; only stub the network senders we assert on.
 vi.mock("~/lib/email.server", async (importOriginal) => {
@@ -51,6 +51,7 @@ beforeEach(async () => {
   await prisma.user.deleteMany();
   resetRateLimitStore();
   resetApiRateLimitStore();
+  resetInviteRateLimitStores();
   vi.clearAllMocks();
 });
 
@@ -62,12 +63,14 @@ describe("POST /api/events/[id]/players — invite by email", () => {
 
     const res = await POST(ctx(event.id, { name: "Friend Smith", email: "friend@t.com" }, { user: { id: owner.id, name: "Owner" } }));
     expect(res.status).toBe(200);
-    expect(await res.json()).toMatchObject({ ok: true, invited: "notified" });
+    const json = await res.json();
+    expect(json).toMatchObject({ ok: true, invited: "notified", resolvedName: "Friend" });
 
     expect(mockPush).toHaveBeenCalledWith(friend.id, "Pickup Game", expect.stringContaining("added you"), expect.any(String));
     expect(mockInviteEmail).not.toHaveBeenCalled();
 
-    const player = await prisma.player.findFirst({ where: { eventId: event.id, name: "Friend Smith" } });
+    // Email resolves → uses User.name ("Friend"), not the client-provided "Friend Smith"
+    const player = await prisma.player.findFirst({ where: { eventId: event.id, name: "Friend" } });
     expect(player?.userId).toBe(friend.id);
   });
 
@@ -77,7 +80,8 @@ describe("POST /api/events/[id]/players — invite by email", () => {
 
     const res = await POST(ctx(event.id, { name: "New Guy", email: "newguy@example.com" }, { user: { id: owner.id, name: "Owner" } }));
     expect(res.status).toBe(200);
-    expect(await res.json()).toMatchObject({ ok: true, invited: "emailed" });
+    const json = await res.json();
+    expect(json).toMatchObject({ ok: true, invited: "emailed", resolvedName: "New Guy" });
 
     expect(mockInviteEmail).toHaveBeenCalledWith(
       "newguy@example.com",
@@ -90,7 +94,8 @@ describe("POST /api/events/[id]/players — invite by email", () => {
     const event = await seedEvent();
     const res = await POST(ctx(event.id, { name: "Plain", email: "not-an-email" }, null));
     expect(res.status).toBe(200);
-    expect(await res.json()).toMatchObject({ ok: true, invited: null });
+    const json = await res.json();
+    expect(json).toMatchObject({ ok: true, invited: null, resolvedName: "Plain" });
     expect(mockPush).not.toHaveBeenCalled();
     expect(mockInviteEmail).not.toHaveBeenCalled();
     expect(await prisma.player.count({ where: { eventId: event.id } })).toBe(1);
@@ -101,7 +106,110 @@ describe("POST /api/events/[id]/players — invite by email", () => {
     const event = await seedEvent(self.id);
     const res = await POST(ctx(event.id, { name: "Self", email: "self@t.com" }, { user: { id: self.id, name: "Self" } }));
     expect(res.status).toBe(200);
-    expect(await res.json()).toMatchObject({ ok: true, invited: null });
+    const json = await res.json();
+    expect(json).toMatchObject({ ok: true, invited: null });
     expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  // ── New tests ────────────────────────────────────────────────────────────────
+
+  it("unauthenticated callers adding with email do NOT send invite emails", async () => {
+    const event = await seedEvent();
+    const res = await POST(ctx(event.id, { name: "Anon Player", email: "someone@example.com" }, null));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toMatchObject({ ok: true, invited: null });
+    expect(mockInviteEmail).not.toHaveBeenCalled();
+    expect(mockPush).not.toHaveBeenCalled();
+    // Player was still added
+    expect(await prisma.player.count({ where: { eventId: event.id } })).toBe(1);
+  });
+
+  it("per-event rate limit: 11th unique email is skipped", async () => {
+    const owner = await prisma.user.create({ data: { id: "u-owner", name: "Owner", email: "owner@t.com", emailVerified: true } });
+    const event = await seedEvent(owner.id);
+
+    // Send 10 successful invites
+    for (let i = 0; i < 10; i++) {
+      const res = await POST(ctx(event.id, { name: `Player ${i}`, email: `user${i}@ext.com` }, { user: { id: owner.id, name: "Owner" } }));
+      expect(res.status).toBe(200);
+    }
+    expect(mockInviteEmail).toHaveBeenCalledTimes(10);
+
+    // 11th should be skipped
+    mockInviteEmail.mockClear();
+    const res = await POST(ctx(event.id, { name: "Player 10", email: "user10@ext.com" }, { user: { id: owner.id, name: "Owner" } }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.ok).toBe(true);
+    expect(json.invited).toBeNull(); // email skipped, player still added
+    expect(mockInviteEmail).not.toHaveBeenCalled();
+    expect(await prisma.player.count({ where: { eventId: event.id, name: "Player 10" } })).toBe(1);
+  });
+
+  it("name-empty + email resolves to registered user → uses User.name", async () => {
+    const owner = await prisma.user.create({ data: { id: "u-owner", name: "Owner", email: "owner@t.com", emailVerified: true } });
+    const friend = await prisma.user.create({ data: { id: "u-friend", name: "Jane Doe", email: "jane@t.com", emailVerified: true } });
+    const event = await seedEvent(owner.id);
+
+    const res = await POST(ctx(event.id, { name: "", email: "jane@t.com" }, { user: { id: owner.id, name: "Owner" } }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.resolvedName).toBe("Jane Doe");
+
+    const player = await prisma.player.findFirst({ where: { eventId: event.id, name: "Jane Doe" } });
+    expect(player).not.toBeNull();
+    expect(player?.userId).toBe(friend.id);
+  });
+
+  it("name-empty + email does NOT resolve → returns 400", async () => {
+    const owner = await prisma.user.create({ data: { id: "u-owner", name: "Owner", email: "owner@t.com", emailVerified: true } });
+    const event = await seedEvent(owner.id);
+
+    const res = await POST(ctx(event.id, { name: "", email: "unknown@nowhere.com" }, { user: { id: owner.id, name: "Owner" } }));
+    expect(res.status).toBe(400);
+  });
+
+  it("P2002 merge: existing unlinked player gets userId set", async () => {
+    const owner = await prisma.user.create({ data: { id: "u-owner", name: "Owner", email: "owner@t.com", emailVerified: true } });
+    const friend = await prisma.user.create({ data: { id: "u-friend", name: "Alex", email: "alex@t.com", emailVerified: true } });
+    const event = await seedEvent(owner.id);
+
+    // Pre-existing unlinked player named "Alex"
+    await prisma.player.create({ data: { name: "Alex", eventId: event.id, order: 0 } });
+
+    // Add by email → resolves to User "Alex", triggers P2002, should merge
+    const res = await POST(ctx(event.id, { name: "Alex", email: "alex@t.com" }, { user: { id: owner.id, name: "Owner" } }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toMatchObject({ ok: true, resolvedName: "Alex" });
+
+    // Verify the existing player now has userId linked
+    const player = await prisma.player.findUnique({ where: { eventId_name: { eventId: event.id, name: "Alex" } } });
+    expect(player?.userId).toBe(friend.id);
+  });
+
+  it("P2002 reject: existing player linked to different user", async () => {
+    const owner = await prisma.user.create({ data: { id: "u-owner", name: "Owner", email: "owner@t.com", emailVerified: true } });
+    const other = await prisma.user.create({ data: { id: "u-other", name: "Bob", email: "bob@t.com", emailVerified: true } });
+    const _friend = await prisma.user.create({ data: { id: "u-friend", name: "Bob", email: "bob2@t.com", emailVerified: true } });
+    const event = await seedEvent(owner.id);
+
+    // Pre-existing player "Bob" linked to "u-other"
+    await prisma.player.create({ data: { name: "Bob", eventId: event.id, order: 0, userId: other.id } });
+
+    // Try to add by email (bob2@t.com resolves to friend whose name is "Bob")
+    const res = await POST(ctx(event.id, { name: "Bob", email: "bob2@t.com" }, { user: { id: owner.id, name: "Owner" } }));
+    expect(res.status).toBe(409);
+    const json = await res.json();
+    expect(json.error).toContain("different account");
+  });
+
+  it("resolvedName is returned in the response", async () => {
+    const event = await seedEvent();
+    const res = await POST(ctx(event.id, { name: "Test Player" }, null));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.resolvedName).toBe("Test Player");
   });
 });


### PR DESCRIPTION
## UX: seamless add-by-identity (zero extra taps)

When you pick a contact or provide an email, the system **resolves the person automatically**:

| Input | Registered? | Result |
|---|---|---|
| Contact picker (email) | Yes | **Auto-add** as their Convocados name, linked. Push notify. Zero extra taps + undo snackbar. |
| Contact picker (email) | No | Auto-add as contact display name + email invite. Zero extra taps + undo. |
| Web email field | Yes | Name field optional — backend resolves to User.name. Shows "Added {resolvedName} ✓". |
| Web email field | No | Name required — sends invite email. |

### Design decisions (grill session)
1. Always use `User.name` when linking (not the contact's display name)
2. Response includes `resolvedName` for instant client feedback
3. Android: auto-add immediately on contact pick + undo snackbar (no confirm step)
4. Web: name field optional when email provided, resolve on submit
5. P2002 collision: merge (auto-claim unlinked player) or reject (if linked to different user)

## Security mitigations

- **Auth-gate:** Invite emails only sent when caller is authenticated
- **Per-event rate limit:** Max 10 unique invite emails per event per 24h
- **Per-sender rate limit:** Max 20 invite emails per user per 24h
- **Audit trail:** `invitedByUserId` column on Player (Prisma migration)
- **Abuse link:** Invite email includes 'Didn't expect this?' + report-abuse mailto

## Testing (11 tests)
- Auth-gate, per-event limit, name resolution, P2002 merge, P2002 reject, resolvedName, self-invite no-op, malformed email
- Android: compileDebugKotlin + testDebugUnitTest pass
- Web: typecheck + lint + i18n-sync pass