### PR TITLE
fix: use node to run prisma generate in Docker (bypass pnpm)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,8 @@ RUN tar -C /usr/local/bin -xzf /tmp/litestream.tar.gz && rm /tmp/litestream.tar.
 COPY --from=prod-deps /app/node_modules ./node_modules
 COPY --from=build /app/dist ./dist
 COPY prisma ./prisma
-RUN npx prisma generate
 COPY package.json ./
+RUN node node_modules/prisma/build/index.js generate
 COPY public ./public
 COPY litestream.yml ./litestream.yml
 COPY scripts/start.sh ./scripts/start.sh


### PR DESCRIPTION
pnpm 11 blocks prisma generate due to approve-builds. Call prisma's index.js directly.