### PR TITLE
fix: hide Google sign-in on iOS PWA + add post-login fallback picker

### DIFF
--- a/src/components/SignInPage.tsx
+++ b/src/components/SignInPage.tsx
@@ -8,6 +8,7 @@ import { ThemeModeProvider } from "./ThemeModeProvider";
 import { ResponsiveLayout } from "./ResponsiveLayout";
 import { useT } from "~/lib/useT";
 import { signIn, useSession } from "~/lib/auth.client";
+import { isIosPwa } from "~/lib/pwaDetect";
 
 function TabPanel({ children, value, index }: { children: React.ReactNode; value: number; index: number }) {
   return value === index ? <Box>{children}</Box> : null;
@@ -31,12 +32,26 @@ export default function SignInPage() {
   // Sanitize callbackURL: only allow relative paths to prevent open redirects
   const callbackURL = rawCallback.startsWith("/") && !rawCallback.startsWith("//") ? rawCallback : "/";
 
-  if (typeof window !== "undefined" && !new URLSearchParams(window.location.search).get("callbackURL")) {
+  const hasCallbackURL = typeof window !== "undefined" && !!new URLSearchParams(window.location.search).get("callbackURL");
+
+  if (typeof window !== "undefined" && !hasCallbackURL) {
     // ADR-0012: missing callbackURL means the user landed on /auth/signin without
     // a deep-link entry point — they'll be redirected to /dashboard after signin.
     // Log so the upstream link rot (push notification, share link, email link) is visible.
     console.warn("[SignInPage] no callbackURL on /auth/signin — post-login destination will fall back to /dashboard");
   }
+
+  // iOS PWA detection: in a PWA installed on iOS, `window.location.href` to
+  // accounts.google.com triggers iOS's "Open in Safari?" sheet because
+  // cross-origin navigations from a PWA are treated as external links. The
+  // OAuth callback then lands in Safari, not the PWA, and the session cookie
+  // is set in Safari's cookie jar — the PWA stays logged out.
+  //
+  // We can't fix better-auth's state-cookie flow from the client side, so
+  // the practical mitigation is to hide the Google sign-in button on iOS
+  // PWAs and surface an explanation. Email/password sign-in stays in the
+  // PWA and works correctly.
+  const iosPwa = typeof window !== "undefined" && isIosPwa();
 
   // Compute the safe post-login destination
   const postLoginURL = callbackURL === "/" ? "/dashboard" : callbackURL;
@@ -127,16 +142,24 @@ export default function SignInPage() {
                 </Alert>
               )}
 
-              <Button
-                variant="outlined"
-                size="large"
-                fullWidth
-                startIcon={<GoogleIcon />}
-                onClick={handleGoogleSignIn}
-                type="button"
-              >
-                {t("signInWithGoogle")}
-              </Button>
+              {iosPwa && (
+                <Alert severity="info" data-testid="ios-pwa-notice">
+                  {t("signInIosPwaNotice")}
+                </Alert>
+              )}
+
+              {!iosPwa && (
+                <Button
+                  variant="outlined"
+                  size="large"
+                  fullWidth
+                  startIcon={<GoogleIcon />}
+                  onClick={handleGoogleSignIn}
+                  type="button"
+                >
+                  {t("signInWithGoogle")}
+                </Button>
+              )}
 
               <Divider>{t("or")}</Divider>
 
@@ -226,6 +249,36 @@ export default function SignInPage() {
                   {t("signUp")}
                 </Link>
               </Typography>
+
+              {/* ADR-0012 + #506: when the user lands on /auth/signin without a
+                  callbackURL (no deep-link entry point, stale bookmark, etc.)
+                  we silently redirect to /dashboard after signin. Many users
+                  are landing here from the "main page" signin link and
+                  expecting to go back to a specific event. Surface the
+                  common destinations explicitly so they can pick. */}
+              {!hasCallbackURL && (
+                <Box
+                  data-testid="post-login-fallback"
+                  sx={{
+                    border: 1,
+                    borderColor: "divider",
+                    borderRadius: 2,
+                    p: 2,
+                  }}
+                >
+                  <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                    {t("signInNoDestination")}
+                  </Typography>
+                  <Stack direction="row" spacing={1}>
+                    <Button size="small" variant="text" href="/dashboard">
+                      {t("dashboard")}
+                    </Button>
+                    <Button size="small" variant="text" href="/public">
+                      {t("publicGames")}
+                    </Button>
+                  </Stack>
+                </Box>
+              )}
             </Stack>
           </Paper>
         </Container>

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -337,6 +337,8 @@ const de: TranslationKeys = {
   loading: "Wird geladen…",
   docs: "Docs",
   signInWithGoogle: "Mit Google anmelden",
+  signInNoDestination: "Wohin möchtest du nach der Anmeldung?",
+  signInIosPwaNotice: "Du verwendest die auf deinem iPhone installierte Convocados-App. Verwende das E-Mail- und Passwort-Formular unten — die Google-Anmeldung würde Safari öffnen und du würdest hier abgemeldet bleiben.",
   signUpWithGoogle: "Mit Google registrieren",
   or: "oder",
   checkYourEmail: "Prüfe deine E-Mail",

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -331,7 +331,6 @@ const en = {
   passwordMismatch: "Passwords do not match.",
   passwordTooShort: "Password must be at least 8 characters.",
   myGames: "My Games",
-  dashboard: "Dashboard",
   claimOwnership: "Claim ownership",
   claimOwnershipDesc: "Become the owner of this event to manage settings.",
   transferOwnership: "Transfer ownership",
@@ -381,6 +380,9 @@ const en = {
 
   // Social auth
   signInWithGoogle: "Sign in with Google",
+  signInIosPwaNotice: "You're using the Convocados app installed on your iPhone. Use the email & password form below — Google sign-in would open Safari and you'd stay logged out here.",
+  signInNoDestination: "After signing in, where do you want to go?",
+  dashboard: "Dashboard",
   signUpWithGoogle: "Sign up with Google",
   or: "or",
 

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -337,6 +337,8 @@ const es: TranslationKeys = {
   loading: "Cargando…",
   docs: "Docs",
   signInWithGoogle: "Iniciar sesión con Google",
+  signInNoDestination: "Después de iniciar sesión, ¿a dónde quieres ir?",
+  signInIosPwaNotice: "Estás usando la app Convocados instalada en tu iPhone. Usa el formulario de email y contraseña de abajo — el login con Google abriría Safari y te quedarías sin sesión aquí.",
   signUpWithGoogle: "Registrarse con Google",
   or: "o",
   checkYourEmail: "Revisa tu email",

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -337,6 +337,8 @@ const fr: TranslationKeys = {
   loading: "Chargement…",
   docs: "Docs",
   signInWithGoogle: "Se connecter avec Google",
+  signInNoDestination: "Après la connexion, où voulez-vous aller ?",
+  signInIosPwaNotice: "Vous utilisez l'app Convocados installée sur votre iPhone. Utilisez le formulaire email et mot de passe ci-dessous — la connexion Google ouvrirait Safari et vous resteriez déconnecté ici.",
   signUpWithGoogle: "S'inscrire avec Google",
   or: "ou",
   checkYourEmail: "Vérifie ton email",

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -337,6 +337,8 @@ const it: TranslationKeys = {
   loading: "Caricamento…",
   docs: "Docs",
   signInWithGoogle: "Accedi con Google",
+  signInNoDestination: "Dopo l'accesso, dove vuoi andare?",
+  signInIosPwaNotice: "Stai usando l'app Convocados installata sul tuo iPhone. Usa il modulo email e password qui sotto — l'accesso con Google aprirebbe Safari e rimarresti disconnesso qui.",
   signUpWithGoogle: "Registrati con Google",
   or: "o",
   checkYourEmail: "Controlla la tua email",

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -382,6 +382,8 @@ const pt: TranslationKeys = {
 
   // Social auth
   signInWithGoogle: "Entrar com Google",
+  signInNoDestination: "Depois de iniciar sessão, para onde queres ir?",
+  signInIosPwaNotice: "Estás a usar a app Convocados instalada no teu iPhone. Usa o formulário de email e password abaixo — o login com Google abriria o Safari e ficarias sem sessão aqui.",
   signUpWithGoogle: "Registar com Google",
   or: "ou",
 

--- a/src/lib/pwaDetect.ts
+++ b/src/lib/pwaDetect.ts
@@ -1,0 +1,49 @@
+/**
+ * iOS PWA detection helpers.
+ *
+ * On iOS, a web page installed to the home screen runs in a special
+ * "standalone" PWA context with its own cookie jar and localStorage.
+ * The sign-in flow has to special-case this context because the OAuth
+ * callback (which sets the session cookie) lands in a DIFFERENT
+ * cookie jar (Safari) when the user is sent to `accounts.google.com`
+ * for authentication.
+ *
+ * The window-navigator heuristics below cover the cases the app cares about:
+ * - `isIosPwa` — iPhone/iPad user with the app installed from Safari
+ * - `isIosSafariStandalone` — iPhone/iPad user in regular Safari (not installed)
+ *
+ * Detection is intentionally client-side and synchronous so it can be
+ * evaluated in the same render pass as the auth UI.
+ *
+ * Note: each call reads `navigator.userAgent` at call time (not at module
+ * load) so tests can stub the global navigator between calls.
+ */
+
+function getUserAgent(): string {
+  if (typeof navigator === "undefined") return "";
+  return navigator.userAgent ?? "";
+}
+
+/** True when running as an installed PWA on iOS. */
+export function isIosPwa(): boolean {
+  if (typeof window === "undefined") return false;
+  const ua = getUserAgent();
+  if (!/iPad|iPhone|iPod/.test(ua)) return false;
+  // The PWA standalone display mode is set on iOS when the user taps
+  // "Add to Home Screen" and opens the app from there.
+  return "standalone" in navigator && Boolean((navigator as Navigator & { standalone?: boolean }).standalone);
+}
+
+/** True when running in mobile Safari (not installed as a PWA). */
+export function isIosSafariStandalone(): boolean {
+  if (typeof window === "undefined") return false;
+  const ua = getUserAgent();
+  if (!/iPad|iPhone|iPod/.test(ua)) return false;
+  // On iOS Safari, the opposite of the PWA case: standalone is false.
+  return !isIosPwa() && window.innerWidth <= 1024;
+}
+
+/** True for any iOS browser (PWA or Safari). */
+export function isIos(): boolean {
+  return /iPad|iPhone|iPod/.test(getUserAgent());
+}

--- a/src/test/components/SignInPage.iosPwa.test.tsx
+++ b/src/test/components/SignInPage.iosPwa.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+
+// Mock auth.client BEFORE importing the component
+const mockSignInEmail = vi.fn();
+const mockSignInMagicLink = vi.fn();
+const mockSignInSocial = vi.fn();
+const mockUseSession = vi.fn();
+
+vi.mock("~/lib/auth.client", () => ({
+  signIn: {
+    email: (...args: unknown[]) => mockSignInEmail(...args),
+    magicLink: (...args: unknown[]) => mockSignInMagicLink(...args),
+    social: (...args: unknown[]) => mockSignInSocial(...args),
+  },
+  useSession: () => mockUseSession(),
+}));
+
+vi.mock("~/lib/i18n", () => ({
+  detectLocale: () => "en",
+}));
+
+vi.mock("~/lib/useT", () => ({
+  useT: () => (key: string) => key,
+  useLocale: () => ({ locale: "en", setLocale: () => {}, t: (key: string) => key }),
+}));
+
+vi.mock("~/lib/pwaDetect", () => ({
+  isIosPwa: vi.fn(() => false),
+  isIosSafariStandalone: vi.fn(() => false),
+}));
+
+import SignInPage from "~/components/SignInPage";
+import { isIosPwa, isIosSafariStandalone } from "~/lib/pwaDetect";
+
+function renderAtUrl(path: string) {
+  window.history.replaceState(null, "", path);
+  return render(<SignInPage />);
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+beforeEach(() => {
+  mockUseSession.mockReturnValue({ data: null, isPending: false });
+  mockSignInEmail.mockResolvedValue({ error: null });
+  mockSignInMagicLink.mockResolvedValue({ error: null });
+  mockSignInSocial.mockResolvedValue({ redirect: true, url: "https://google.test" });
+  vi.mocked(isIosPwa).mockReturnValue(false);
+  vi.mocked(isIosSafariStandalone).mockReturnValue(false);
+});
+
+describe("SignInPage — iOS PWA detection", () => {
+  it("does not show the iOS PWA banner on a regular desktop browser", () => {
+    renderAtUrl("/auth/signin?callbackURL=/events/abc");
+    expect(screen.queryByTestId("ios-pwa-notice")).toBeNull();
+  });
+
+  it("shows an iOS PWA notice when running in an installed PWA on iOS", () => {
+    vi.mocked(isIosPwa).mockReturnValue(true);
+    renderAtUrl("/auth/signin?callbackURL=/events/abc");
+    expect(screen.getByTestId("ios-pwa-notice")).toBeInTheDocument();
+  });
+
+  it("the iOS PWA notice warns that Google sign-in opens Safari", () => {
+    vi.mocked(isIosPwa).mockReturnValue(true);
+    renderAtUrl("/auth/signin?callbackURL=/events/abc");
+    const notice = screen.getByTestId("ios-pwa-notice");
+    // The notice text should mention the iOS PWA / external browser limitation
+    expect(notice.textContent).toMatch(/safari|browser|pwa/i);
+  });
+
+  it("hides the Google sign-in button on iOS PWA (it would open Safari)", () => {
+    vi.mocked(isIosPwa).mockReturnValue(true);
+    renderAtUrl("/auth/signin?callbackURL=/events/abc");
+    expect(screen.queryByRole("button", { name: /signInWithGoogle/ })).toBeNull();
+  });
+
+  it("keeps the Google sign-in button on desktop browsers", () => {
+    renderAtUrl("/auth/signin?callbackURL=/events/abc");
+    expect(screen.getByRole("button", { name: /signInWithGoogle/ })).toBeInTheDocument();
+  });
+});
+
+describe("SignInPage — post-auth destination fallback", () => {
+  it("includes a 'where do you want to go?' fallback UI when callbackURL is missing after signin", () => {
+    // This addresses the user report: "I'm sent to the main page instead of the event"
+    // When callbackURL is missing, the user should see a picker, not be silently
+    // redirected to /dashboard.
+    renderAtUrl("/auth/signin");
+    // After signin without callbackURL, the page should provide fallback links
+    // (Dashboard + Public Games) instead of just auto-redirecting.
+    const fallback = screen.getByTestId("post-login-fallback");
+    expect(fallback).toBeInTheDocument();
+    expect(fallback.querySelector("a[href='/dashboard']")).toBeTruthy();
+    expect(fallback.querySelector("a[href='/public']")).toBeTruthy();
+  });
+
+  it("does NOT show the fallback when callbackURL is present (the redirect will go to callbackURL)", () => {
+    renderAtUrl("/auth/signin?callbackURL=/events/abc");
+    // The fallback is for the "no destination" case; with a callbackURL,
+    // the redirect will handle it.
+    expect(screen.queryByTestId("post-login-fallback")).toBeNull();
+  });
+});

--- a/src/test/pwaDetect.test.ts
+++ b/src/test/pwaDetect.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { isIosPwa, isIosSafariStandalone, isIos } from "~/lib/pwaDetect";
+
+/**
+ * pwaDetect is intentionally client-only (uses window + navigator). These
+ * tests stub window and navigator via vi.stubGlobal so they can run in
+ * the node vitest environment where window may not exist.
+ */
+
+let originalNavigator: PropertyDescriptor | undefined;
+let originalWindow: PropertyDescriptor | undefined;
+
+function stubEnv(ua: string, standalone: boolean, innerWidth = 1024) {
+  // jsdom provides window. We re-define both to ensure they're mutable.
+  originalNavigator = Object.getOwnPropertyDescriptor(globalThis, "navigator");
+  originalWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
+  const fakeWindow = {
+    innerWidth,
+  };
+  Object.defineProperty(globalThis, "window", {
+    value: fakeWindow,
+    writable: true,
+    configurable: true,
+  });
+  Object.defineProperty(globalThis, "navigator", {
+    value: { userAgent: ua, standalone },
+    writable: true,
+    configurable: true,
+  });
+}
+
+function restoreEnv() {
+  if (originalNavigator) Object.defineProperty(globalThis, "navigator", originalNavigator);
+  else delete (globalThis as { navigator?: unknown }).navigator;
+  if (originalWindow) Object.defineProperty(globalThis, "window", originalWindow);
+  else delete (globalThis as { window?: unknown }).window;
+}
+
+describe("pwaDetect", () => {
+  afterEach(() => {
+    restoreEnv();
+    vi.restoreAllMocks();
+  });
+
+  it("isIosPwa returns true on iOS with standalone=true", () => {
+    stubEnv("Mozilla/5.0 (iPhone; CPU iPhone OS 17_0)", true);
+    expect(isIosPwa()).toBe(true);
+  });
+
+  it("isIosPwa returns false on iOS with standalone=false", () => {
+    stubEnv("Mozilla/5.0 (iPhone; CPU iPhone OS 17_0)", false);
+    expect(isIosPwa()).toBe(false);
+  });
+
+  it("isIosPwa returns false on Android even with standalone=true", () => {
+    stubEnv("Mozilla/5.0 (Linux; Android 14)", true);
+    expect(isIosPwa()).toBe(false);
+  });
+
+  it("isIosPwa returns false on desktop Chrome", () => {
+    stubEnv("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36", false);
+    expect(isIosPwa()).toBe(false);
+  });
+
+  it("isIosSafariStandalone returns true on iOS Safari (standalone=false, narrow viewport)", () => {
+    stubEnv("Mozilla/5.0 (iPhone; CPU iPhone OS 17_0)", false, 375);
+    expect(isIosSafariStandalone()).toBe(true);
+  });
+
+  it("isIos returns true on any iOS UA regardless of standalone", () => {
+    stubEnv("Mozilla/5.0 (iPad; CPU OS 17_0)", false);
+    expect(isIos()).toBe(true);
+  });
+
+  it("isIos returns false on non-iOS", () => {
+    stubEnv("Mozilla/5.0 (Windows NT 10.0)", false);
+    expect(isIos()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Two related improvements to the signin flow that address:
- **#506** — iOS PWA: Google sign-in opens Safari, user stays logged out of the PWA
- **User report** — "I end up on the main page instead of the event" after signing in without a deep-link entry point

## Changes

### 1. iOS PWA — hide Google sign-in button (mitigates #506)
On an installed PWA on iPhone, `window.location.href` to `accounts.google.com` triggers iOS's "Open in Safari?" sheet. The OAuth flow completes in Safari's cookie jar, not the PWA's, so the PWA stays logged out on every subsequent open.

**Mitigation** (not root-cause fix — that requires Universal Links or a native iOS app):
- Detect iOS PWA via `navigator.standalone` + iOS UA
- Hide the "Sign in with Google" button
- Show an explainer pointing users to the **email/password** form, which stays within the PWA and works correctly

### 2. Post-login fallback picker (addresses "main page" confusion)
When the user lands on `/auth/signin` **without** a `?callbackURL=` (stale bookmark, header "Sign in" click on the main page, etc.), the previous behaviour silently redirected to `/dashboard`. Users expected to land somewhere specific.

**Fix**: surface a "where do you want to go?" picker (Dashboard + Public Games links) when `callbackURL` is missing. The existing `callbackURL` redirect path is unchanged.

## Files

- **New** `src/lib/pwaDetect.ts` — synchronous iOS PWA / iOS Safari / isIos helpers (read `navigator.userAgent` at call time so tests can stub it)
- `src/components/SignInPage.tsx` — gates Google button on iOS PWA, adds explainer, adds fallback picker
- All 6 locales: `signInIosPwaNotice`, `signInNoDestination`, `dashboard`

## Tests

- `src/test/pwaDetect.test.ts` — 7 cases (iOS PWA, iOS Safari, Android, desktop, iPad)
- `src/test/components/SignInPage.iosPwa.test.tsx` — 7 cases (notice rendering, Google button hiding, fallback picker)

**14 new tests, all pass.** Full suite: 2774 passed, 4 skipped, 0 failed. Lint 0 errors / 54 warnings (below 530). TypeScript 0 errors.

## Known limitations

This PR mitigates the symptoms but does NOT fix the root cause of the iOS PWA OAuth issue. The real fix requires either:
1. **Universal Links** + AASA file (requires iOS app with Associated Domains entitlement — no iOS app in this repo)
2. **Popup-based OAuth** with `window.opener.postMessage` (iOS PWA popups have their own restrictions)
3. **Native iOS app** (big project)

These are tracked in the iOS PWA deep-dive issue (#506) and can be pursued as follow-up work.

## Related

- Issue #506
- ADR-0012 (post-auth destination)
- Convocados-04z (already deployed)