### PR TITLE
fix(log): show anonymous actor instead of added player name (#456)

### DIFF
--- a/src/pages/api/events/[id]/players.ts
+++ b/src/pages/api/events/[id]/players.ts
@@ -541,7 +541,7 @@ export const POST: APIRoute = async ({ params, request }) => {
 
   await syncPaymentsForEvent(eventId);
 
-  logEvent(eventId, "player_added", session?.user?.name ?? trimmed, session?.user?.id ?? null, { playerName: trimmed }).catch(() => {});
+  logEvent(eventId, "player_added", session?.user?.name ?? null, session?.user?.id ?? null, { playerName: trimmed }).catch(() => {});
 
   // ── Invite-by-email: notify or email (auth-gated + rate-limited) ───────────
   let inviteResult: "notified" | "emailed" | null = null;

--- a/src/test/players-autolink.test.ts
+++ b/src/test/players-autolink.test.ts
@@ -36,6 +36,7 @@ async function seedEvent() {
 }
 
 beforeEach(async () => {
+  await prisma.eventLog.deleteMany();
   await prisma.playerRating.deleteMany();
   await prisma.teamResult.deleteMany();
   await prisma.player.deleteMany();
@@ -155,5 +156,24 @@ describe("POST /api/events/[id]/players — auto-link on name match", () => {
     expect(normalizeForMatch("Gonçalo")).toBe(normalizeForMatch("GONCALO"));
     expect(normalizeForMatch("Gonçalo")).toBe(normalizeForMatch("goncalo"));
     expect(normalizeForMatch("Gonçalo")).not.toBe(normalizeForMatch("João"));
+  });
+
+  it("logs actor as null (anonymous) when no session is present (#456)", async () => {
+    const event = await seedEvent();
+    const res = await POST(ctx(event.id, { name: "Stranger" }, null));
+    expect(res.status).toBe(200);
+
+    // logEvent is fire-and-forget in the handler — wait for the row.
+    let log: Awaited<ReturnType<typeof prisma.eventLog.findFirst>> = null;
+    for (let i = 0; i < 20 && !log; i++) {
+      log = await prisma.eventLog.findFirst({ where: { eventId: event.id, action: "player_added" } });
+      if (!log) await new Promise((r) => setTimeout(r, 25));
+    }
+    expect(log).not.toBeNull();
+    // #456: actor must NOT be the added player's name; it should be null so
+    // EventLogPage renders the i18n "logAnonymous" fallback.
+    expect(log!.actor).toBeNull();
+    expect(log!.actorId).toBeNull();
+    expect(JSON.parse(log!.details)).toEqual({ playerName: "Stranger" });
   });
 });


### PR DESCRIPTION
## Problem

Closes #456. When an unauthenticated client posts to
`POST /api/events/:id/players`, the handler logged the added player's
name as the actor — the event log then read 'John added John' instead of
'Someone added John'.

## Fix

`src/pages/api/events/[id]/players.ts:544` — change the actor fallback
from `trimmed` to `null`. `EventLogPage.tsx:131` already renders
`t('logAnonymous')` for null actors in all 6 locales.

## Tests

`src/test/players-autolink.test.ts` — new test asserts the logged
actor is `null` (not the player's name) when no session is present.

148 files / 2583 tests green. Typecheck clean.