### PR TITLE
fix: run prisma generate in production Docker stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,12 +32,9 @@ RUN tar -C /usr/local/bin -xzf /tmp/litestream.tar.gz && rm /tmp/litestream.tar.
 
 COPY --from=prod-deps /app/node_modules ./node_modules
 COPY --from=build /app/dist ./dist
-COPY --from=build /app/node_modules/.prisma ./node_modules/.prisma
-COPY --from=build /app/node_modules/@prisma/client ./node_modules/@prisma/client
-COPY --from=build /app/node_modules/prisma ./node_modules/prisma
-RUN mkdir -p node_modules/.bin && ln -sf ../prisma/build/index.js node_modules/.bin/prisma
-COPY package.json ./
 COPY prisma ./prisma
+RUN npx prisma generate
+COPY package.json ./
 COPY public ./public
 COPY litestream.yml ./litestream.yml
 COPY scripts/start.sh ./scripts/start.sh


### PR DESCRIPTION
The .prisma directory doesn't exist in the build stage with pnpm hoisted layout. Run prisma generate directly in the production stage after copying the schema.