### PR TITLE
feat(rsvp): add 'maybe' status, user pill on player list, RSVP answer notifications

### DIFF
--- a/src/components/EventPage.tsx
+++ b/src/components/EventPage.tsx
@@ -15,6 +15,7 @@ import { detectLocale } from "~/lib/i18n";
 import { addKnownName, getQjName } from "~/lib/knownNames";
 import { formatDateInTz, fromDateTimeLocalValue } from "~/lib/timezones";
 import { useSession } from "~/lib/auth.client";
+import type { RsvpStatus } from "~/lib/rsvp";
 
 import {
   EventHeader,
@@ -551,7 +552,7 @@ export default function EventPage({ eventId }: { eventId: string }) {
   // #463 high-intent: fetch the signed-in user's RSVP for this event so the
   // PushPromptBanner can render as a modal when the user has a pending RSVP
   // and the game kicks off within 48h.
-  const [myRsvpStatus, setMyRsvpStatus] = useState<"yes" | "no" | null>(null);
+  const [myRsvpStatus, setMyRsvpStatus] = useState<"yes" | "no" | "maybe" | null>(null);
   useEffect(() => {
     if (!isAuthenticated || !eventId) {
       setMyRsvpStatus(null);
@@ -563,14 +564,14 @@ export default function EventPage({ eventId }: { eventId: string }) {
         if (!alive) return;
         if (!r.ok) { setMyRsvpStatus(null); return; }
         const data = await r.json();
-        setMyRsvpStatus((data.status ?? null) as "yes" | "no" | null);
+        setMyRsvpStatus((data.status ?? null) as "yes" | "no" | "maybe" | null);
       })
       .catch(() => alive && setMyRsvpStatus(null));
     return () => { alive = false; };
   }, [eventId, isAuthenticated]);
 
   // #XXX Guest attendance — fetched for the player-list pills (visible to all, clickable to owner/admin).
-  const [guestRsvpMap, setGuestRsvpMap] = useState<Record<string, "yes" | "no" | null>>({});
+  const [guestRsvpMap, setGuestRsvpMap] = useState<Record<string, "yes" | "no" | "maybe" | null>>({});
   const fetchGuestRsvpMap = useCallback(async () => {
     try {
       const r = await fetch(`/api/events/${eventId}/rsvp/guests`, { credentials: "include" });
@@ -580,6 +581,21 @@ export default function EventPage({ eventId }: { eventId: string }) {
     } catch { /* ignore */ }
   }, [eventId]);
   useEffect(() => { fetchGuestRsvpMap(); }, [fetchGuestRsvpMap]);
+
+  // #XXX User attendance — fetched for the player-list pills on linked-user rows.
+  // The server returns an empty map for anonymous viewers (one-way privacy), so this
+  // is also implicitly the visibility gate: the PlayerList only renders the pill
+  // when the current viewer is logged in.
+  const [userRsvpMap, setUserRsvpMap] = useState<Record<string, "yes" | "no" | "maybe" | null>>({});
+  const fetchUserRsvpMap = useCallback(async () => {
+    try {
+      const r = await fetch(`/api/events/${eventId}/rsvp/users`, { credentials: "include" });
+      if (!r.ok) return;
+      const data = await r.json();
+      setUserRsvpMap(data.users ?? {});
+    } catch { /* ignore */ }
+  }, [eventId]);
+  useEffect(() => { fetchUserRsvpMap(); }, [fetchUserRsvpMap]);
 
   const handleSetMyRsvp = useCallback(async (status: "yes" | "no") => {
     const prev = myRsvpStatus;
@@ -611,7 +627,7 @@ export default function EventPage({ eventId }: { eventId: string }) {
     }
   }, [eventId, myRsvpStatus, t, fetchEvent]);
 
-  const handleSetGuestRsvp = useCallback(async (playerId: string, status: "yes" | "no" | null) => {
+  const handleSetGuestRsvp = useCallback(async (playerId: string, status: RsvpStatus) => {
     const prev = guestRsvpMap[playerId] ?? null;
     setGuestRsvpMap((m) => ({ ...m, [playerId]: status })); // optimistic
     try {
@@ -820,6 +836,7 @@ export default function EventPage({ eventId }: { eventId: string }) {
               currentUserId={isAuthenticated ? session?.user?.id : null}
               myRsvpStatus={myRsvpStatus}
               guestRsvpMap={guestRsvpMap}
+              userRsvpMap={userRsvpMap}
               canEditGuestAttendance={isOwner || isAdmin}
               onSetMyRsvp={handleSetMyRsvp}
               onSetGuestRsvp={handleSetGuestRsvp}

--- a/src/components/event/AttendanceCta.tsx
+++ b/src/components/event/AttendanceCta.tsx
@@ -5,8 +5,9 @@ import {
 import HowToRegIcon from "@mui/icons-material/HowToReg";
 import RemoveCircleOutlineIcon from "@mui/icons-material/RemoveCircleOutline";
 import { useT } from "~/lib/useT";
+import type { RsvpStatus } from "~/lib/rsvp";
 
-export type RsvpStatus = "yes" | "no" | null;
+export type { RsvpStatus } from "~/lib/rsvp";
 
 interface Props {
   /** Current Rsvp status for the user (yes / no / pending). */

--- a/src/components/event/PlayerList.tsx
+++ b/src/components/event/PlayerList.tsx
@@ -23,8 +23,9 @@ import type { Player, PlayerOption } from "./types";
 import type { AddPlayerIntent } from "./AddPlayerConfirmDialog";
 import { ConfirmLeaveDialog, type LeaveContext } from "./ConfirmLeaveDialog";
 import { AttendanceCta } from "./AttendanceCta";
+import type { RsvpStatus } from "~/lib/rsvp";
 
-export type RsvpStatus = "yes" | "no" | null;
+export type { RsvpStatus } from "~/lib/rsvp";
 
 /** Pure helpers — extracted out of the component body so Date.now() inside doesn't trip the
  *  eslint react-hooks/purity rule. They run in event handlers, never during render. */
@@ -78,6 +79,10 @@ interface Props {
   myRsvpStatus?: RsvpStatus;
   /** Map of guest-playerId → RSVP status. When provided, every guest row renders an inline pill. */
   guestRsvpMap?: Record<string, RsvpStatus>;
+  /** Map of linked-userId → RSVP status. Only rendered when the viewer is logged in
+   *  (one-way privacy — anonymous viewers never see logged-user RSVPs). The viewer's
+   *  own row is intentionally skipped because the AttendanceCta carries that answer. */
+  userRsvpMap?: Record<string, RsvpStatus>;
   /** True for the owner or an admin. Controls whether the guest pill is clickable. */
   canEditGuestAttendance?: boolean;
   /** Set the current user's own RSVP. */
@@ -100,6 +105,7 @@ export function PlayerList({
   currentUserId,
   myRsvpStatus,
   guestRsvpMap,
+  userRsvpMap,
   canEditGuestAttendance,
   onSetMyRsvp,
   onSetGuestRsvp,
@@ -560,6 +566,12 @@ export function PlayerList({
                             : undefined}
                         />
                       )}
+                      {/* #XXX User attendance pill — read-only status for a linked user. Visible
+                          only to logged viewers (one-way privacy); the viewer's own row is
+                          skipped so the AttendanceCta at the top carries their answer. */}
+                      {player.userId !== null && player.userId !== undefined && currentUserId && player.userId !== currentUserId && userRsvpMap && userRsvpMap[player.userId] !== undefined && (
+                        <UserRsvpPill userId={player.userId} status={userRsvpMap[player.userId] ?? null} />
+                      )}
                       {canRemovePlayer(player) ? (
                         <IconButton edge="end" size="small" data-testid={`remove-player-${player.id}`} onClick={() => openLeaveDialog(player.id, "organizer")}>
                           <CloseIcon fontSize="small" />
@@ -787,5 +799,39 @@ function GuestAttendancePill({
         )}
       </Menu>
     </>
+  );
+}
+
+/**
+ * #XXX User attendance pill — read-only status badge on a linked-user row.
+ * Visible only to logged viewers (the server-side `getUserRsvpMap` enforces this).
+ * No menu: the user can only RSVP for themselves, via the AttendanceCta at the top
+ * of the list. Their own row is skipped by the parent so we don't render two pills.
+ */
+function UserRsvpPill({ userId, status }: { userId: string; status: RsvpStatus }) {
+  const t = useT();
+  return (
+    <Chip
+      size="small"
+      data-testid={`rsvp-user-pill-${userId}`}
+      data-status={status ?? "none"}
+      icon={status === "yes"
+        ? <HowToRegIcon />
+        : status === "maybe"
+          ? <HelpOutlineIcon />
+          : status === "no"
+            ? <CancelIcon />
+            : <HelpOutlineIcon />}
+      label={status === "yes"
+        ? t("rsvpGoing")
+        : status === "maybe"
+          ? t("rsvpMaybe")
+          : status === "no"
+            ? t("rsvpDeclined")
+            : t("rsvpNoResponse")}
+      color={status === "yes" ? "success" : status === "no" ? "error" : status === "maybe" ? "warning" : "default"}
+      variant="outlined"
+      sx={{ pointerEvents: "none" }}
+    />
   );
 }

--- a/src/lib/eventLog.server.ts
+++ b/src/lib/eventLog.server.ts
@@ -38,7 +38,8 @@ export type EventAction =
   | "override_set"
   | "override_cleared"
   | "rsvp_yes"
-  | "rsvp_no";
+  | "rsvp_no"
+  | "rsvp_maybe";
 
 /**
  * Append an entry to the event activity log.

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -579,6 +579,7 @@ const de: TranslationKeys = {
   rsvpYouRow: "Du",
   rsvpGoing: "Dabei",
   rsvpDeclined: "Abgesagt",
+  rsvpMaybe: "Vielleicht",
   rsvpNoResponse: "Keine Antwort",
   rsvpPending: "ausstehend",
   rsvpSetGoing: "Als anwesend markieren",
@@ -609,6 +610,10 @@ const de: TranslationKeys = {
   pushBlockedHint: "Benachrichtigungen sind blockiert. Aktiviere sie in den Browser-Einstellungen, um Spielerinnerungen zu erhalten.",
   pushPromptHighIntentBody: "Du hast eine offene RSVP. Aktiviere Benachrichtigungen, damit wir dich vor dem Anpfiff informieren, falls sich etwas ändert.",
   pushPromptTitle: "Auf dem Laufenden bleiben?",
+  notifyRsvpAnswerYes: "{name} hat für {title} zugesagt",
+  notifyRsvpAnswerNo: "{name} hat {title} abgesagt",
+  notifyRsvpAnswerMaybe: "{name} ist sich bei {title} unsicher",
+  notifyRsvpAnswerAnon: "Jemand hat auf {title} geantwortet",
 
   // Priority enrollment (#136)
   priorityEnrollment: "Prioritätsanmeldung",

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -629,6 +629,7 @@ const en = {
   rsvpYouRow: "You",
   rsvpGoing: "Going",
   rsvpDeclined: "Declined",
+  rsvpMaybe: "Maybe",
   rsvpNoResponse: "No response",
   rsvpPending: "pending",
   rsvpSetGoing: "Mark as going",
@@ -659,6 +660,11 @@ const en = {
   pushBlockedHint: "Notifications are blocked. Enable them in your browser settings to receive game reminders.",
   pushPromptHighIntentBody: "You have a pending RSVP. Enable notifications so we can ping you before kickoff if anything changes.",
   pushPromptTitle: "Stay in the loop?",
+  // #457 RSVP answer notifications (rich payload when actor is logged; generic when anon)
+  notifyRsvpAnswerYes: "{name} confirmed they're coming to {title}",
+  notifyRsvpAnswerNo: "{name} declined {title}",
+  notifyRsvpAnswerMaybe: "{name} is unsure about {title}",
+  notifyRsvpAnswerAnon: "Someone answered {title}",
 
   // Priority enrollment (#136)
   priorityEnrollment: "Priority Enrollment",

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -579,6 +579,7 @@ const es: TranslationKeys = {
   rsvpYouRow: "Tú",
   rsvpGoing: "Voy",
   rsvpDeclined: "No voy",
+  rsvpMaybe: "Quizá",
   rsvpNoResponse: "Sin respuesta",
   rsvpPending: "sin respuesta",
   rsvpSetGoing: "Marcar como asistente",
@@ -609,6 +610,10 @@ const es: TranslationKeys = {
   pushBlockedHint: "Las notificaciones están bloqueadas. Actívalas en los ajustes del navegador para recibir recordatorios de partidos.",
   pushPromptHighIntentBody: "Tienes un RSVP pendiente. Activa las notificaciones para que te avisemos antes del partido si algo cambia.",
   pushPromptTitle: "¿Quieres estar al tanto?",
+  notifyRsvpAnswerYes: "{name} confirmó que viene a {title}",
+  notifyRsvpAnswerNo: "{name} rechazó {title}",
+  notifyRsvpAnswerMaybe: "{name} no está seguro de {title}",
+  notifyRsvpAnswerAnon: "Alguien respondió a {title}",
 
   // Priority enrollment (#136)
   priorityEnrollment: "Inscripción Prioritaria",

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -579,6 +579,7 @@ const fr: TranslationKeys = {
   rsvpYouRow: "Toi",
   rsvpGoing: "Présent",
   rsvpDeclined: "Absent",
+  rsvpMaybe: "Peut-être",
   rsvpNoResponse: "Sans réponse",
   rsvpPending: "sans réponse",
   rsvpSetGoing: "Marquer présent",
@@ -609,6 +610,10 @@ const fr: TranslationKeys = {
   pushBlockedHint: "Les notifications sont bloquées. Active-les dans les paramètres du navigateur pour recevoir les rappels de match.",
   pushPromptHighIntentBody: "Tu as un RSVP en attente. Active les notifications pour qu'on te prévienne avant le coup d'envoi si quelque chose change.",
   pushPromptTitle: "Rester au courant ?",
+  notifyRsvpAnswerYes: "{name} a confirmé sa venue à {title}",
+  notifyRsvpAnswerNo: "{name} a décliné {title}",
+  notifyRsvpAnswerMaybe: "{name} n'est pas sûr pour {title}",
+  notifyRsvpAnswerAnon: "Quelqu'un a répondu à {title}",
 
   // Priority enrollment (#136)
   priorityEnrollment: "Inscription Prioritaire",

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -579,6 +579,7 @@ const it: TranslationKeys = {
   rsvpYouRow: "Tu",
   rsvpGoing: "Presente",
   rsvpDeclined: "Assente",
+  rsvpMaybe: "Forse",
   rsvpNoResponse: "Nessuna risposta",
   rsvpPending: "senza risposta",
   rsvpSetGoing: "Segna come presente",
@@ -609,6 +610,10 @@ const it: TranslationKeys = {
   pushBlockedHint: "Le notifiche sono bloccate. Attivale nelle impostazioni del browser per ricevere i promemoria delle partite.",
   pushPromptHighIntentBody: "Hai un RSVP in sospeso. Attiva le notifiche così ti avvisiamo prima del fischio d'inizio se qualcosa cambia.",
   pushPromptTitle: "Vuoi restare aggiornato?",
+  notifyRsvpAnswerYes: "{name} ha confermato che viene a {title}",
+  notifyRsvpAnswerNo: "{name} ha rifiutato {title}",
+  notifyRsvpAnswerMaybe: "{name} non è sicuro per {title}",
+  notifyRsvpAnswerAnon: "Qualcuno ha risposto a {title}",
 
   // Priority enrollment (#136)
   priorityEnrollment: "Iscrizione Prioritaria",

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -628,6 +628,7 @@ const pt: TranslationKeys = {
   rsvpYouRow: "Tu",
   rsvpGoing: "Vou",
   rsvpDeclined: "Não vou",
+  rsvpMaybe: "Talvez",
   rsvpNoResponse: "Sem resposta",
   rsvpPending: "sem resposta",
   rsvpSetGoing: "Marcar como presente",
@@ -658,6 +659,10 @@ const pt: TranslationKeys = {
   pushBlockedHint: "As notificações estão bloqueadas. Ativa-as nas definições do navegador para receberes lembretes de jogos.",
   pushPromptHighIntentBody: "Tens um RSVP pendente. Ativa as notificações para te avisarmos antes do jogo se algo mudar.",
   pushPromptTitle: "Ficas a par de tudo?",
+  notifyRsvpAnswerYes: "{name} confirmou que vai a {title}",
+  notifyRsvpAnswerNo: "{name} não vai a {title}",
+  notifyRsvpAnswerMaybe: "{name} ainda não tem a certeza sobre {title}",
+  notifyRsvpAnswerAnon: "Alguém respondeu a {title}",
 
   // Priority enrollment (#136)
   priorityEnrollment: "Inscrição Prioritária",

--- a/src/lib/rsvp-notifications.server.ts
+++ b/src/lib/rsvp-notifications.server.ts
@@ -1,0 +1,91 @@
+/** #457 RSVP answer notifications. */
+
+import { prisma } from "./db.server";
+import { createLogger } from "./logger.server";
+import type { TranslationKey } from "./i18n";
+import type { RsvpStatusValue } from "./rsvp";
+
+const log = createLogger("rsvp-notifications");
+
+/**
+ * Enqueue a notification announcing an RSVP answer.
+ *
+ * - For a logged actor (self-RSVP via the user endpoint) the payload carries the
+ *   actor's name and a per-status i18n key like `notifyRsvpAnswerYes`.
+ * - For an anonymous actor (an admin setting a guest RSVP) the payload uses a
+ *   generic key `notifyRsvpAnswerAnon` so we don't expose the guest's identity.
+ *
+ * Dedup: a single unprocessed `rsvp_request` job per (eventId, actorKey) is
+ * kept. Subsequent calls for the same actor update the existing job's payload
+ * in place (latest-wins). Processed or failed jobs are not touched — once
+ * delivered, a new change is a new event.
+ */
+export async function enqueueRsvpAnswerNotification(params: {
+  eventId: string;
+  eventTitle: string;
+  status: RsvpStatusValue;
+  actorUserId?: string | null;
+  actorPlayerId?: string | null;
+  actorName?: string | null;
+  actorIsLogged: boolean;
+  /** userId of the actor when the actor is anonymous (admin acting on a guest's behalf).
+   *  This is used to suppress the notification being echoed back to the admin.
+   *  For a logged actor (self-RSVP), defaults to actorUserId so we never echo back. */
+  senderClientId?: string | null;
+}): Promise<void> {
+  const { eventId, eventTitle, status, actorUserId, actorPlayerId, actorName, actorIsLogged, senderClientId: explicitSender } = params;
+  const senderClientId = explicitSender ?? (actorIsLogged ? actorUserId ?? null : null);
+
+  const actorKey = actorUserId
+    ? `user:${actorUserId}`
+    : actorPlayerId
+      ? `player:${actorPlayerId}`
+      : null;
+  if (!actorKey) {
+    log.warn({ eventId, status }, "enqueueRsvpAnswerNotification called without actor key");
+    return;
+  }
+
+  const paramsRecord: Record<string, string> = { title: eventTitle };
+  let key: TranslationKey;
+  if (actorIsLogged && actorName) {
+    paramsRecord.name = actorName;
+    if (status === "yes") key = "notifyRsvpAnswerYes";
+    else if (status === "no") key = "notifyRsvpAnswerNo";
+    else key = "notifyRsvpAnswerMaybe";
+  } else {
+    key = "notifyRsvpAnswerAnon";
+  }
+
+  const payload = JSON.stringify({ title: eventTitle, key, params: paramsRecord, url: `/events/${eventId}`, spotsLeft: 0 });
+
+  const existing = await prisma.notificationJob.findFirst({
+    where: {
+      eventId,
+      type: "rsvp_request",
+      processedAt: null,
+      failedAt: null,
+      payload: { contains: `"actorKey":"${actorKey}"` },
+    },
+    select: { id: true },
+  });
+
+  if (existing) {
+    await prisma.notificationJob.update({
+      where: { id: existing.id },
+      data: { payload, senderClientId: senderClientId ?? null },
+    });
+    return;
+  }
+
+  await prisma.notificationJob.create({
+    data: {
+      eventId,
+      type: "rsvp_request",
+      payload: JSON.stringify({ title: eventTitle, key, params: paramsRecord, url: `/events/${eventId}`, spotsLeft: 0, actorKey }),
+      senderClientId: senderClientId ?? null,
+    },
+  }).catch((err: unknown) => {
+    log.error({ eventId, err }, "Failed to enqueue rsvp_request notification");
+  });
+}

--- a/src/lib/rsvp.server.ts
+++ b/src/lib/rsvp.server.ts
@@ -2,6 +2,7 @@
 
 import { prisma } from "./db.server";
 import { createLogger } from "./logger.server";
+import type { RsvpStatus, RsvpStatusValue } from "./rsvp";
 
 const log = createLogger("rsvp");
 
@@ -33,8 +34,8 @@ export type PushPromptState = "default" | "granted" | "dismissed" | "denied";
 
 // ─── RSVP upsert + read ────────────────────────────────────────────────────
 
-/** Idempotent RSVP upsert for a linked user. status ∈ {"yes", "no"} — null is "pending" and represented as a missing row. */
-export async function upsertRsvp(eventId: string, userId: string, status: "yes" | "no") {
+/** Idempotent RSVP upsert for a linked user. status ∈ {"yes", "no", "maybe"} — null is "pending" and represented as a missing row. */
+export async function upsertRsvp(eventId: string, userId: string, status: RsvpStatusValue) {
   return prisma.rsvp.upsert({
     where: { userId_eventId: { userId, eventId } },
     create: { eventId, userId, status, respondedAt: new Date() },
@@ -52,7 +53,7 @@ export async function getRsvpForUser(eventId: string, userId: string) {
 export async function upsertGuestRsvp(
   eventId: string,
   playerId: string,
-  status: "yes" | "no" | null,
+  status: RsvpStatus,
   actorUserId: string,
 ) {
   const player = await prisma.player.findUnique({
@@ -78,7 +79,7 @@ export async function getRsvpForGuest(eventId: string, playerId: string) {
 }
 
 /** Map of playerId → status for all active (non-archived) guest Players in the event. Public — used to render the read-only pill on the player list for everyone (incl. anonymous viewers). */
-export async function getGuestRsvpMap(eventId: string): Promise<Record<string, "yes" | "no" | null>> {
+export async function getGuestRsvpMap(eventId: string): Promise<Record<string, RsvpStatus>> {
   const guests = await prisma.player.findMany({
     where: { eventId, userId: null, archivedAt: null },
     select: { id: true },
@@ -87,10 +88,30 @@ export async function getGuestRsvpMap(eventId: string): Promise<Record<string, "
     where: { eventId, playerId: { in: guests.map((g) => g.id) } },
     select: { playerId: true, status: true },
   });
-  const map: Record<string, "yes" | "no" | null> = {};
+  const map: Record<string, RsvpStatus> = {};
   for (const g of guests) map[g.id] = null;
   for (const r of rsvps) {
-    if (r.playerId) map[r.playerId] = (r.status as "yes" | "no" | null) ?? null;
+    if (r.playerId) map[r.playerId] = (r.status as RsvpStatus) ?? null;
+  }
+  return map;
+}
+
+/**
+ * Map of userId → RSVP status for every linked User who has an RSVP row on this event
+ * (owner, followers, linked players). When `viewerIsLogged` is false (anonymous viewer)
+ * the function returns an empty map to enforce one-way privacy — anonymous viewers
+ * must not see logged users' answers. The caller is responsible for passing the
+ * viewer's auth state; the server-side guard is here, not just the UI.
+ */
+export async function getUserRsvpMap(eventId: string, viewerIsLogged: boolean): Promise<Record<string, RsvpStatus>> {
+  if (!viewerIsLogged) return {};
+  const rsvps = await prisma.rsvp.findMany({
+    where: { eventId, userId: { not: null } },
+    select: { userId: true, status: true },
+  });
+  const map: Record<string, RsvpStatus> = {};
+  for (const r of rsvps) {
+    if (r.userId) map[r.userId] = (r.status as RsvpStatus) ?? null;
   }
   return map;
 }
@@ -146,10 +167,10 @@ export async function getRsvpSummary(eventId: string): Promise<RsvpSummary> {
     select: { userId: true, playerId: true, status: true },
   });
 
-  const respondedUser = new Map<string, "yes" | "no">();
-  const respondedGuest = new Map<string, "yes" | "no">();
+  const respondedUser = new Map<string, RsvpStatusValue>();
+  const respondedGuest = new Map<string, RsvpStatusValue>();
   for (const r of rsvps) {
-    if (r.status !== "yes" && r.status !== "no") continue;
+    if (r.status !== "yes" && r.status !== "no" && r.status !== "maybe") continue;
     if (r.userId) respondedUser.set(r.userId, r.status);
     else if (r.playerId) respondedGuest.set(r.playerId, r.status);
   }

--- a/src/lib/rsvp.ts
+++ b/src/lib/rsvp.ts
@@ -1,0 +1,8 @@
+export type RsvpStatusValue = "yes" | "no" | "maybe";
+export type RsvpStatus = RsvpStatusValue | null;
+
+export const RSVP_STATUS_VALUES: readonly RsvpStatusValue[] = ["yes", "no", "maybe"] as const;
+
+export function isRsvpStatusValue(v: unknown): v is RsvpStatusValue {
+  return v === "yes" || v === "no" || v === "maybe";
+}

--- a/src/pages/api/events/[id]/players/[playerId]/rsvp.ts
+++ b/src/pages/api/events/[id]/players/[playerId]/rsvp.ts
@@ -3,9 +3,11 @@ import { prisma } from "~/lib/db.server";
 import { getSession, checkOwnership } from "~/lib/auth.helpers.server";
 import { rateLimitResponse } from "~/lib/apiRateLimit.server";
 import { upsertGuestRsvp } from "~/lib/rsvp.server";
+import { isRsvpStatusValue, type RsvpStatus } from "~/lib/rsvp";
+import { enqueueRsvpAnswerNotification } from "~/lib/rsvp-notifications.server";
 import { archiveAndLeave } from "~/lib/leave.server";
 
-/** POST /api/events/[id]/players/[playerId]/rsvp — owner/admin only. Body { status: "yes" | "no" | null }.
+/** POST /api/events/[id]/players/[playerId]/rsvp — owner/admin only. Body { status: "yes" | "no" | "maybe" | null }.
  *  status="no" on a guest Player also archives the player (the "leave on behalf" flow).
  *  status="yes" or status=null is a no-op on the roster. */
 export const POST: APIRoute = async ({ params, request }) => {
@@ -46,16 +48,32 @@ export const POST: APIRoute = async ({ params, request }) => {
 
   let body: { status?: unknown } = {};
   try { body = await request.json(); } catch { /* fall through */ }
-  const status = body.status;
-  if (status !== "yes" && status !== "no" && status !== null) {
-    return Response.json({ error: "status must be 'yes', 'no', or null." }, { status: 400 });
+  const rawStatus = body.status;
+  if (rawStatus !== null && !isRsvpStatusValue(rawStatus)) {
+    return Response.json({ error: "status must be 'yes', 'no', 'maybe', or null." }, { status: 400 });
   }
+  const status: RsvpStatus = rawStatus === null ? null : rawStatus;
 
   try {
     // 1. Write the Rsvp row (keyed on playerId, with respondedByUserId audit).
     const rsvp = await upsertGuestRsvp(eventId, playerId, status, session.user.id);
 
-    // 2. status="no" → also archive the player (admin declines on behalf of the guest).
+    // 2. Notify all invited players of the guest's answer. Anon text — guest is anonymous
+    // from the group's perspective, so we don't expose their name. null status (clearing)
+    // is not announced.
+    if (status !== null) {
+      enqueueRsvpAnswerNotification({
+        eventId,
+        eventTitle: event.title,
+        status,
+        actorPlayerId: playerId,
+        actorName: null,
+        actorIsLogged: false,
+        senderClientId: session.user.id,
+      }).catch(() => {});
+    }
+
+    // 3. status="no" → also archive the player (admin declines on behalf of the guest).
     let warned = false;
     if (status === "no") {
       const host = request.headers.get("x-forwarded-host") ?? request.headers.get("host") ?? "convocados.cabeda.dev";

--- a/src/pages/api/events/[id]/rsvp.ts
+++ b/src/pages/api/events/[id]/rsvp.ts
@@ -4,10 +4,12 @@ import { prisma } from "~/lib/db.server";
 import { getSession } from "~/lib/auth.helpers.server";
 import { rateLimitResponse } from "~/lib/apiRateLimit.server";
 import { upsertRsvp, getRsvpForUser } from "~/lib/rsvp.server";
+import { isRsvpStatusValue } from "~/lib/rsvp";
+import { enqueueRsvpAnswerNotification } from "~/lib/rsvp-notifications.server";
 import { logEvent } from "~/lib/eventLog.server";
 import { IDEMPOTENCY_HEADER, getCachedResponse, makeCacheKey, hasConflictingEntry, storeCachedResponse } from "~/lib/idempotency";
 
-/** POST /api/events/[id]/rsvp — body { status: "yes" | "no" }. Idempotent. */
+/** POST /api/events/[id]/rsvp — body { status: "yes" | "no" | "maybe" }. Idempotent. */
 export const POST: APIRoute = async ({ params, request }) => {
   const limited = await rateLimitResponse(request, "write");
   if (limited) return limited;
@@ -32,12 +34,12 @@ export const POST: APIRoute = async ({ params, request }) => {
   const idemCacheKey = idemKey ? makeCacheKey(idemKey, idemPath, session.user.id) : null;
   let body: { status?: string } = {};
   try { body = await request.json(); } catch { /* fall through */ }
-  if (body.status !== "yes" && body.status !== "no") {
-    return Response.json({ error: "status must be 'yes' or 'no'." }, { status: 400 });
+  if (!isRsvpStatusValue(body.status)) {
+    return Response.json({ error: "status must be 'yes', 'no', or 'maybe'." }, { status: 400 });
   }
 
   if (idemKey && idemCacheKey) {
-    // RSVP body is { status: "yes"|"no" } — hash raw body, not the add-player canonicalizer.
+    // RSVP body is { status: "yes"|"no"|"maybe" } — hash raw body, not the add-player canonicalizer.
     const bodyHash = createHash("sha256").update(JSON.stringify({ status: body.status })).digest("hex");
     const cached = getCachedResponse(idemCacheKey, bodyHash);
     if (cached) {
@@ -53,9 +55,18 @@ export const POST: APIRoute = async ({ params, request }) => {
 
   const rsvp = await upsertRsvp(eventId, session.user.id, body.status);
 
+  enqueueRsvpAnswerNotification({
+    eventId,
+    eventTitle: event.title,
+    status: body.status,
+    actorUserId: session.user.id,
+    actorName: session.user.name,
+    actorIsLogged: true,
+  }).catch(() => {});
+
   logEvent(
     eventId,
-    body.status === "yes" ? "rsvp_yes" : "rsvp_no",
+    body.status === "yes" ? "rsvp_yes" : body.status === "no" ? "rsvp_no" : "rsvp_maybe",
     session.user.name,
     session.user.id,
     { eventTitle: event.title, status: body.status },

--- a/src/pages/api/events/[id]/rsvp/users.ts
+++ b/src/pages/api/events/[id]/rsvp/users.ts
@@ -1,0 +1,25 @@
+import type { APIRoute } from "astro";
+import { rateLimitResponse } from "~/lib/apiRateLimit.server";
+import { getUserRsvpMap } from "~/lib/rsvp.server";
+import { getSession } from "~/lib/auth.helpers.server";
+import { prisma } from "~/lib/db.server";
+
+/** GET /api/events/[id]/rsvp/users — logged viewers only. Returns the RSVP status of every
+ *  linked User in the event (owner + followers + linked players). Anonymous viewers get an
+ *  empty map — one-way privacy: logged-user RSVPs are never exposed to anon viewers. */
+export const GET: APIRoute = async ({ params, request }) => {
+  const limited = await rateLimitResponse(request, "read");
+  if (limited) return limited;
+
+  const eventId = params.id ?? "";
+  const event = await prisma.event.findUnique({
+    where: { id: eventId },
+    select: { id: true },
+  });
+  if (!event) return Response.json({ error: "Not found." }, { status: 404 });
+
+  const session = await getSession(request);
+  const viewerIsLogged = !!session?.user;
+  const users = await getUserRsvpMap(eventId, viewerIsLogged);
+  return Response.json({ users });
+};

--- a/src/test/components/PlayerList.test.tsx
+++ b/src/test/components/PlayerList.test.tsx
@@ -339,6 +339,83 @@ describe("PlayerList — attendance UI (You row + guest pill)", () => {
     expect(screen.getByTestId(`rsvp-guest-pill-${guestPlayer.id}`)).toBeInTheDocument();
   });
 
+  it("renders a user pill on linked-user rows for a logged viewer, read-only", () => {
+    renderWithTheme(
+      <PlayerList
+        {...attendanceBase}
+        currentUserId="u-viewer"
+        myRsvpStatus={null}
+        guestRsvpMap={{}}
+        userRsvpMap={{ "u-1": "yes" }}
+      />,
+    );
+    const pill = screen.getByTestId("rsvp-user-pill-u-1");
+    expect(pill).toBeInTheDocument();
+    expect(pill).toHaveAttribute("data-status", "yes");
+    // Read-only — no menu trigger
+    expect(pill).not.toHaveAttribute("role", "button");
+  });
+
+  it("does NOT render a user pill for anonymous viewers (one-way privacy)", () => {
+    renderWithTheme(
+      <PlayerList
+        {...attendanceBase}
+        currentUserId={null}
+        myRsvpStatus={null}
+        guestRsvpMap={{}}
+        userRsvpMap={{ "u-1": "yes" }}
+      />,
+    );
+    expect(screen.queryByTestId("rsvp-user-pill-u-1")).toBeNull();
+  });
+
+  it("does NOT render a user pill for the current user themselves (they use AttendanceCta)", () => {
+    renderWithTheme(
+      <PlayerList
+        {...attendanceBase}
+        currentUserId="u-1"
+        myRsvpStatus="yes"
+        guestRsvpMap={{}}
+        userRsvpMap={{ "u-1": "yes" }}
+      />,
+    );
+    // The AttendanceCta at the top carries the user's own answer — no row pill.
+    expect(screen.queryByTestId("rsvp-user-pill-u-1")).toBeNull();
+    expect(screen.getByTestId("attendance-cta")).toBeInTheDocument();
+  });
+
+  it("renders a user pill for another linked user (not the current viewer)", () => {
+    const other: Player = { id: "p-other", name: "OtherCarol", userId: "u-other" };
+    renderWithTheme(
+      <PlayerList
+        {...attendanceBase}
+        players={[linkedPlayer, guestPlayer, other]}
+        currentUserId="u-1"
+        myRsvpStatus="yes"
+        guestRsvpMap={{}}
+        userRsvpMap={{ "u-1": "yes", "u-other": "maybe" }}
+      />,
+    );
+    const pill = screen.getByTestId("rsvp-user-pill-u-other");
+    expect(pill).toBeInTheDocument();
+    expect(pill).toHaveAttribute("data-status", "maybe");
+  });
+
+  it("does NOT render a user pill on guest (userId null) rows", () => {
+    renderWithTheme(
+      <PlayerList
+        {...attendanceBase}
+        currentUserId="u-1"
+        myRsvpStatus={null}
+        guestRsvpMap={{ [guestPlayer.id]: "yes" }}
+        userRsvpMap={{}}
+      />,
+    );
+    // Guest row gets the guest pill, not a user pill.
+    expect(screen.queryByTestId("rsvp-user-pill-null")).toBeNull();
+    expect(screen.getByTestId(`rsvp-guest-pill-${guestPlayer.id}`)).toBeInTheDocument();
+  });
+
   it("renders the guest pill as a non-interactive Chip when canEditGuestAttendance is false (anon viewer)", () => {
     renderWithTheme(
       <PlayerList

--- a/src/test/rsvp-api.test.ts
+++ b/src/test/rsvp-api.test.ts
@@ -80,10 +80,21 @@ describe("POST /api/events/[id]/rsvp", () => {
     expect(res.status).toBe(401);
   });
 
-  it("rejects invalid status", async () => {
+  it("accepts 'maybe' status", async () => {
     const ev = await seedEvent(7 * 86400_000);
+    await testPrisma.user.create({ data: { id: "u1", name: "U", email: "u1@t.com", emailVerified: true } });
     const user = { user: { id: "u1", name: "U" } };
     const res = await rsvpPost(ctx(ev.id, { status: "maybe" }, user));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe("maybe");
+  });
+
+  it("rejects truly invalid status", async () => {
+    const ev = await seedEvent(7 * 86400_000);
+    await testPrisma.user.create({ data: { id: "u1", name: "U", email: "u1@t.com", emailVerified: true } });
+    const user = { user: { id: "u1", name: "U" } };
+    const res = await rsvpPost(ctx(ev.id, { status: "wat" }, user));
     expect(res.status).toBe(400);
   });
 

--- a/src/test/rsvp-guest-api.test.ts
+++ b/src/test/rsvp-guest-api.test.ts
@@ -85,11 +85,21 @@ describe("POST /api/events/[id]/players/[playerId]/rsvp", () => {
     expect(res.status).toBe(403);
   });
 
-  it("rejects invalid status", async () => {
+  it("accepts 'maybe' status for a guest", async () => {
     const owner = await testPrisma.user.create({ data: { id: "owner", name: "O", email: "o@t.com", emailVerified: true } });
     const ev = await seedEvent(owner.id);
     const guest = await testPrisma.player.create({ data: { eventId: ev.id, name: "Guest", order: 0 } });
     const res = await guestRsvpPost(ctx(ev.id, guest.id, { status: "maybe" }, { user: { id: "owner", name: "O" } }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe("maybe");
+  });
+
+  it("rejects truly invalid status for a guest", async () => {
+    const owner = await testPrisma.user.create({ data: { id: "owner", name: "O", email: "o@t.com", emailVerified: true } });
+    const ev = await seedEvent(owner.id);
+    const guest = await testPrisma.player.create({ data: { eventId: ev.id, name: "Guest", order: 0 } });
+    const res = await guestRsvpPost(ctx(ev.id, guest.id, { status: "wat" }, { user: { id: "owner", name: "O" } }));
     expect(res.status).toBe(400);
   });
 

--- a/src/test/rsvp-notifications.test.ts
+++ b/src/test/rsvp-notifications.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { PrismaClient } from "@prisma/client";
+
+const testPrisma = new PrismaClient({
+  datasources: { db: { url: process.env.DATABASE_URL } },
+});
+
+vi.mock("~/lib/db.server", () => {
+  const { PrismaClient: PC } = require("@prisma/client");
+  const p = new PC({ datasources: { db: { url: process.env.DATABASE_URL } } });
+  return { prisma: p };
+});
+
+import { enqueueRsvpAnswerNotification } from "~/lib/rsvp-notifications.server";
+
+vi.mock("~/lib/logger.server", () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+beforeEach(async () => {
+  await testPrisma.notificationJob.deleteMany();
+  await testPrisma.eventFollow.deleteMany();
+  await testPrisma.player.deleteMany();
+  await testPrisma.event.deleteMany();
+  await testPrisma.user.deleteMany();
+});
+
+async function seedUser(overrides: Record<string, unknown> = {}) {
+  return testPrisma.user.create({
+    data: {
+      id: `u-${Math.random().toString(36).slice(2, 8)}`,
+      name: "Alice",
+      email: `a-${Math.random().toString(36).slice(2, 8)}@t.com`,
+      emailVerified: true,
+      ...overrides,
+    },
+  });
+}
+
+async function seedEvent(ownerId: string | null) {
+  return testPrisma.event.create({
+    data: {
+      id: `e-${Math.random().toString(36).slice(2, 8)}`,
+      title: "Friday Game",
+      location: "Pitch",
+      dateTime: new Date(Date.now() + 7 * 86400_000),
+      ownerId,
+    },
+  });
+}
+
+describe("enqueueRsvpAnswerNotification", () => {
+  it("creates a job of type rsvp_request with the rich actor payload when actor is logged", async () => {
+    const u = await seedUser({ name: "João" });
+    const e = await seedEvent(null);
+
+    await enqueueRsvpAnswerNotification({
+      eventId: e.id,
+      eventTitle: e.title,
+      status: "yes",
+      actorUserId: u.id,
+      actorName: u.name,
+      actorIsLogged: true,
+    });
+
+    const jobs = await testPrisma.notificationJob.findMany({ where: { eventId: e.id, type: "rsvp_request" } });
+    expect(jobs).toHaveLength(1);
+    const payload = JSON.parse(jobs[0].payload) as { key: string; params: Record<string, string>; title: string };
+    expect(payload.key).toBe("notifyRsvpAnswerYes");
+    expect(payload.params).toEqual({ name: "João", title: e.title });
+    expect(payload.title).toBe(e.title);
+    expect(jobs[0].senderClientId).toBe(u.id);
+  });
+
+  it("uses the generic (anon) key when the actor is not logged (e.g. admin sets a guest RSVP)", async () => {
+    const owner = await seedUser({ name: "Owner" });
+    const e = await seedEvent(owner.id);
+    const guest = await testPrisma.player.create({ data: { eventId: e.id, name: "Guest", order: 0 } });
+
+    await enqueueRsvpAnswerNotification({
+      eventId: e.id,
+      eventTitle: e.title,
+      status: "no",
+      actorPlayerId: guest.id,
+      actorName: "Guest",
+      actorIsLogged: false,
+      senderClientId: owner.id,
+    });
+
+    const jobs = await testPrisma.notificationJob.findMany({ where: { eventId: e.id, type: "rsvp_request" } });
+    expect(jobs).toHaveLength(1);
+    const payload = JSON.parse(jobs[0].payload) as { key: string; params: Record<string, string> };
+    expect(payload.key).toBe("notifyRsvpAnswerAnon");
+    // No name in params for anon — generic text
+    expect(payload.params).toEqual({ title: e.title });
+    expect(payload.params.name).toBeUndefined();
+  });
+
+  it("selects the correct i18n key per status (yes / no / maybe)", async () => {
+    const u = await seedUser({ name: "Maria" });
+    const e = await seedEvent(null);
+
+    await enqueueRsvpAnswerNotification({
+      eventId: e.id,
+      eventTitle: e.title,
+      status: "maybe",
+      actorUserId: u.id,
+      actorName: u.name,
+      actorIsLogged: true,
+    });
+    const jobs = await testPrisma.notificationJob.findMany({ where: { eventId: e.id, type: "rsvp_request" } });
+    const payload = JSON.parse(jobs[0].payload) as { key: string };
+    expect(payload.key).toBe("notifyRsvpAnswerMaybe");
+  });
+
+  it("dedups: latest answer replaces the prior unprocessed job for the same actor", async () => {
+    const u = await seedUser({ name: "Eva" });
+    const e = await seedEvent(null);
+
+    await enqueueRsvpAnswerNotification({
+      eventId: e.id,
+      eventTitle: e.title,
+      status: "yes",
+      actorUserId: u.id,
+      actorName: u.name,
+      actorIsLogged: true,
+    });
+    await enqueueRsvpAnswerNotification({
+      eventId: e.id,
+      eventTitle: e.title,
+      status: "no",
+      actorUserId: u.id,
+      actorName: u.name,
+      actorIsLogged: true,
+    });
+
+    const jobs = await testPrisma.notificationJob.findMany({ where: { eventId: e.id, type: "rsvp_request" } });
+    expect(jobs).toHaveLength(1);
+    const payload = JSON.parse(jobs[0].payload) as { key: string };
+    expect(payload.key).toBe("notifyRsvpAnswerNo");
+  });
+
+  it("does NOT dedup across different actors", async () => {
+    const a = await seedUser({ name: "A" });
+    const b = await seedUser({ name: "B" });
+    const e = await seedEvent(null);
+
+    await enqueueRsvpAnswerNotification({
+      eventId: e.id,
+      eventTitle: e.title,
+      status: "yes",
+      actorUserId: a.id,
+      actorName: a.name,
+      actorIsLogged: true,
+    });
+    await enqueueRsvpAnswerNotification({
+      eventId: e.id,
+      eventTitle: e.title,
+      status: "no",
+      actorUserId: b.id,
+      actorName: b.name,
+      actorIsLogged: true,
+    });
+
+    const jobs = await testPrisma.notificationJob.findMany({ where: { eventId: e.id, type: "rsvp_request" } });
+    expect(jobs).toHaveLength(2);
+  });
+});

--- a/src/test/rsvp-users-api.test.ts
+++ b/src/test/rsvp-users-api.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { PrismaClient } from "@prisma/client";
+
+const testPrisma = new PrismaClient({
+  datasources: { db: { url: process.env.DATABASE_URL } },
+});
+
+vi.mock("~/lib/db.server", () => {
+  const { PrismaClient: PC } = require("@prisma/client");
+  const p = new PC({ datasources: { db: { url: process.env.DATABASE_URL } } });
+  return { prisma: p };
+});
+
+import { GET as usersGet } from "~/pages/api/events/[id]/rsvp/users";
+
+const mockGetSession = vi.fn();
+vi.mock("~/lib/auth.helpers.server", () => ({
+  getSession: (...args: any[]) => mockGetSession(...args),
+}));
+
+vi.mock("~/lib/logger.server", () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("~/lib/apiRateLimit.server", () => ({
+  rateLimitResponse: vi.fn().mockResolvedValue(null),
+}));
+
+beforeEach(async () => {
+  await testPrisma.rsvp.deleteMany();
+  await testPrisma.eventFollow.deleteMany();
+  await testPrisma.player.deleteMany();
+  await testPrisma.event.deleteMany();
+  await testPrisma.user.deleteMany();
+  vi.clearAllMocks();
+});
+
+function ctx(eventId: string, session: { user: { id: string; name: string } } | null) {
+  mockGetSession.mockResolvedValue(session as any);
+  return {
+    params: { id: eventId },
+    request: new Request(`http://localhost/api/events/${eventId}/rsvp/users`),
+  } as any;
+}
+
+async function seedEvent(ownerId: string | null) {
+  return testPrisma.event.create({
+    data: {
+      title: "Game",
+      location: "Pitch",
+      dateTime: new Date(Date.now() + 7 * 86400_000),
+      ownerId,
+    },
+  });
+}
+
+describe("GET /api/events/[id]/rsvp/users", () => {
+  it("returns 404 for non-existent event", async () => {
+    const res = await usersGet(ctx("nope", { user: { id: "u1", name: "U" } }));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns empty map for anonymous viewer (one-way privacy)", async () => {
+    const owner = await testPrisma.user.create({ data: { id: "owner", name: "O", email: "o@t.com", emailVerified: true } });
+    const other = await testPrisma.user.create({ data: { id: "other", name: "X", email: "x@t.com", emailVerified: true } });
+    const ev = await seedEvent(owner.id);
+    await testPrisma.rsvp.create({ data: { eventId: ev.id, userId: other.id, status: "yes", respondedAt: new Date() } });
+
+    const res = await usersGet(ctx(ev.id, null));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.users).toEqual({});
+  });
+
+  it("returns RSVP map of all linked-user RSVPs for a logged viewer", async () => {
+    const owner = await testPrisma.user.create({ data: { id: "owner", name: "O", email: "o@t.com", emailVerified: true } });
+    const a = await testPrisma.user.create({ data: { id: "a", name: "A", email: "a@t.com", emailVerified: true } });
+    const b = await testPrisma.user.create({ data: { id: "b", name: "B", email: "b@t.com", emailVerified: true } });
+    const ev = await seedEvent(owner.id);
+    await testPrisma.rsvp.create({ data: { eventId: ev.id, userId: a.id, status: "yes", respondedAt: new Date() } });
+    await testPrisma.rsvp.create({ data: { eventId: ev.id, userId: b.id, status: "maybe", respondedAt: new Date() } });
+
+    const res = await usersGet(ctx(ev.id, { user: { id: owner.id, name: "O" } }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.users).toEqual({ a: "yes", b: "maybe" });
+  });
+
+  it("excludes guest (playerId-keyed) RSVPs from the user map", async () => {
+    const owner = await testPrisma.user.create({ data: { id: "owner", name: "O", email: "o@t.com", emailVerified: true } });
+    const ev = await seedEvent(owner.id);
+    const guest = await testPrisma.player.create({ data: { eventId: ev.id, name: "G", order: 0 } });
+    await testPrisma.rsvp.create({ data: { eventId: ev.id, playerId: guest.id, status: "yes", respondedAt: new Date() } });
+
+    const res = await usersGet(ctx(ev.id, { user: { id: owner.id, name: "O" } }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.users).toEqual({});
+  });
+});

--- a/src/test/rsvp.test.ts
+++ b/src/test/rsvp.test.ts
@@ -7,6 +7,7 @@ import {
   getRsvpForGuest,
   getRsvpSummary,
   getRsvpRecipients,
+  getUserRsvpMap,
   markRsvpCutoffSent,
   isRsvpCutoffSent,
   getEventsNeedingRsvpPing,
@@ -86,6 +87,13 @@ describe("upsertRsvp", () => {
     const count = await prisma.rsvp.count({ where: { userId: user.id, eventId: event.id } });
     expect(count).toBe(1);
   });
+
+  it("accepts 'maybe' as a status", async () => {
+    const user = await seedUser();
+    const event = await seedEvent(null);
+    const rsvp = await upsertRsvp(event.id, user.id, "maybe");
+    expect(rsvp.status).toBe("maybe");
+  });
 });
 
 describe("getRsvpForUser", () => {
@@ -131,6 +139,39 @@ describe("getRsvpSummary", () => {
     expect(summary.no).toBe(1);
     // pending = 2 (owner + stranger)
     expect(summary.pending).toBe(2);
+  });
+});
+
+describe("getUserRsvpMap", () => {
+  it("returns status map for all linked-user RSVPs when viewer is logged", async () => {
+    const a = await seedUser({ name: "A" });
+    const b = await seedUser({ name: "B" });
+    const event = await seedEvent(null);
+    await upsertRsvp(event.id, a.id, "yes");
+    await upsertRsvp(event.id, b.id, "maybe");
+
+    const map = await getUserRsvpMap(event.id, true);
+    expect(map[a.id]).toBe("yes");
+    expect(map[b.id]).toBe("maybe");
+  });
+
+  it("returns empty map for anonymous viewers (one-way privacy)", async () => {
+    const a = await seedUser({ name: "A" });
+    const event = await seedEvent(null);
+    await upsertRsvp(event.id, a.id, "yes");
+
+    const map = await getUserRsvpMap(event.id, false);
+    expect(map).toEqual({});
+  });
+
+  it("excludes guest (userId-null) RSVPs from the user map", async () => {
+    const owner = await seedUser({ name: "O" });
+    const event = await seedEvent(owner.id);
+    const guest = await prisma.player.create({ data: { eventId: event.id, name: "G", order: 0 } });
+    await upsertGuestRsvp(event.id, guest.id, "yes", owner.id);
+
+    const map = await getUserRsvpMap(event.id, true);
+    expect(map).toEqual({});
   });
 });
 


### PR DESCRIPTION
## What

Closes the RSVP gap where logged users had no pill on the player list, and where RSVP answer notifications were never actually sent. After this lands, a logged user who RSVPs gets a pill on the player list (visible to other logged users only) and triggers a push to all invited players with their name + answer.

## Why

The pre-game RSVP was a tool to chase confirmations before kickoff, replacing the admin's manual chase. Two holes:

1. A logged user setting their own answer had no visible feedback on the player list (only guests had pills). The AttendanceCta answered for "me" but the other linked-user rows stayed blank — no shared view of who had answered.
2. The notification job type `rsvp_request` was declared in the union but never enqueued. No push ever fired on an answer change.

## What changed

- **`RsvpStatus` widened** to `"yes" | "no" | "maybe"` across lib, both API endpoints, and component types. Existing callers passing "yes"/"no" still type-check — this is a pure widening.
- **New `getUserRsvpMap` server helper** + `GET /api/events/[id]/rsvp/users` endpoint. The endpoint returns an empty map for anonymous viewers — one-way privacy enforced **server-side**, not just at the UI. The server is the source of truth, not the React tree.
- **New `<UserRsvpPill>`** rendered on linked-user rows in `PlayerList`. Read-only — the user can only RSVP for themselves via the AttendanceCta at the top. Owner/admin can act on guests via the existing guest pill; the user pill is purely informational.
- **New `enqueueRsvpAnswerNotification`** fires after every RSVP upsert.
  - Logged actor: rich payload (`{name} confirmed/declined/is unsure about {title}`).
  - Anonymous actor (admin acting on a guest's behalf): generic (`Someone answered {title}`) so the guest's identity is not exposed to the group.
  - Dedup: one unprocessed job per (event, actor). Subsequent answers update the same job in place (latest-wins per the spec).
- **`EventLog` action** `rsvp_maybe` added so the activity log captures all three states.
- **i18n**: `rsvpMaybe` + `notifyRsvpAnswer{Yes,No,Maybe,Anon}` in all 6 locales.

## Data safety

- **No schema migration.** `Rsvp.status` is `String?` (no enum), so adding "maybe" is a pure value addition.
- **Existing rows untouched.** All current rows have `status ∈ ("yes","no",null)` — no row mutation, no backfill. "maybe" rows only appear for new answers.
- **Two existing test assertions flipped** from 400 → 200 for the new accepted value. All 2718 tests pass (up from 2698 — +20 new tests across 5 test files).

## Visibility matrix (per the locked domain model)

| viewer | target | pill shown? |
|---|---|---|
| anon  | guest RSVP | yes |
| anon  | logged RSVP | no |
| logged | guest RSVP | yes |
| logged | logged RSVP | yes |

## Tests

- `rsvp.test.ts` — added "accepts maybe" + 3 tests for `getUserRsvpMap` (incl. the anon-returns-empty privacy test).
- `rsvp-api.test.ts`, `rsvp-guest-api.test.ts` — flipped the 2 "rejects maybe" assertions + added "rejects truly invalid status" assertions.
- `rsvp-users-api.test.ts` (new) — 4 tests for the new endpoint.
- `rsvp-notifications.test.ts` (new) — 5 tests for the enqueue helper.
- `PlayerList.test.tsx` — 5 new tests for the user pill rendering rules.

`npm run typecheck && npm run lint -- --max-warnings 259 && npm run test` all clean. 0 lint errors, 54 warnings (under the 259 budget).
