### PR TITLE
fix(auth): show only email/password on iOS PWA (Google + magic link don't work there)

### DIFF
--- a/src/components/SignInPage.tsx
+++ b/src/components/SignInPage.tsx
@@ -17,13 +17,27 @@ function TabPanel({ children, value, index }: { children: React.ReactNode; value
 export default function SignInPage() {
   const t = useT();
   const { data: session, isPending } = useSession();
-  const [tab, setTab] = useState(0);
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [unverified, setUnverified] = useState(false);
   const [loading, setLoading] = useState(false);
   const [magicLinkSent, setMagicLinkSent] = useState(false);
+
+  // iOS PWA detection: on iOS the PWA and Safari have separate cookie jars,
+  // so any auth flow that opens a different browser context (Google OAuth
+  // redirect, magic link email, Apple popup) sets the session cookie in
+  // Safari's jar — the PWA stays logged out. The ONLY sign-in method that
+  // works on iOS PWA is the email/password form (same-origin POST).
+  //
+  // On iOS PWA we:
+  // - hide Google sign-in and the magic-link tab (they don't work)
+  // - default to the password tab so the user lands on the working option
+  // - skip the misleading "popup will open" notice from the previous attempt
+  const iosPwa = typeof window !== "undefined" && isIosPwa();
+  // Tab state is only used on non-iOS-PWA (where the tabbed UI is shown).
+  // iOS PWA renders the password form directly without tabs.
+  const [tab, setTab] = useState(0);
 
   const rawCallback = typeof window !== "undefined"
     ? new URLSearchParams(window.location.search).get("callbackURL") || "/"
@@ -41,11 +55,7 @@ export default function SignInPage() {
     console.warn("[SignInPage] no callbackURL on /auth/signin — post-login destination will fall back to /dashboard");
   }
 
-  // iOS PWA detection: needed to switch the Google sign-in flow to a popup
-  // (`window.open`) so the session cookie is set in the PWA's cookie jar
-  // instead of being lost when iOS routes `accounts.google.com` to Safari.
-  // On desktop and regular Safari the default redirect flow is fine.
-  const iosPwa = typeof window !== "undefined" && isIosPwa();
+  // iOS PWA detection moved above (needed before useState for the default tab).
 
   // Compute the safe post-login destination
   const postLoginURL = callbackURL === "/" ? "/dashboard" : callbackURL;
@@ -102,40 +112,10 @@ export default function SignInPage() {
   };
 
   const handleGoogleSignIn = async () => {
-    if (iosPwa) {
-      // iOS PWA: window.location.href to accounts.google.com triggers
-      // "Open in Safari?" sheet, and even if the user accepts, the
-      // better-auth `state` cookie is stuck in the PWA's jar — Safari
-      // can't find it, so callbackURL is lost and the user lands on `/`.
-      //
-      // Popup-based flow: disable better-auth's auto-redirect, open the
-      // OAuth URL in a popup, wait for the popup to close (which signals
-      // the OAuth round-trip is done), then reload the main window so it
-      // picks up the session cookie. On iOS the popup still opens Safari,
-      // but at least the round-trip is explicit and the user can act on it.
-      const result = await signIn.social({
-        provider: "google",
-        callbackURL,
-        disableRedirect: true,
-      });
-      const url = result && typeof result === "object" ? (result as { url?: string }).url : undefined;
-      if (url) {
-        const popup = window.open(url, "google-oauth", "width=500,height=600,scrollbars=yes");
-        if (popup) {
-          const poll = setInterval(() => {
-            if (popup.closed) {
-              clearInterval(poll);
-              window.location.reload();
-            }
-          }, 300);
-        } else {
-          // Popup blocked — fall back to the redirect flow so the user
-          // can complete signin in the same tab.
-          window.location.href = url;
-        }
-      }
-      return;
-    }
+    // Google sign-in is not available on iOS PWA (the button is hidden in
+    // the render below). On desktop and regular mobile Safari the standard
+    // redirect flow works — the callback lands in the same browser context,
+    // so the session cookie is set in the right jar.
     await signIn.social({ provider: "google", callbackURL });
   };
 
@@ -170,75 +150,60 @@ export default function SignInPage() {
                 </Alert>
               )}
 
-              {iosPwa && (
-                <Alert severity="info" data-testid="ios-pwa-notice">
-                  {t("signInIosPwaNotice")}
-                </Alert>
+              {!iosPwa && (
+                <>
+                  <Button
+                    variant="outlined"
+                    size="large"
+                    fullWidth
+                    startIcon={<GoogleIcon />}
+                    onClick={handleGoogleSignIn}
+                    type="button"
+                    data-testid="google-signin"
+                  >
+                    {t("signInWithGoogle")}
+                  </Button>
+                  <Divider>{t("or")}</Divider>
+                </>
               )}
 
-              <Button
-                variant="outlined"
-                size="large"
-                fullWidth
-                startIcon={<GoogleIcon />}
-                onClick={handleGoogleSignIn}
-                type="button"
-                data-testid="google-signin"
-              >
-                {t("signInWithGoogle")}
-              </Button>
-
-              <Divider>{t("or")}</Divider>
-
-              <Tabs
-                value={tab}
-                onChange={handleTabChange}
-                variant="fullWidth"
-                sx={{ minHeight: 40 }}
-              >
-                <Tab
-                  icon={<EmailIcon sx={{ fontSize: 18 }} />}
-                  iconPosition="start"
-                  label={t("signInWithEmail")}
-                  sx={{ minHeight: 40, textTransform: "none" }}
-                />
-                <Tab
-                  label={t("signInWithPassword")}
-                  sx={{ minHeight: 40, textTransform: "none" }}
-                />
-              </Tabs>
-
-              {/* Magic link tab */}
-              <TabPanel value={tab} index={0}>
-                <Stack spacing={3} component="form" action="#" method="post" onSubmit={handleMagicLinkSubmit}>
-                  <Typography variant="body2" color="text.secondary">
-                    {t("magicLinkDesc")}
-                  </Typography>
-                  <TextField
-                    label={t("email")}
-                    type="email"
-                    value={email}
-                    onChange={(e) => setEmail(e.target.value)}
-                    required
-                    fullWidth
-                    autoComplete="email"
-                    autoFocus
+              {/* iOS PWA only shows the password tab — Google and magic link
+                  open Safari for auth, and Safari's cookie jar is separate
+                  from the PWA's, so the session would never reach the PWA.
+                  The Tabs bar is skipped entirely on iOS PWA since there's
+                  only one option. */}
+              {!iosPwa && (
+                <Tabs
+                  value={tab}
+                  onChange={handleTabChange}
+                  variant="fullWidth"
+                  sx={{ minHeight: 40 }}
+                >
+                  <Tab
+                    icon={<EmailIcon sx={{ fontSize: 18 }} />}
+                    iconPosition="start"
+                    label={t("signInWithEmail")}
+                    sx={{ minHeight: 40, textTransform: "none" }}
                   />
-                  <Button
-                    type="submit"
-                    variant="contained"
-                    size="large"
-                    disabled={loading || magicLinkSent}
-                    fullWidth
-                  >
-                    {loading ? t("sendingMagicLink") : t("magicLinkBtn")}
-                  </Button>
-                </Stack>
-              </TabPanel>
+                  <Tab
+                    label={t("signInWithPassword")}
+                    sx={{ minHeight: 40, textTransform: "none" }}
+                  />
+                </Tabs>
+              )}
 
-              {/* Password tab */}
-              <TabPanel value={tab} index={1}>
-                <Stack spacing={3} component="form" action="#" method="post" onSubmit={handlePasswordSubmit}>
+              {/* iOS PWA: render only the password form (the only auth method
+                  that works due to cookie-jar isolation). On all other
+                  platforms, use the tabbed interface with both options. */}
+              {iosPwa ? (
+                <Stack
+                  spacing={3}
+                  component="form"
+                  action="#"
+                  method="post"
+                  onSubmit={handlePasswordSubmit}
+                  data-testid="ios-pwa-password-form"
+                >
                   <TextField
                     label={t("email")}
                     type="email"
@@ -268,7 +233,71 @@ export default function SignInPage() {
                     {loading ? t("signingIn") : t("signIn")}
                   </Button>
                 </Stack>
-              </TabPanel>
+              ) : (
+                <>
+                  {/* Magic link tab */}
+                  <TabPanel value={tab} index={0}>
+                    <Stack spacing={3} component="form" action="#" method="post" onSubmit={handleMagicLinkSubmit}>
+                      <Typography variant="body2" color="text.secondary">
+                        {t("magicLinkDesc")}
+                      </Typography>
+                      <TextField
+                        label={t("email")}
+                        type="email"
+                        value={email}
+                        onChange={(e) => setEmail(e.target.value)}
+                        required
+                        fullWidth
+                        autoComplete="email"
+                        autoFocus
+                      />
+                      <Button
+                        type="submit"
+                        variant="contained"
+                        size="large"
+                        disabled={loading || magicLinkSent}
+                        fullWidth
+                      >
+                        {loading ? t("sendingMagicLink") : t("magicLinkBtn")}
+                      </Button>
+                    </Stack>
+                  </TabPanel>
+
+                  {/* Password tab */}
+                  <TabPanel value={tab} index={1}>
+                    <Stack spacing={3} component="form" action="#" method="post" onSubmit={handlePasswordSubmit}>
+                      <TextField
+                        label={t("email")}
+                        type="email"
+                        value={email}
+                        onChange={(e) => setEmail(e.target.value)}
+                        required
+                        fullWidth
+                        autoComplete="email"
+                        autoFocus
+                      />
+                      <TextField
+                        label={t("password")}
+                        type="password"
+                        value={password}
+                        onChange={(e) => setPassword(e.target.value)}
+                        required
+                        fullWidth
+                        autoComplete="current-password"
+                      />
+                      <Button
+                        type="submit"
+                        variant="contained"
+                        size="large"
+                        disabled={loading}
+                        fullWidth
+                      >
+                        {loading ? t("signingIn") : t("signIn")}
+                      </Button>
+                    </Stack>
+                  </TabPanel>
+                </>
+              )}
 
               <Typography variant="body2" textAlign="center" color="text.secondary">
                 {t("noAccount")}{" "}

--- a/src/test/components/SignInPage.iosPwa.test.tsx
+++ b/src/test/components/SignInPage.iosPwa.test.tsx
@@ -54,43 +54,56 @@ beforeEach(() => {
   vi.mocked(isIosSafariStandalone).mockReturnValue(false);
 });
 
-describe("SignInPage — iOS PWA detection", () => {
-  it("does not show the iOS PWA banner on a regular desktop browser", () => {
+describe("SignInPage — iOS PWA auth options", () => {
+  it("shows the Google sign-in button on desktop browsers", () => {
+    renderAtUrl("/auth/signin?callbackURL=/events/abc");
+    expect(screen.getByRole("button", { name: /signInWithGoogle/ })).toBeInTheDocument();
+  });
+
+  it("hides the Google sign-in button on iOS PWA (cookie jar isolation makes it non-functional)", () => {
+    vi.mocked(isIosPwa).mockReturnValue(true);
+    renderAtUrl("/auth/signin?callbackURL=/events/abc");
+    expect(screen.queryByRole("button", { name: /signInWithGoogle/ })).toBeNull();
+  });
+
+  it("hides the Google sign-in button on iOS PWA even without callbackURL", () => {
+    vi.mocked(isIosPwa).mockReturnValue(true);
+    renderAtUrl("/auth/signin");
+    expect(screen.queryByRole("button", { name: /signInWithGoogle/ })).toBeNull();
+  });
+
+  it("hides the magic link tab on iOS PWA (magic link email opens Safari, same jar problem)", () => {
+    vi.mocked(isIosPwa).mockReturnValue(true);
+    renderAtUrl("/auth/signin?callbackURL=/events/abc");
+    // The "Sign in with Email" tab (magic link) should not be present
+    expect(screen.queryByRole("tab", { name: /signInWithEmail/ })).toBeNull();
+  });
+
+  it("shows the password tab on iOS PWA (same-origin form submit works)", () => {
+    vi.mocked(isIosPwa).mockReturnValue(true);
+    renderAtUrl("/auth/signin?callbackURL=/events/abc");
+    // The iOS PWA password form should be present
+    expect(screen.getByTestId("ios-pwa-password-form")).toBeInTheDocument();
+    // The Tabs bar should not be present on iOS PWA
+    expect(screen.queryByRole("tablist")).toBeNull();
+  });
+
+  it("does NOT show the misleading popup notice on iOS PWA (the user reported this was confusing)", () => {
+    vi.mocked(isIosPwa).mockReturnValue(true);
     renderAtUrl("/auth/signin?callbackURL=/events/abc");
     expect(screen.queryByTestId("ios-pwa-notice")).toBeNull();
   });
 
-  it("shows an iOS PWA notice when running in an installed PWA on iOS", () => {
-    vi.mocked(isIosPwa).mockReturnValue(true);
+  it("does NOT show the misleading popup notice on desktop either", () => {
     renderAtUrl("/auth/signin?callbackURL=/events/abc");
-    expect(screen.getByTestId("ios-pwa-notice")).toBeInTheDocument();
-  });
-
-  it("the iOS PWA notice warns that Google sign-in opens Safari", () => {
-    vi.mocked(isIosPwa).mockReturnValue(true);
-    renderAtUrl("/auth/signin?callbackURL=/events/abc");
-    const notice = screen.getByTestId("ios-pwa-notice");
-    // The notice text should mention the iOS PWA / external browser limitation
-    expect(notice.textContent).toMatch(/safari|browser|pwa/i);
-  });
-
-  it("keeps the Google sign-in button on iOS PWA (popup-based flow handles cross-origin nav)", () => {
-    vi.mocked(isIosPwa).mockReturnValue(true);
-    renderAtUrl("/auth/signin?callbackURL=/events/abc");
-    expect(screen.getByRole("button", { name: /signInWithGoogle/ })).toBeInTheDocument();
-  });
-
-  it("keeps the Google sign-in button on desktop browsers", () => {
-    renderAtUrl("/auth/signin?callbackURL=/events/abc");
-    expect(screen.getByRole("button", { name: /signInWithGoogle/ })).toBeInTheDocument();
+    expect(screen.queryByTestId("ios-pwa-notice")).toBeNull();
   });
 });
 
-describe("SignInPage — Google sign-in popup flow on iOS PWA", () => {
-  it("on iOS PWA, clicking Google sign-in calls signIn.social with disableRedirect", async () => {
+describe("SignInPage — Google sign-in default redirect flow", () => {
+  it("on desktop, clicking Google sign-in calls signIn.social with the callbackURL", async () => {
     const { default: userEvent } = await import("@testing-library/user-event");
     const user = userEvent.setup();
-    vi.mocked(isIosPwa).mockReturnValue(true);
     renderAtUrl("/auth/signin?callbackURL=/events/abc");
 
     await user.click(screen.getByRole("button", { name: /signInWithGoogle/ }));
@@ -98,64 +111,13 @@ describe("SignInPage — Google sign-in popup flow on iOS PWA", () => {
     expect(mockSignInSocial).toHaveBeenCalledWith({
       provider: "google",
       callbackURL: "/events/abc",
-      disableRedirect: true,
     });
   });
 
-  it("on iOS PWA, opens a popup window with the returned OAuth URL", async () => {
+  it("on desktop, does not open a popup window (default redirect flow)", async () => {
     const { default: userEvent } = await import("@testing-library/user-event");
     const user = userEvent.setup();
     const openSpy = vi.spyOn(window, "open").mockReturnValue(null);
-    vi.mocked(isIosPwa).mockReturnValue(true);
-    renderAtUrl("/auth/signin?callbackURL=/events/abc");
-    mockSignInSocial.mockResolvedValue({ redirect: false, url: "https://accounts.google.com/o/oauth2/v2/auth?state=abc" });
-
-    await user.click(screen.getByRole("button", { name: /signInWithGoogle/ }));
-
-    expect(openSpy).toHaveBeenCalledWith(
-      "https://accounts.google.com/o/oauth2/v2/auth?state=abc",
-      "google-oauth",
-      expect.stringMatching(/width|height/),
-    );
-    openSpy.mockRestore();
-  });
-
-  it("on iOS PWA, reloads the page when the popup closes (so the session cookie is picked up)", async () => {
-    const { default: userEvent } = await import("@testing-library/user-event");
-    const user = userEvent.setup();
-    const reloadSpy = vi.fn();
-    // Stub window.location.reload by replacing the Location object (jsdom's
-    // Location is non-writable, so we replace the whole property).
-    const realLocation = window.location;
-    const fakeLocation = { ...realLocation, reload: reloadSpy } as unknown as Location;
-    Object.defineProperty(window, "location", { value: fakeLocation, writable: true, configurable: true });
-    // Popup that reports as closed on the next .closed check
-    const fakePopup = { closed: false, close: vi.fn() } as unknown as Window;
-    const openSpy = vi.spyOn(window, "open").mockReturnValue(fakePopup);
-    try {
-      vi.mocked(isIosPwa).mockReturnValue(true);
-      renderAtUrl("/auth/signin?callbackURL=/events/abc");
-      mockSignInSocial.mockResolvedValue({ redirect: false, url: "https://google.test" });
-
-      await user.click(screen.getByRole("button", { name: /signInWithGoogle/ }));
-
-      // Simulate the popup closing after the OAuth round-trip
-      await new Promise((r) => setTimeout(r, 10));
-      (fakePopup as { closed: boolean }).closed = true;
-      await new Promise((r) => setTimeout(r, 400)); // poll interval is ~300ms
-
-      expect(reloadSpy).toHaveBeenCalled();
-    } finally {
-      openSpy.mockRestore();
-      Object.defineProperty(window, "location", { value: realLocation, writable: true, configurable: true });
-    }
-  });
-
-  it("on desktop, clicking Google sign-in does NOT open a popup (default redirect flow)", async () => {
-    const { default: userEvent } = await import("@testing-library/user-event");
-    const user = userEvent.setup();
-    const openSpy = vi.spyOn(window, "open").mockReturnValue(null);
-    vi.mocked(isIosPwa).mockReturnValue(false);
     renderAtUrl("/auth/signin?callbackURL=/events/abc");
 
     await user.click(screen.getByRole("button", { name: /signInWithGoogle/ }));
@@ -184,5 +146,11 @@ describe("SignInPage — post-auth destination fallback", () => {
     // The fallback is for the "no destination" case; with a callbackURL,
     // the redirect will handle it.
     expect(screen.queryByTestId("post-login-fallback")).toBeNull();
+  });
+
+  it("shows the fallback on iOS PWA too (the picker is auth-method-agnostic)", () => {
+    vi.mocked(isIosPwa).mockReturnValue(true);
+    renderAtUrl("/auth/signin");
+    expect(screen.getByTestId("post-login-fallback")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Problem

iOS PWA and Safari have separate cookie jars. Any auth flow that opens a different browser context (Google OAuth redirect, magic link email) sets the session cookie in Safari's jar — the PWA stays logged out. The previous popup-based Google sign-in (PR #508) was the standard PWA pattern but doesn't fix this platform limitation.

User report: "the deployed version still isn't allowing me to login on ios. The users don't have an alternative — we need to allow it and remove the warning."

## Fix

On iOS PWA, show **only** the email/password form (same-origin POST, works correctly). Hide Google and the magic-link tab. Remove the misleading 'popup will open' notice.

- **Desktop and regular mobile Safari**: unchanged — Google sign-in uses the standard redirect flow, magic link works, password works.
- **iOS PWA**: password form only, no tabs, no Google button, no notice.

The fallback destination picker (post-login-fallback) is still shown on iOS PWA when callbackURL is missing — that's auth-method-agnostic.

## Why this works

- **Password form** (same-origin POST): the form submits to  from the PWA's context. The session cookie is set in the PWA's cookie jar. User is logged in. ✓
- **Google OAuth** (cross-origin redirect): opens Safari, session goes to Safari's jar. PWA stays logged out. ✗
- **Magic link** (email link): user opens link in Safari (default mail client), session goes to Safari's jar. PWA stays logged out. ✗

The cookie-jar isolation is an iOS platform limitation. The only OAuth that works in iOS PWA without a native app is **Sign in with Apple JS** (uses  instead of cookie redirects). That's tracked as a follow-up — it requires Apple Developer setup (Service ID, private key, web auth config).

## Changes

- `src/components/SignInPage.tsx`: on iOS PWA, render the password form directly (no TabPanels, no Tabs bar). Removed the `ios-pwa-notice` Alert. Removed the popup-based Google flow (replaced with the standard redirect flow which works on desktop/mobile Safari).
- `src/test/components/SignInPage.iosPwa.test.tsx`: rewritten — 12 tests covering the new iOS PWA behavior (password-only, no Google, no magic link tab, no misleading notice) and the desktop flow.

## Test plan

- [x] 2779 tests pass (4 skipped in CI by design)
- [x] Lint: 0 errors, 54 warnings
- [x] Typecheck: clean
- [x] Manual: tested on POCOPHONE_F1 with the debug APK — custom URL scheme deep link works, verified App Links open the app directly. iOS PWA fix needs iOS device for full manual test (the user can verify on their iPhone after deploy).

## Follow-up

- Add Sign in with Apple JS for OAuth on iOS PWA (proper fix, requires Apple Developer setup)
- Build the ios-app/ SwiftUI app with ASWebAuthenticationSession + Universal Links (the real long-term fix)