### PR TITLE
fix(android): responsive tab layout for games (My Games / Archived / Public)

### DIFF
--- a/android-app/app/src/main/java/dev/convocados/ui/screen/games/GamesScreen.kt
+++ b/android-app/app/src/main/java/dev/convocados/ui/screen/games/GamesScreen.kt
@@ -133,45 +133,46 @@ fun GamesScreen(
         val archived = archivedOwned
         val games = if (showArchived) archived else active
 
-        PullToRefreshBox(
-            isRefreshing = isRefreshing,
-            onRefresh = { viewModel.refresh() },
-            modifier = Modifier.fillMaxSize().padding(padding),
-        ) {
-            LazyColumn(
-                contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp),
+        Column(Modifier.fillMaxSize().padding(padding)) {
+            // Fixed tab header — stays visible while content scrolls.
+            // SecondaryScrollableTabRow adapts: scrollable when tabs overflow,
+            // fills width otherwise. Better than chips that clip on small screens.
+            val tabIndex = if (showArchived) 1 else 0
+            SecondaryScrollableTabRow(
+                selectedTabIndex = tabIndex,
+                edgePadding = 16.dp,
+                containerColor = MaterialTheme.colorScheme.background,
+                divider = {},
             ) {
-                // Tab bar
-                item {
-                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.padding(bottom = 8.dp)) {
-                        FilterChip(
-                            selected = !showArchived,
-                            onClick = { showArchived = false },
-                            label = { Text("${stringResource(R.string.my_games)} (${active.size})") },
-                            colors = FilterChipDefaults.filterChipColors(
-                                selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
-                                selectedLabelColor = MaterialTheme.colorScheme.onPrimaryContainer,
-                            ),
-                        )
-                        if (archived.isNotEmpty()) {
-                            FilterChip(
-                                selected = showArchived,
-                                onClick = { showArchived = true },
-                                label = { Text("${stringResource(R.string.archived)} (${archived.size})") },
-                                colors = FilterChipDefaults.filterChipColors(
-                                    selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
-                                    selectedLabelColor = MaterialTheme.colorScheme.onPrimaryContainer,
-                                ),
-                            )
-                        }
-                        FilterChip(
-                            selected = false,
-                            onClick = onPublicClick,
-                            label = { Text(stringResource(R.string.public_label)) }, leadingIcon = { Icon(Icons.Default.Public, stringResource(R.string.public_label), modifier = Modifier.size(18.dp)) },
-                        )
-                    }
+                Tab(
+                    selected = tabIndex == 0,
+                    onClick = { showArchived = false },
+                    text = { Text("${stringResource(R.string.my_games)} (${active.size})") },
+                )
+                if (archived.isNotEmpty()) {
+                    Tab(
+                        selected = tabIndex == 1,
+                        onClick = { showArchived = true },
+                        text = { Text("${stringResource(R.string.archived)} (${archived.size})") },
+                    )
                 }
+                Tab(
+                    selected = false,
+                    onClick = onPublicClick,
+                    text = { Text(stringResource(R.string.public_label)) },
+                    icon = { Icon(Icons.Default.Public, null, modifier = Modifier.size(18.dp)) },
+                )
+            }
+
+            PullToRefreshBox(
+                isRefreshing = isRefreshing,
+                onRefresh = { viewModel.refresh() },
+                modifier = Modifier.fillMaxSize(),
+            ) {
+                LazyColumn(
+                    contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
 
                 if (games.isEmpty() && showArchived) {
                     item {
@@ -235,7 +236,8 @@ fun GamesScreen(
                     )
                 }
             }
-        }
+        }  // PullToRefreshBox
+        }  // Column
     }
 }
 


### PR DESCRIPTION
## Problem
The tab bar (My Games, Archived, Public) used `FilterChip`s in a fixed `Row`. On smaller screens the chips overflow and clip — the 'Public' chip with its leading icon often isn't fully visible, and with the count badges (`My Games (5)`) the bar exceeds viewport width.

## Fix
Replace with **`SecondaryScrollableTabRow`** (M3 responsive pattern):
- Tabs **scroll horizontally** when they can't all fit — works on any screen width
- **Fixed above the list** (tabs no longer scroll with content — correct M3 hierarchy)
- Pull-to-refresh still works on the game list below
- Visual: proper selected-tab indicator underline vs. chip fill

## Why SecondaryScrollableTabRow vs. alternatives
- `TabRow` (fixed): equal-width tabs — wastes space when only 2 tabs, can't scroll
- `ScrollableTabRow`: first-party M3, handles overflow gracefully, adapts width
- Chips in `horizontalScroll`: not a standard navigation pattern — no indicator, no a11y role