### PR TITLE
test(e2e): handle confirm-leave dialog in X button tests + unique IP for duplicate test

### DIFF
--- a/e2e/add-player-confirmation.spec.ts
+++ b/e2e/add-player-confirmation.spec.ts
@@ -166,10 +166,12 @@ test.describe("Event page — add and remove players (issue #455)", () => {
     // Pre-condition: both are on the roster.
     expect((await getRoster(request, eventId)).sort()).toEqual([keep, remove].sort());
 
-    // Action: click the remove IconButton on the row for `remove`.
+    // Action: click the remove IconButton on the row for `remove`, then confirm in the dialog.
     const removeRow = page.locator(".MuiListItem-root", { hasText: remove }).first();
     await expect(removeRow).toBeVisible();
     await removeRow.locator("button").last().click();
+    // The X button now opens a confirm-leave dialog (#469). Confirm the removal.
+    await page.getByTestId("leave-dialog-confirm").click();
 
     // Post-condition: remove is gone, keep is still there (DOM + server).
     await expectRosterOmits(page, request, eventId, remove);

--- a/e2e/event-lifecycle.spec.ts
+++ b/e2e/event-lifecycle.spec.ts
@@ -111,11 +111,16 @@ test.describe("Event lifecycle — create, add players, randomize", () => {
   });
 
   test("duplicate player name returns 409", async ({ request }) => {
+    // Use a unique IP so this test doesn't share the per-IP event-create rate limit with
+    // the other tests in this file (which all hit the same 127.0.0.1).
+    const ip = `10.99.${Math.floor(Math.random() * 256)}.${Math.floor(Math.random() * 256)}`;
+    const headers = { "X-Forwarded-For": ip };
     const tomorrow = new Date();
     tomorrow.setDate(tomorrow.getDate() + 1);
     tomorrow.setHours(20, 0, 0, 0);
 
     const createRes = await request.post("/api/events", {
+      headers,
       data: {
         title: "E2E Duplicate Test",
         dateTime: tomorrow.toISOString(),
@@ -127,12 +132,14 @@ test.describe("Event lifecycle — create, add players, randomize", () => {
 
     // Add player
     const res1 = await request.post(`/api/events/${id}/players`, {
+      headers,
       data: { name: "Alice" },
     });
     expect(res1.status()).toBe(200);
 
     // Add same player again
     const res2 = await request.post(`/api/events/${id}/players`, {
+      headers,
       data: { name: "Alice" },
     });
     expect(res2.status()).toBe(409);

--- a/e2e/notifications.spec.ts
+++ b/e2e/notifications.spec.ts
@@ -134,6 +134,8 @@ test.describe("Snackbar notifications", () => {
     const listItem = page.locator(`[data-testid="player-item-UndoTestPlayer"], li:has-text("UndoTestPlayer")`).first();
     const deleteBtn = listItem.locator('button').last();
     await deleteBtn.click();
+    // The X button now opens a confirm-leave dialog (#469). Confirm the removal.
+    await page.getByTestId("leave-dialog-confirm").click();
 
     // Undo snackbar should appear
     await expect(page.locator('.MuiSnackbar-root')).toBeVisible({ timeout: 5_000 });


### PR DESCRIPTION
## Fix

Two e2e test failures from the current main branch CI:

1. **X button tests** (add-player-confirmation.spec.ts:153, notifications.spec.ts:113): PR #467 changed the X button to open a confirm dialog before removing the player. The tests were clicking the X and expecting the player to disappear / snackbar to appear immediately — but the confirm dialog blocks the action. Updated both tests to click the confirm button after the X.

2. **Duplicate name test** (event-lifecycle.spec.ts:113): Was failing with 404 on the first add. Root cause: rate limit (10 events/hour/IP). All tests in event-lifecycle.spec.ts share 127.0.0.1, and the suite has consumed the budget. Pass a unique X-Forwarded-For IP for this test.

## Why this is needed

CI on main is currently failing on the E2E job, which blocks the version-bump + Fly.io deploy workflow. This PR unblocks the deploy of #469 (skip confirm when no warning applies) and any subsequent merges.