### PR TITLE
fix: remove @prisma/engines from Dockerfile (Prisma 6 uses WASM)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,8 @@ RUN tar -C /usr/local/bin -xzf /tmp/litestream.tar.gz && rm /tmp/litestream.tar.
 COPY --from=prod-deps /app/node_modules ./node_modules
 COPY --from=build /app/dist ./dist
 COPY --from=build /app/node_modules/.prisma ./node_modules/.prisma
+COPY --from=build /app/node_modules/@prisma/client ./node_modules/@prisma/client
 COPY --from=build /app/node_modules/prisma ./node_modules/prisma
-COPY --from=build /app/node_modules/@prisma/engines ./node_modules/@prisma/engines
 RUN mkdir -p node_modules/.bin && ln -sf ../prisma/build/index.js node_modules/.bin/prisma
 COPY package.json ./
 COPY prisma ./prisma


### PR DESCRIPTION
Prisma 6 no longer ships native engines in @prisma/engines. The generated client now uses WASM engines bundled in .prisma/client. This fixes the Release workflow Docker build failure.