### PR TITLE
fix: re-add places player at end of list (queue semantics)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -195,5 +195,5 @@ _Avoid_: RSVP (table name only), response
 ### Leave / Re-join round-trip
 A **Player** can leave a Game via the X button (admin) or the "Not coming" CTA (self). The leave is a **soft-archive**: `Player.archivedAt` is set, the row is hidden from the active list, and an `Rsvp` audit row with `status="no"` is written. The `Rsvp` recipient set filters out archived players.
 
-Re-adding the same name (self or by an organizer) is a **silent un-archive** handled in the `POST /api/events/[id]/players` P2002 branch: the original `order` is restored, any current occupant of that slot is bumped to the bench, `archivedAt` is cleared, and the `Rsvp` is reset to `status="yes"`. The response carries `reactivated: true` so the client can show an "Undo" snackbar.
+Re-adding the same name (self or by an organizer) is a **silent un-archive** handled in the `POST /api/events/[id]/players` P2002 branch. The player is placed at the **end of the list** (queue/join semantics — joining is enqueuing, regardless of past membership), `archivedAt` is cleared, and the `Rsvp` is reset to `status="yes"`. The response carries `reactivated: true` so the client can show an "Undo" snackbar.
 

--- a/src/pages/api/events/[id]/players.ts
+++ b/src/pages/api/events/[id]/players.ts
@@ -428,28 +428,20 @@ export const POST: APIRoute = async ({ params, request }) => {
         select: { id: true, userId: true, order: true, archivedAt: true },
       });
       if (existing?.archivedAt) {
-        // ── Re-add: un-archive + restore order + reset Rsvp=yes ──────
-        const restoredOrder = existing.order;
-        const occupant = await prisma.player.findFirst({
-          where: { eventId, archivedAt: null, order: restoredOrder, id: { not: existing.id } },
-          select: { id: true, order: true },
+        // ── Re-add: un-archive + place at end of list + reset Rsvp=yes ─
+        // New joiners go to the end of the list (the "Queue" mental model).
+        // A re-add follows the same rule — the player loses their prior slot.
+        const maxOrder = await prisma.player.aggregate({
+          where: { eventId, archivedAt: null },
+          _max: { order: true },
         });
-        if (occupant) {
-          // Bump the occupant to the end of the bench (maxPlayers + bench count).
-          const benchSize = await prisma.player.count({
-            where: { eventId, archivedAt: null, order: { gte: event.maxPlayers } },
-          });
-          await prisma.player.update({
-            where: { id: occupant.id },
-            data: { order: event.maxPlayers + benchSize },
-          });
-        }
+        const newOrder = (maxOrder._max.order ?? -1) + 1;
         const reactivatedUserId = resolvedUser?.id ?? existing.userId;
         await prisma.player.update({
           where: { id: existing.id },
           data: {
             archivedAt: null,
-            order: restoredOrder,
+            order: newOrder,
             ...(resolvedUser && !existing.userId ? { userId: resolvedUser.id } : {}),
           },
         });

--- a/src/test/api.test.ts
+++ b/src/test/api.test.ts
@@ -294,7 +294,7 @@ describe("POST /api/events/[id]/players", () => {
     expect(res.status).toBe(409);
   });
 
-  it("re-adding a soft-archived player un-archives them and restores their order", async () => {
+  it("re-adding a soft-archived player un-archives them and places them at the end of the list", async () => {
     const id = await seedEvent();
     // Add three players: Alice (order 0), Bob (order 1), Charlie (order 2)
     await prisma.player.createMany({
@@ -317,16 +317,16 @@ describe("POST /api/events/[id]/players", () => {
     expect(body.reactivated).toBe(true);
     expect(body.resolvedName).toBe("Bob");
 
-    // Bob is back at order 1 (his original slot).
+    // Bob is at the END of the list (queue mental model — joining = enqueue).
     const players = await prisma.player.findMany({
-      where: { eventId: id },
+      where: { eventId: id, archivedAt: null },
       orderBy: { order: "asc" },
     });
-    expect(players.map((p) => p.name)).toEqual(["Alice", "Bob", "Charlie"]);
+    expect(players.map((p) => p.name)).toEqual(["Alice", "Charlie", "Bob"]);
     expect(players.find((p) => p.name === "Bob")?.archivedAt).toBeNull();
   });
 
-  it("re-adding a player bumps the new occupant of the slot to the bench", async () => {
+  it("re-adding a player does not bump the current occupant of the original slot", async () => {
     const id = await seedEvent(); // maxPlayers: 5
     // Alice is at order 0. She leaves (gets archived).
     const alice = await prisma.player.create({
@@ -340,19 +340,18 @@ describe("POST /api/events/[id]/players", () => {
     // Dave takes her slot (order 0).
     await prisma.player.create({ data: { name: "Dave", eventId: id, order: 0 } });
 
-    // Alice re-joins. Dave should be bumped.
+    // Alice re-joins. She goes to the end; Dave stays at order 0.
     const res = await addPlayer(ctx({ id }, { name: "Alice" }));
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.reactivated).toBe(true);
 
-    // Alice is back at order 0. Dave is on the bench.
     const players = await prisma.player.findMany({
       where: { eventId: id, archivedAt: null },
       orderBy: { order: "asc" },
     });
-    expect(players.find((p) => p.name === "Alice")?.order).toBe(0);
-    expect(players.find((p) => p.name === "Dave")?.order).toBeGreaterThanOrEqual(5);
+    expect(players.find((p) => p.name === "Dave")?.order).toBe(0);
+    expect(players.find((p) => p.name === "Alice")?.order).toBe(1);
   });
 });
 


### PR DESCRIPTION
The un-archive branch in `POST /api/events/[id]/players` previously restored the archived Player's original `order`. After leaving and re-joining, the player kept their old slot (e.g. order 0 = top of the list), which violated the 'new joiners go to the end' invariant.

Fix: un-archive sets `order = max(active orders) + 1`. A re-add now behaves like a fresh join — the player loses their prior slot and joins the back of the queue.

Tests: 2 cases in `src/test/api.test.ts` updated to expect end-of-list placement and no slot bump. Full suite 2698/2698 green. Lint clean. Typecheck clean.

CONTEXT.md Leave/Re-join section updated.