### PR TITLE
fix(priority): allow self-confirm up to kickoff (#454)

### DIFF
--- a/src/lib/priority.server.ts
+++ b/src/lib/priority.server.ts
@@ -116,7 +116,24 @@ export async function confirmSpot(eventId: string, userId: string, gameDate: Dat
     where: { eventId_userId_gameDate: { eventId, userId, gameDate } },
   });
   if (!confirmation) return null;
-  if (confirmation.status !== "pending") return confirmation;
+  if (confirmation.status !== "pending") {
+    // #454: allow late confirmation of an expired spot, up until kickoff.
+    // The deadline is a nudge, not a hard wall — if the game has not
+    // started yet, the player can still claim their spot.
+    const gameStarted = gameDate.getTime() <= Date.now();
+    if (confirmation.status === "expired" && !gameStarted) {
+      const updated = await prisma.priorityConfirmation.update({
+        where: { id: confirmation.id },
+        data: { status: "confirmed", respondedAt: new Date() },
+      });
+      await prisma.priorityEnrollment.updateMany({
+        where: { eventId, userId },
+        data: { declineStreak: 0 },
+      });
+      return updated;
+    }
+    return confirmation;
+  }
 
   const updated = await prisma.priorityConfirmation.update({
     where: { id: confirmation.id },

--- a/src/pages/api/events/[id]/priority/confirm.ts
+++ b/src/pages/api/events/[id]/priority/confirm.ts
@@ -21,6 +21,14 @@ export const POST: APIRoute = async ({ params, request }) => {
   const result = await confirmSpot(event.id, session.user.id, event.dateTime);
   if (!result) return Response.json({ error: "No pending confirmation found." }, { status: 404 });
 
+  // #454: if the game has already started, an expired spot stays expired.
+  if (result.status === "expired" && event.dateTime.getTime() <= Date.now()) {
+    return Response.json(
+      { error: "The game has already started — you can no longer claim a priority spot." },
+      { status: 409 },
+    );
+  }
+
   if (result.status === "confirmed") {
     // Auto-add player to the event if not already there
     const existingPlayer = await prisma.player.findFirst({

--- a/src/test/priority-api.test.ts
+++ b/src/test/priority-api.test.ts
@@ -386,6 +386,58 @@ describe("POST /api/events/:id/priority/confirm", () => {
     const res = await confirmPriority(ctx({ id: event.id }, {}));
     expect(res.status).toBe(404);
   });
+
+  it("allows late confirmation of an expired spot before kickoff (#454)", async () => {
+    const owner = await seedUser();
+    const player = await seedUser({ name: "LatePlayer" });
+    const gameDate = new Date(Date.now() + 3600_000);
+    const event = await seedEvent(owner.id, { priorityEnabled: true, dateTime: gameDate });
+
+    await testPrisma.priorityEnrollment.create({
+      data: { eventId: event.id, userId: player.id, source: "auto" },
+    });
+    await testPrisma.priorityConfirmation.create({
+      data: {
+        eventId: event.id,
+        userId: player.id,
+        gameDate,
+        status: "expired",
+        notifiedAt: new Date(),
+        deadline: new Date(Date.now() - 60_000),
+      },
+    });
+
+    mockAuth(player.id);
+    const res = await confirmPriority(ctx({ id: event.id }, {}));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe("confirmed");
+  });
+
+  it("rejects confirmation of an expired spot after kickoff (#454)", async () => {
+    const owner = await seedUser();
+    const player = await seedUser({ name: "TooLate" });
+    const gameDate = new Date(Date.now() - 60_000);
+    const event = await seedEvent(owner.id, { priorityEnabled: true, dateTime: gameDate });
+
+    await testPrisma.priorityEnrollment.create({
+      data: { eventId: event.id, userId: player.id, source: "auto" },
+    });
+    await testPrisma.priorityConfirmation.create({
+      data: {
+        eventId: event.id,
+        userId: player.id,
+        gameDate,
+        status: "expired",
+        notifiedAt: new Date(),
+        deadline: new Date(Date.now() - 120_000),
+      },
+    });
+
+    mockAuth(player.id);
+    const res = await confirmPriority(ctx({ id: event.id }, {}));
+    expect(res.status).toBe(409);
+  });
 });
 
 describe("POST /api/events/:id/priority/decline", () => {

--- a/src/test/priority-server.test.ts
+++ b/src/test/priority-server.test.ts
@@ -99,6 +99,40 @@ describe("confirmSpot", () => {
     });
     expect(enrollment!.declineStreak).toBe(0);
   });
+
+  it("allows late confirmation of an expired spot before kickoff (#454)", async () => {
+    const { user, event } = await seedEventAndUser();
+    const pastDeadline = new Date(Date.now() - 1000);
+    await createConfirmations(event.id, [user.id], event.dateTime, pastDeadline);
+    await expireUnconfirmed();
+
+    const result = await confirmSpot(event.id, user.id, event.dateTime);
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe("confirmed");
+  });
+
+  it("refuses late confirmation after the game has started (#454)", async () => {
+    const pastEvent = await prisma.event.create({
+      data: {
+        title: "Past Game", location: "Pitch", dateTime: new Date(Date.now() - 60000),
+        maxPlayers: 10, priorityEnabled: true, priorityThreshold: 70,
+        priorityWindow: 10, priorityMaxPercent: 50, priorityDeadlineHours: 24, priorityMinGames: 3,
+      },
+    });
+    const user = await prisma.user.create({
+      data: { id: "prio-late", name: "Late", email: "l@t.com", emailVerified: true },
+    });
+    await prisma.priorityEnrollment.create({
+      data: { eventId: pastEvent.id, userId: user.id, source: "auto", optedIn: true },
+    });
+    const pastDeadline = new Date(Date.now() - 120000);
+    await createConfirmations(pastEvent.id, [user.id], pastEvent.dateTime, pastDeadline);
+    await expireUnconfirmed();
+
+    const result = await confirmSpot(pastEvent.id, user.id, pastEvent.dateTime);
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe("expired");
+  });
 });
 
 describe("declineSpot", () => {


### PR DESCRIPTION
## Problem

Closes #454. A user that lands in the priority list but misses the confirmation
deadline (`expireUnconfirmed` flips their spot to `expired`) cannot re-confirm
via `POST /api/events/:id/priority/confirm`. `confirmSpot` returned the existing
`expired` row, leaving the user with no path to add themselves to the game.

## Fix

`src/lib/priority.server.ts` — `confirmSpot` now recovers from `expired`
status up to the event's `dateTime`. After kickoff, expired stays expired.

`src/pages/api/events/[id]/priority/confirm.ts` — surfaces a clear 409 message
when the game has already started instead of the misleading 200 + "expired"
status.

## Tests

- `src/test/priority-server.test.ts` — late confirm of expired spot before kickoff, refuses after kickoff
- `src/test/priority-api.test.ts` — same cases at the API layer

148 test files / 2586 tests green. Typecheck clean. No new lint warnings.

## Out of scope

- UI: the player-facing surface is the priority deep-link from the push
  notification. The API fix unblocks that path. Surfacing a "you can still
  claim your spot" banner on `EventPage` is a follow-up.