### PR TITLE
fix: silent un-archive + restore order on re-add

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -191,3 +191,9 @@ The recipient set for a Game is the union of: **EventFollow** (followers), `Play
 
 Distinguished from the historical-stats API at `/api/events/[id]/attendance` (which computes per-player attendance rate from `GameHistory`); that endpoint shares the user-facing word but is a different concept.
 _Avoid_: RSVP (table name only), response
+
+### Leave / Re-join round-trip
+A **Player** can leave a Game via the X button (admin) or the "Not coming" CTA (self). The leave is a **soft-archive**: `Player.archivedAt` is set, the row is hidden from the active list, and an `Rsvp` audit row with `status="no"` is written. The `Rsvp` recipient set filters out archived players.
+
+Re-adding the same name (self or by an organizer) is a **silent un-archive** handled in the `POST /api/events/[id]/players` P2002 branch: the original `order` is restored, any current occupant of that slot is bumped to the bench, `archivedAt` is cleared, and the `Rsvp` is reset to `status="yes"`. The response carries `reactivated: true` so the client can show an "Undo" snackbar.
+

--- a/src/pages/api/events/[id]/players.ts
+++ b/src/pages/api/events/[id]/players.ts
@@ -422,12 +422,53 @@ export const POST: APIRoute = async ({ params, request }) => {
     });
   } catch (e) {
     if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === "P2002") {
-      // ── P2002 merge logic ──────────────────────────────────────────────
-      if (resolvedUser) {
-        const existing = await prisma.player.findUnique({
-          where: { eventId_name: { eventId, name: trimmed } },
-          select: { id: true, userId: true },
+      // ── P2002 merge / re-add logic ─────────────────────────────────────
+      const existing = await prisma.player.findUnique({
+        where: { eventId_name: { eventId, name: trimmed } },
+        select: { id: true, userId: true, order: true, archivedAt: true },
+      });
+      if (existing?.archivedAt) {
+        // ── Re-add: un-archive + restore order + reset Rsvp=yes ──────
+        const restoredOrder = existing.order;
+        const occupant = await prisma.player.findFirst({
+          where: { eventId, archivedAt: null, order: restoredOrder, id: { not: existing.id } },
+          select: { id: true, order: true },
         });
+        if (occupant) {
+          // Bump the occupant to the end of the bench (maxPlayers + bench count).
+          const benchSize = await prisma.player.count({
+            where: { eventId, archivedAt: null, order: { gte: event.maxPlayers } },
+          });
+          await prisma.player.update({
+            where: { id: occupant.id },
+            data: { order: event.maxPlayers + benchSize },
+          });
+        }
+        const reactivatedUserId = resolvedUser?.id ?? existing.userId;
+        await prisma.player.update({
+          where: { id: existing.id },
+          data: {
+            archivedAt: null,
+            order: restoredOrder,
+            ...(resolvedUser && !existing.userId ? { userId: resolvedUser.id } : {}),
+          },
+        });
+        if (reactivatedUserId) {
+          await prisma.rsvp.upsert({
+            where: { userId_eventId: { userId: reactivatedUserId, eventId } },
+            create: { eventId, userId: reactivatedUserId, status: "yes", respondedAt: new Date() },
+            update: { status: "yes", respondedAt: new Date() },
+          });
+        } else {
+          // Guest re-add: reset their guest Rsvp to "yes" if it was "no".
+          await prisma.rsvp.updateMany({
+            where: { playerId: existing.id, status: "no" },
+            data: { status: "yes", respondedAt: new Date() },
+          });
+        }
+        return Response.json({ ok: true, invited: null, resolvedName: trimmed, reactivated: true });
+      }
+      if (resolvedUser) {
         if (existing) {
           if (!existing.userId) {
             // Merge: link existing unlinked player to the resolved user

--- a/src/test/api.test.ts
+++ b/src/test/api.test.ts
@@ -293,6 +293,67 @@ describe("POST /api/events/[id]/players", () => {
     const res = await addPlayer(ctx({ id }, { name: "Bob" }));
     expect(res.status).toBe(409);
   });
+
+  it("re-adding a soft-archived player un-archives them and restores their order", async () => {
+    const id = await seedEvent();
+    // Add three players: Alice (order 0), Bob (order 1), Charlie (order 2)
+    await prisma.player.createMany({
+      data: [
+        { name: "Alice", eventId: id, order: 0 },
+        { name: "Bob", eventId: id, order: 1 },
+        { name: "Charlie", eventId: id, order: 2 },
+      ],
+    });
+    // Soft-archive Bob directly (simulating DELETE /players behaviour).
+    await prisma.player.updateMany({
+      where: { eventId: id, name: "Bob" },
+      data: { archivedAt: new Date() },
+    });
+
+    // Re-add Bob → should un-archive, not 409.
+    const res = await addPlayer(ctx({ id }, { name: "Bob" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.reactivated).toBe(true);
+    expect(body.resolvedName).toBe("Bob");
+
+    // Bob is back at order 1 (his original slot).
+    const players = await prisma.player.findMany({
+      where: { eventId: id },
+      orderBy: { order: "asc" },
+    });
+    expect(players.map((p) => p.name)).toEqual(["Alice", "Bob", "Charlie"]);
+    expect(players.find((p) => p.name === "Bob")?.archivedAt).toBeNull();
+  });
+
+  it("re-adding a player bumps the new occupant of the slot to the bench", async () => {
+    const id = await seedEvent(); // maxPlayers: 5
+    // Alice is at order 0. She leaves (gets archived).
+    const alice = await prisma.player.create({
+      data: { name: "Alice", eventId: id, order: 0 },
+    });
+    await prisma.player.update({
+      where: { id: alice.id },
+      data: { archivedAt: new Date() },
+    });
+
+    // Dave takes her slot (order 0).
+    await prisma.player.create({ data: { name: "Dave", eventId: id, order: 0 } });
+
+    // Alice re-joins. Dave should be bumped.
+    const res = await addPlayer(ctx({ id }, { name: "Alice" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.reactivated).toBe(true);
+
+    // Alice is back at order 0. Dave is on the bench.
+    const players = await prisma.player.findMany({
+      where: { eventId: id, archivedAt: null },
+      orderBy: { order: "asc" },
+    });
+    expect(players.find((p) => p.name === "Alice")?.order).toBe(0);
+    expect(players.find((p) => p.name === "Dave")?.order).toBeGreaterThanOrEqual(5);
+  });
 });
 
 // ─── DELETE /api/events/[id]/players ────────────────────────────────────────


### PR DESCRIPTION
When a soft-archived player is re-added (self or organizer), the POST /players P2002 branch now restores the original Player.order, bumps any current occupant of that slot to the bench, clears Player.archivedAt, and resets the Rsvp to status='yes' (user-keyed for linked users, player-keyed for guests).

Response carries reactivated:true so the client can show an undo snackbar.

Tests: 2 new cases in src/test/api.test.ts (order restoration + bench bump). Full suite: 156 files / 2698 tests pass. Lint clean. Typecheck clean.

CONTEXT.md: documents the leave / re-join round-trip.