### PR TITLE
fix(auth): re-enable Google sign-in on iOS PWA + in-place sign-in modal

### DIFF
--- a/src/components/ResponsiveLayout.tsx
+++ b/src/components/ResponsiveLayout.tsx
@@ -27,6 +27,7 @@ import { useLocale } from "~/lib/useT";
 import type { Locale } from "~/lib/i18n";
 import { useSession, signOut } from "~/lib/auth.client";
 import { shareForHomeScreen } from "~/lib/pwaInstall";
+import { SignInModal } from "./SignInModal";
 
 const LOCALE_OPTIONS: { code: Locale; label: string }[] = [
   { code: "en", label: "English" },
@@ -319,8 +320,15 @@ export const ResponsiveLayout: React.FC<{ children: React.ReactNode }> = ({ chil
   const [userAnchor, setUserAnchor] = useState<null | HTMLElement>(null);
   const [prefsAnchor, setPrefsAnchor] = useState<null | HTMLElement>(null);
   const [langAnchor, setLangAnchor] = useState<null | HTMLElement>(null);
-  const { data: session, isPending: sessionLoading } = useSession();
+  const { data: session, isPending: sessionLoading, refetch: refetchSession } = useSession();
   const [isAdminUser, setIsAdminUser] = useState(false);
+  const [signInOpen, setSignInOpen] = useState(false);
+
+  // Where Google redirect should return to: the current page (so in-place
+  // login on an event page lands back on that event).
+  const signInCallbackURL = typeof window !== "undefined"
+    ? (window.location.pathname === "/" ? "/dashboard" : window.location.pathname + window.location.search)
+    : "/dashboard";
 
   useEffect(() => {
     if (!session?.user) { setIsAdminUser(false); return; }
@@ -469,8 +477,7 @@ export const ResponsiveLayout: React.FC<{ children: React.ReactNode }> = ({ chil
                 </Menu>
                 <Button
                   color="inherit"
-                  component="a"
-                  href={`/auth/signin?callbackURL=${encodeURIComponent(window.location.pathname === "/" ? "/dashboard" : window.location.pathname + window.location.search)}`}
+                  onClick={() => setSignInOpen(true)}
                   size="small"
                   sx={{ textTransform: "none", fontWeight: 600 }}
                 >
@@ -502,6 +509,18 @@ export const ResponsiveLayout: React.FC<{ children: React.ReactNode }> = ({ chil
       <Box component="main" sx={{ flexGrow: 1, width: "100%", pb: 4 }}>
         {children}
       </Box>
+
+      <SignInModal
+        open={signInOpen}
+        onClose={() => setSignInOpen(false)}
+        callbackURL={signInCallbackURL}
+        onSuccess={() => {
+          setSignInOpen(false);
+          // Revalidate the session so the signed-in UI swaps in without a
+          // full-page navigation — the user stays on the current page.
+          refetchSession?.();
+        }}
+      />
 
       <Box component="footer" sx={{
         py: 3, px: 2, mt: "auto",

--- a/src/components/SignInForm.tsx
+++ b/src/components/SignInForm.tsx
@@ -1,0 +1,208 @@
+import React, { useState } from "react";
+import {
+  TextField, Button, Stack, Alert, Link, Divider, Tabs, Tab, Box,
+} from "@mui/material";
+import GoogleIcon from "@mui/icons-material/Google";
+import EmailIcon from "@mui/icons-material/Email";
+import { useT } from "~/lib/useT";
+import { signIn } from "~/lib/auth.client";
+
+function TabPanel({ children, value, index }: { children: React.ReactNode; value: number; index: number }) {
+  return value === index ? <Box>{children}</Box> : null;
+}
+
+export interface SignInFormProps {
+  /** Relative path to return to after a Google redirect / where to send the user on success. */
+  callbackURL: string;
+  /**
+   * Called after a successful email/password sign-in. When provided (modal use)
+   * the form does NOT navigate — the caller closes the dialog and revalidates the
+   * session in place. When omitted (full-page use) the form navigates to `callbackURL`.
+   */
+  onSuccess?: () => void;
+  /** Show the "no account → sign up" footer link. Default true. */
+  showSignUpLink?: boolean;
+}
+
+/**
+ * Shared sign-in form body: Google button + magic-link / password tabs.
+ *
+ * Used both by the full-page `SignInPage` and the in-place `SignInModal`.
+ * The only context-dependent behaviour is what happens on success:
+ *   - full page → `window.location.href = callbackURL`
+ *   - modal     → `onSuccess()` (close + revalidate, no navigation)
+ *
+ * Google sign-in always uses the plain top-level redirect flow on every
+ * platform — including iOS PWA. The earlier popup flow was removed because
+ * `window.open` on iOS always opens Safari/SFSafariViewController, which has
+ * a separate cookie jar from the standalone PWA, so the session cookie was
+ * lost. A same-window top-level redirect stays inside the PWA's browsing
+ * context on iOS 16.4+.
+ *
+ * ponytail: iOS < 16.4 may still hand the cross-origin Google redirect to
+ * Safari (cookie lost). Those users fall back to email/password. Upgrade
+ * path: Sign in with Apple JS (in-jar, needs Apple Developer credentials).
+ */
+export function SignInForm({ callbackURL, onSuccess, showSignUpLink = true }: SignInFormProps) {
+  const t = useT();
+  const [tab, setTab] = useState(0);
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [unverified, setUnverified] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [magicLinkSent, setMagicLinkSent] = useState(false);
+
+  const handlePasswordSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setUnverified(false);
+    setLoading(true);
+    try {
+      const result = await signIn.email({ email, password });
+      if (result.error) {
+        const code = (result.error.code ?? "").toUpperCase();
+        if (code === "EMAIL_NOT_VERIFIED") {
+          setUnverified(true);
+          setError(t("emailNotVerified"));
+        } else {
+          setError(t("authError"));
+        }
+      } else if (onSuccess) {
+        onSuccess();
+      } else {
+        window.location.href = callbackURL;
+      }
+    } catch {
+      setError(t("authError"));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleMagicLinkSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setMagicLinkSent(false);
+    setLoading(true);
+    try {
+      const result = await signIn.magicLink({ email, callbackURL });
+      if (result.error) {
+        setError(t("magicLinkError"));
+      } else {
+        setMagicLinkSent(true);
+      }
+    } catch {
+      setError(t("magicLinkError"));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleGoogleSignIn = async () => {
+    // Plain top-level redirect on every platform (see component doc comment).
+    await signIn.social({ provider: "google", callbackURL });
+  };
+
+  const handleTabChange = (_: React.SyntheticEvent, newValue: number) => {
+    setTab(newValue);
+    setError(null);
+    setUnverified(false);
+    setMagicLinkSent(false);
+  };
+
+  return (
+    <Stack spacing={3}>
+      {error && <Alert severity="error">{error}</Alert>}
+      {unverified && email && (
+        <Alert severity="info">
+          <Link href={`/auth/verify-email?email=${encodeURIComponent(email)}`} underline="hover">
+            {t("resendVerification")}
+          </Link>
+        </Alert>
+      )}
+      {magicLinkSent && (
+        <Alert severity="success">
+          {t("magicLinkSent").replace("{email}", email)}
+        </Alert>
+      )}
+
+      <Button
+        variant="outlined"
+        size="large"
+        fullWidth
+        startIcon={<GoogleIcon />}
+        onClick={handleGoogleSignIn}
+        type="button"
+        data-testid="google-signin"
+      >
+        {t("signInWithGoogle")}
+      </Button>
+
+      <Divider>{t("or")}</Divider>
+
+      <Tabs value={tab} onChange={handleTabChange} variant="fullWidth" sx={{ minHeight: 40 }}>
+        <Tab
+          icon={<EmailIcon sx={{ fontSize: 18 }} />}
+          iconPosition="start"
+          label={t("signInWithEmail")}
+          sx={{ minHeight: 40, textTransform: "none" }}
+        />
+        <Tab label={t("signInWithPassword")} sx={{ minHeight: 40, textTransform: "none" }} />
+      </Tabs>
+
+      {/* Magic link tab */}
+      <TabPanel value={tab} index={0}>
+        <Stack spacing={3} component="form" action="#" method="post" onSubmit={handleMagicLinkSubmit}>
+          <TextField
+            label={t("email")}
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+            fullWidth
+            autoComplete="email"
+          />
+          <Button type="submit" variant="contained" size="large" disabled={loading || magicLinkSent} fullWidth>
+            {loading ? t("sendingMagicLink") : t("magicLinkBtn")}
+          </Button>
+        </Stack>
+      </TabPanel>
+
+      {/* Password tab */}
+      <TabPanel value={tab} index={1}>
+        <Stack spacing={3} component="form" action="#" method="post" onSubmit={handlePasswordSubmit}>
+          <TextField
+            label={t("email")}
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+            fullWidth
+            autoComplete="email"
+          />
+          <TextField
+            label={t("password")}
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+            fullWidth
+            autoComplete="current-password"
+          />
+          <Button type="submit" variant="contained" size="large" disabled={loading} fullWidth>
+            {loading ? t("signingIn") : t("signIn")}
+          </Button>
+        </Stack>
+      </TabPanel>
+
+      {showSignUpLink && (
+        <Box textAlign="center">
+          <Link href={`/auth/signup?callbackURL=${encodeURIComponent(callbackURL)}`} underline="hover" variant="body2">
+            {t("noAccount")} {t("signUp")}
+          </Link>
+        </Box>
+      )}
+    </Stack>
+  );
+}

--- a/src/components/SignInModal.tsx
+++ b/src/components/SignInModal.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import { Dialog, DialogTitle, DialogContent, IconButton, Box } from "@mui/material";
+import CloseIcon from "@mui/icons-material/Close";
+import { SignInForm } from "./SignInForm";
+import { useT } from "~/lib/useT";
+
+export interface SignInModalProps {
+  open: boolean;
+  onClose: () => void;
+  /**
+   * Where Google redirect returns to / where to consider "done". For in-place
+   * login on an event page this is the current path, so the user lands back on
+   * the same event after the Google round-trip.
+   */
+  callbackURL: string;
+  /**
+   * Called after a successful email/password sign-in. The caller should close
+   * the dialog and revalidate the session (no navigation needed — the user
+   * stays on the current page).
+   */
+  onSuccess: () => void;
+}
+
+/**
+ * In-place sign-in dialog. Lets a signed-out user log in without leaving the
+ * page they're on (e.g. an event page). Email/password resolves entirely in
+ * place via `onSuccess`; Google uses the same top-level redirect as the full
+ * page but returns to `callbackURL` (the current path).
+ */
+export function SignInModal({ open, onClose, callbackURL, onSuccess }: SignInModalProps) {
+  const t = useT();
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogTitle sx={{ pr: 6 }}>
+        {t("signIn")}
+        <IconButton
+          aria-label={t("dismiss")}
+          onClick={onClose}
+          sx={{ position: "absolute", right: 8, top: 8 }}
+        >
+          <CloseIcon />
+        </IconButton>
+      </DialogTitle>
+      <DialogContent>
+        <Box sx={{ pt: 1 }}>
+          <SignInForm callbackURL={callbackURL} onSuccess={onSuccess} />
+        </Box>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/SignInPage.tsx
+++ b/src/components/SignInPage.tsx
@@ -1,43 +1,14 @@
-import React, { useState } from "react";
-import {
-  Container, Paper, Typography, TextField, Button, Stack, Alert, Link, Divider, Tabs, Tab, Box,
-} from "@mui/material";
-import GoogleIcon from "@mui/icons-material/Google";
-import EmailIcon from "@mui/icons-material/Email";
+import React from "react";
+import { Container, Paper, Typography, Stack, Box, Button } from "@mui/material";
 import { ThemeModeProvider } from "./ThemeModeProvider";
 import { ResponsiveLayout } from "./ResponsiveLayout";
+import { SignInForm } from "./SignInForm";
 import { useT } from "~/lib/useT";
-import { signIn, useSession } from "~/lib/auth.client";
-import { isIosPwa } from "~/lib/pwaDetect";
-
-function TabPanel({ children, value, index }: { children: React.ReactNode; value: number; index: number }) {
-  return value === index ? <Box>{children}</Box> : null;
-}
+import { useSession } from "~/lib/auth.client";
 
 export default function SignInPage() {
   const t = useT();
   const { data: session, isPending } = useSession();
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
-  const [error, setError] = useState<string | null>(null);
-  const [unverified, setUnverified] = useState(false);
-  const [loading, setLoading] = useState(false);
-  const [magicLinkSent, setMagicLinkSent] = useState(false);
-
-  // iOS PWA detection: on iOS the PWA and Safari have separate cookie jars,
-  // so any auth flow that opens a different browser context (Google OAuth
-  // redirect, magic link email, Apple popup) sets the session cookie in
-  // Safari's jar — the PWA stays logged out. The ONLY sign-in method that
-  // works on iOS PWA is the email/password form (same-origin POST).
-  //
-  // On iOS PWA we:
-  // - hide Google sign-in and the magic-link tab (they don't work)
-  // - default to the password tab so the user lands on the working option
-  // - skip the misleading "popup will open" notice from the previous attempt
-  const iosPwa = typeof window !== "undefined" && isIosPwa();
-  // Tab state is only used on non-iOS-PWA (where the tabbed UI is shown).
-  // iOS PWA renders the password form directly without tabs.
-  const [tab, setTab] = useState(0);
 
   const rawCallback = typeof window !== "undefined"
     ? new URLSearchParams(window.location.search).get("callbackURL") || "/"
@@ -51,11 +22,8 @@ export default function SignInPage() {
   if (typeof window !== "undefined" && !hasCallbackURL) {
     // ADR-0012: missing callbackURL means the user landed on /auth/signin without
     // a deep-link entry point — they'll be redirected to /dashboard after signin.
-    // Log so the upstream link rot (push notification, share link, email link) is visible.
     console.warn("[SignInPage] no callbackURL on /auth/signin — post-login destination will fall back to /dashboard");
   }
-
-  // iOS PWA detection moved above (needed before useState for the default tab).
 
   // Compute the safe post-login destination
   const postLoginURL = callbackURL === "/" ? "/dashboard" : callbackURL;
@@ -67,65 +35,6 @@ export default function SignInPage() {
     }
   }, [isPending, session, postLoginURL]);
 
-  const handlePasswordSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setError(null);
-    setUnverified(false);
-    setLoading(true);
-    try {
-      const result = await signIn.email({ email, password });
-      if (result.error) {
-        const code = (result.error.code ?? "").toUpperCase();
-        if (code === "EMAIL_NOT_VERIFIED") {
-          setUnverified(true);
-          setError(t("emailNotVerified"));
-        } else {
-          setError(t("authError"));
-        }
-      } else {
-        window.location.href = postLoginURL;
-      }
-    } catch {
-      setError(t("authError"));
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const handleMagicLinkSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setError(null);
-    setMagicLinkSent(false);
-    setLoading(true);
-    try {
-      const result = await signIn.magicLink({ email, callbackURL });
-      if (result.error) {
-        setError(t("magicLinkError"));
-      } else {
-        setMagicLinkSent(true);
-      }
-    } catch {
-      setError(t("magicLinkError"));
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const handleGoogleSignIn = async () => {
-    // Google sign-in is not available on iOS PWA (the button is hidden in
-    // the render below). On desktop and regular mobile Safari the standard
-    // redirect flow works — the callback lands in the same browser context,
-    // so the session cookie is set in the right jar.
-    await signIn.social({ provider: "google", callbackURL });
-  };
-
-  const handleTabChange = (_: React.SyntheticEvent, newValue: number) => {
-    setTab(newValue);
-    setError(null);
-    setUnverified(false);
-    setMagicLinkSent(false);
-  };
-
   return (
     <ThemeModeProvider>
       <ResponsiveLayout>
@@ -136,191 +45,15 @@ export default function SignInPage() {
                 {t("signIn")}
               </Typography>
 
-              {error && <Alert severity="error">{error}</Alert>}
-              {unverified && email && (
-                <Alert severity="info">
-                  <Link href={`/auth/verify-email?email=${encodeURIComponent(email)}`} underline="hover">
-                    {t("resendVerification")}
-                  </Link>
-                </Alert>
-              )}
-              {magicLinkSent && (
-                <Alert severity="success">
-                  {t("magicLinkSent").replace("{email}", email)}
-                </Alert>
-              )}
-
-              {!iosPwa && (
-                <>
-                  <Button
-                    variant="outlined"
-                    size="large"
-                    fullWidth
-                    startIcon={<GoogleIcon />}
-                    onClick={handleGoogleSignIn}
-                    type="button"
-                    data-testid="google-signin"
-                  >
-                    {t("signInWithGoogle")}
-                  </Button>
-                  <Divider>{t("or")}</Divider>
-                </>
-              )}
-
-              {/* iOS PWA only shows the password tab — Google and magic link
-                  open Safari for auth, and Safari's cookie jar is separate
-                  from the PWA's, so the session would never reach the PWA.
-                  The Tabs bar is skipped entirely on iOS PWA since there's
-                  only one option. */}
-              {!iosPwa && (
-                <Tabs
-                  value={tab}
-                  onChange={handleTabChange}
-                  variant="fullWidth"
-                  sx={{ minHeight: 40 }}
-                >
-                  <Tab
-                    icon={<EmailIcon sx={{ fontSize: 18 }} />}
-                    iconPosition="start"
-                    label={t("signInWithEmail")}
-                    sx={{ minHeight: 40, textTransform: "none" }}
-                  />
-                  <Tab
-                    label={t("signInWithPassword")}
-                    sx={{ minHeight: 40, textTransform: "none" }}
-                  />
-                </Tabs>
-              )}
-
-              {/* iOS PWA: render only the password form (the only auth method
-                  that works due to cookie-jar isolation). On all other
-                  platforms, use the tabbed interface with both options. */}
-              {iosPwa ? (
-                <Stack
-                  spacing={3}
-                  component="form"
-                  action="#"
-                  method="post"
-                  onSubmit={handlePasswordSubmit}
-                  data-testid="ios-pwa-password-form"
-                >
-                  <TextField
-                    label={t("email")}
-                    type="email"
-                    value={email}
-                    onChange={(e) => setEmail(e.target.value)}
-                    required
-                    fullWidth
-                    autoComplete="email"
-                    autoFocus
-                  />
-                  <TextField
-                    label={t("password")}
-                    type="password"
-                    value={password}
-                    onChange={(e) => setPassword(e.target.value)}
-                    required
-                    fullWidth
-                    autoComplete="current-password"
-                  />
-                  <Button
-                    type="submit"
-                    variant="contained"
-                    size="large"
-                    disabled={loading}
-                    fullWidth
-                  >
-                    {loading ? t("signingIn") : t("signIn")}
-                  </Button>
-                </Stack>
-              ) : (
-                <>
-                  {/* Magic link tab */}
-                  <TabPanel value={tab} index={0}>
-                    <Stack spacing={3} component="form" action="#" method="post" onSubmit={handleMagicLinkSubmit}>
-                      <Typography variant="body2" color="text.secondary">
-                        {t("magicLinkDesc")}
-                      </Typography>
-                      <TextField
-                        label={t("email")}
-                        type="email"
-                        value={email}
-                        onChange={(e) => setEmail(e.target.value)}
-                        required
-                        fullWidth
-                        autoComplete="email"
-                        autoFocus
-                      />
-                      <Button
-                        type="submit"
-                        variant="contained"
-                        size="large"
-                        disabled={loading || magicLinkSent}
-                        fullWidth
-                      >
-                        {loading ? t("sendingMagicLink") : t("magicLinkBtn")}
-                      </Button>
-                    </Stack>
-                  </TabPanel>
-
-                  {/* Password tab */}
-                  <TabPanel value={tab} index={1}>
-                    <Stack spacing={3} component="form" action="#" method="post" onSubmit={handlePasswordSubmit}>
-                      <TextField
-                        label={t("email")}
-                        type="email"
-                        value={email}
-                        onChange={(e) => setEmail(e.target.value)}
-                        required
-                        fullWidth
-                        autoComplete="email"
-                        autoFocus
-                      />
-                      <TextField
-                        label={t("password")}
-                        type="password"
-                        value={password}
-                        onChange={(e) => setPassword(e.target.value)}
-                        required
-                        fullWidth
-                        autoComplete="current-password"
-                      />
-                      <Button
-                        type="submit"
-                        variant="contained"
-                        size="large"
-                        disabled={loading}
-                        fullWidth
-                      >
-                        {loading ? t("signingIn") : t("signIn")}
-                      </Button>
-                    </Stack>
-                  </TabPanel>
-                </>
-              )}
-
-              <Typography variant="body2" textAlign="center" color="text.secondary">
-                {t("noAccount")}{" "}
-                <Link href={`/auth/signup?callbackURL=${encodeURIComponent(callbackURL)}`} underline="hover">
-                  {t("signUp")}
-                </Link>
-              </Typography>
+              <SignInForm callbackURL={postLoginURL} />
 
               {/* ADR-0012 + #506: when the user lands on /auth/signin without a
                   callbackURL (no deep-link entry point, stale bookmark, etc.)
-                  we silently redirect to /dashboard after signin. Many users
-                  are landing here from the "main page" signin link and
-                  expecting to go back to a specific event. Surface the
-                  common destinations explicitly so they can pick. */}
+                  surface the common destinations explicitly so they can pick. */}
               {!hasCallbackURL && (
                 <Box
                   data-testid="post-login-fallback"
-                  sx={{
-                    border: 1,
-                    borderColor: "divider",
-                    borderRadius: 2,
-                    p: 2,
-                  }}
+                  sx={{ border: 1, borderColor: "divider", borderRadius: 2, p: 2 }}
                 >
                   <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
                     {t("signInNoDestination")}

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -338,7 +338,6 @@ const de: TranslationKeys = {
   docs: "Docs",
   signInWithGoogle: "Mit Google anmelden",
   signInNoDestination: "Wohin möchtest du nach der Anmeldung?",
-  signInIosPwaNotice: "Du verwendest die auf deinem iPhone installierte Convocados-App. Die Google-Anmeldung öffnet ein Fenster — schließe sie dort ab, und du wirst automatisch hierher zurückgebracht.",
   signUpWithGoogle: "Mit Google registrieren",
   or: "oder",
   checkYourEmail: "Prüfe deine E-Mail",

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -380,7 +380,6 @@ const en = {
 
   // Social auth
   signInWithGoogle: "Sign in with Google",
-  signInIosPwaNotice: "You're using the Convocados app installed on your iPhone. Google sign-in will open a window — complete it there, and you'll be brought back here to the app.",
   signInNoDestination: "After signing in, where do you want to go?",
   dashboard: "Dashboard",
   signUpWithGoogle: "Sign up with Google",

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -338,7 +338,6 @@ const es: TranslationKeys = {
   docs: "Docs",
   signInWithGoogle: "Iniciar sesión con Google",
   signInNoDestination: "Después de iniciar sesión, ¿a dónde quieres ir?",
-  signInIosPwaNotice: "Estás usando la app Convocados instalada en tu iPhone. El login con Google abrirá una ventana — complétalo allí y volverás automáticamente aquí.",
   signUpWithGoogle: "Registrarse con Google",
   or: "o",
   checkYourEmail: "Revisa tu email",

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -338,7 +338,6 @@ const fr: TranslationKeys = {
   docs: "Docs",
   signInWithGoogle: "Se connecter avec Google",
   signInNoDestination: "Après la connexion, où voulez-vous aller ?",
-  signInIosPwaNotice: "Vous utilisez l'app Convocados installée sur votre iPhone. La connexion Google ouvrira une fenêtre — complétez-la là-bas, et vous reviendrez automatiquement ici.",
   signUpWithGoogle: "S'inscrire avec Google",
   or: "ou",
   checkYourEmail: "Vérifie ton email",

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -338,7 +338,6 @@ const it: TranslationKeys = {
   docs: "Docs",
   signInWithGoogle: "Accedi con Google",
   signInNoDestination: "Dopo l'accesso, dove vuoi andare?",
-  signInIosPwaNotice: "Stai usando l'app Convocados installata sul tuo iPhone. L'accesso con Google aprirà una finestra — completalo lì, e tornerai automaticamente qui.",
   signUpWithGoogle: "Registrati con Google",
   or: "o",
   checkYourEmail: "Controlla la tua email",

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -383,7 +383,6 @@ const pt: TranslationKeys = {
   // Social auth
   signInWithGoogle: "Entrar com Google",
   signInNoDestination: "Depois de iniciar sessão, para onde queres ir?",
-  signInIosPwaNotice: "Estás a usar a app Convocados instalada no teu iPhone. O login com Google vai abrir uma janela — completa-o lá, e voltas automaticamente para aqui.",
   signUpWithGoogle: "Registar com Google",
   or: "ou",
 

--- a/src/test/components/SignInModal.test.tsx
+++ b/src/test/components/SignInModal.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React from "react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+
+const mockSignInEmail = vi.fn();
+const mockSignInMagicLink = vi.fn();
+const mockSignInSocial = vi.fn();
+
+vi.mock("~/lib/auth.client", () => ({
+  signIn: {
+    email: (...args: unknown[]) => mockSignInEmail(...args),
+    magicLink: (...args: unknown[]) => mockSignInMagicLink(...args),
+    social: (...args: unknown[]) => mockSignInSocial(...args),
+  },
+}));
+
+vi.mock("~/lib/useT", () => ({
+  useT: () => (key: string) => key,
+  useLocale: () => ({ locale: "en", setLocale: () => {}, t: (key: string) => key }),
+}));
+
+import { SignInModal } from "~/components/SignInModal";
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+beforeEach(() => {
+  mockSignInEmail.mockResolvedValue({ error: null });
+  mockSignInMagicLink.mockResolvedValue({ error: null });
+  mockSignInSocial.mockResolvedValue({ redirect: true, url: "https://google.test" });
+});
+
+describe("SignInModal", () => {
+  it("does not render its content when closed", () => {
+    render(<SignInModal open={false} onClose={() => {}} callbackURL="/events/abc" onSuccess={() => {}} />);
+    expect(screen.queryByTestId("google-signin")).toBeNull();
+  });
+
+  it("renders the shared sign-in form when open", () => {
+    render(<SignInModal open onClose={() => {}} callbackURL="/events/abc" onSuccess={() => {}} />);
+    expect(screen.getByTestId("google-signin")).toBeInTheDocument();
+  });
+
+  it("Google sign-in uses the plain redirect flow with the given callbackURL (returns to the same page)", async () => {
+    const { default: userEvent } = await import("@testing-library/user-event");
+    const user = userEvent.setup();
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(null);
+    render(<SignInModal open onClose={() => {}} callbackURL="/events/abc" onSuccess={() => {}} />);
+
+    await user.click(screen.getByTestId("google-signin"));
+
+    expect(mockSignInSocial).toHaveBeenCalledWith({ provider: "google", callbackURL: "/events/abc" });
+    expect(openSpy).not.toHaveBeenCalled();
+    openSpy.mockRestore();
+  });
+
+  it("on successful email/password sign-in, calls onSuccess and does NOT navigate", async () => {
+    const { default: userEvent } = await import("@testing-library/user-event");
+    const user = userEvent.setup();
+    const onSuccess = vi.fn();
+    render(<SignInModal open onClose={() => {}} callbackURL="/events/abc" onSuccess={onSuccess} />);
+
+    // Switch to the password tab
+    await user.click(screen.getByRole("tab", { name: /signInWithPassword/ }));
+
+    const inputs = screen.getAllByRole("textbox"); // email field
+    await user.type(inputs[0], "a@b.com");
+    // password field is not a textbox role (type=password) — grab by label
+    const pwd = document.querySelector('input[type="password"]') as HTMLInputElement;
+    await user.type(pwd, "secret");
+
+    await user.click(screen.getByRole("button", { name: /^signIn$/ }));
+
+    await waitFor(() => expect(onSuccess).toHaveBeenCalled());
+    expect(mockSignInEmail).toHaveBeenCalledWith({ email: "a@b.com", password: "secret" });
+  });
+});

--- a/src/test/components/SignInPage.iosPwa.test.tsx
+++ b/src/test/components/SignInPage.iosPwa.test.tsx
@@ -54,56 +54,47 @@ beforeEach(() => {
   vi.mocked(isIosSafariStandalone).mockReturnValue(false);
 });
 
-describe("SignInPage — iOS PWA auth options", () => {
-  it("shows the Google sign-in button on desktop browsers", () => {
+describe("SignInPage — iOS PWA Google sign-in", () => {
+  it("keeps the Google sign-in button on iOS PWA", () => {
+    vi.mocked(isIosPwa).mockReturnValue(true);
     renderAtUrl("/auth/signin?callbackURL=/events/abc");
     expect(screen.getByRole("button", { name: /signInWithGoogle/ })).toBeInTheDocument();
   });
 
-  it("hides the Google sign-in button on iOS PWA (cookie jar isolation makes it non-functional)", () => {
-    vi.mocked(isIosPwa).mockReturnValue(true);
+  it("keeps the Google sign-in button on desktop browsers", () => {
     renderAtUrl("/auth/signin?callbackURL=/events/abc");
-    expect(screen.queryByRole("button", { name: /signInWithGoogle/ })).toBeNull();
+    expect(screen.getByRole("button", { name: /signInWithGoogle/ })).toBeInTheDocument();
   });
 
-  it("hides the Google sign-in button on iOS PWA even without callbackURL", () => {
-    vi.mocked(isIosPwa).mockReturnValue(true);
-    renderAtUrl("/auth/signin");
-    expect(screen.queryByRole("button", { name: /signInWithGoogle/ })).toBeNull();
-  });
-
-  it("hides the magic link tab on iOS PWA (magic link email opens Safari, same jar problem)", () => {
-    vi.mocked(isIosPwa).mockReturnValue(true);
-    renderAtUrl("/auth/signin?callbackURL=/events/abc");
-    // The "Sign in with Email" tab (magic link) should not be present
-    expect(screen.queryByRole("tab", { name: /signInWithEmail/ })).toBeNull();
-  });
-
-  it("shows the password tab on iOS PWA (same-origin form submit works)", () => {
-    vi.mocked(isIosPwa).mockReturnValue(true);
-    renderAtUrl("/auth/signin?callbackURL=/events/abc");
-    // The iOS PWA password form should be present
-    expect(screen.getByTestId("ios-pwa-password-form")).toBeInTheDocument();
-    // The Tabs bar should not be present on iOS PWA
-    expect(screen.queryByRole("tablist")).toBeNull();
-  });
-
-  it("does NOT show the misleading popup notice on iOS PWA (the user reported this was confusing)", () => {
+  it("does NOT show the old misleading iOS PWA popup notice", () => {
     vi.mocked(isIosPwa).mockReturnValue(true);
     renderAtUrl("/auth/signin?callbackURL=/events/abc");
     expect(screen.queryByTestId("ios-pwa-notice")).toBeNull();
   });
 
-  it("does NOT show the misleading popup notice on desktop either", () => {
-    renderAtUrl("/auth/signin?callbackURL=/events/abc");
-    expect(screen.queryByTestId("ios-pwa-notice")).toBeNull();
-  });
-});
-
-describe("SignInPage — Google sign-in default redirect flow", () => {
-  it("on desktop, clicking Google sign-in calls signIn.social with the callbackURL", async () => {
+  it("on iOS PWA, clicking Google uses the plain top-level redirect flow (no disableRedirect, no popup)", async () => {
     const { default: userEvent } = await import("@testing-library/user-event");
     const user = userEvent.setup();
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(null);
+    vi.mocked(isIosPwa).mockReturnValue(true);
+    renderAtUrl("/auth/signin?callbackURL=/events/abc");
+
+    await user.click(screen.getByRole("button", { name: /signInWithGoogle/ }));
+
+    // Same path as web/Android: redirect flow, no popup, no disableRedirect.
+    expect(mockSignInSocial).toHaveBeenCalledWith({
+      provider: "google",
+      callbackURL: "/events/abc",
+    });
+    expect(openSpy).not.toHaveBeenCalled();
+    openSpy.mockRestore();
+  });
+
+  it("on desktop, clicking Google uses the same redirect flow (no popup)", async () => {
+    const { default: userEvent } = await import("@testing-library/user-event");
+    const user = userEvent.setup();
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(null);
+    vi.mocked(isIosPwa).mockReturnValue(false);
     renderAtUrl("/auth/signin?callbackURL=/events/abc");
 
     await user.click(screen.getByRole("button", { name: /signInWithGoogle/ }));
@@ -112,16 +103,6 @@ describe("SignInPage — Google sign-in default redirect flow", () => {
       provider: "google",
       callbackURL: "/events/abc",
     });
-  });
-
-  it("on desktop, does not open a popup window (default redirect flow)", async () => {
-    const { default: userEvent } = await import("@testing-library/user-event");
-    const user = userEvent.setup();
-    const openSpy = vi.spyOn(window, "open").mockReturnValue(null);
-    renderAtUrl("/auth/signin?callbackURL=/events/abc");
-
-    await user.click(screen.getByRole("button", { name: /signInWithGoogle/ }));
-
     expect(openSpy).not.toHaveBeenCalled();
     openSpy.mockRestore();
   });
@@ -129,12 +110,7 @@ describe("SignInPage — Google sign-in default redirect flow", () => {
 
 describe("SignInPage — post-auth destination fallback", () => {
   it("includes a 'where do you want to go?' fallback UI when callbackURL is missing after signin", () => {
-    // This addresses the user report: "I'm sent to the main page instead of the event"
-    // When callbackURL is missing, the user should see a picker, not be silently
-    // redirected to /dashboard.
     renderAtUrl("/auth/signin");
-    // After signin without callbackURL, the page should provide fallback links
-    // (Dashboard + Public Games) instead of just auto-redirecting.
     const fallback = screen.getByTestId("post-login-fallback");
     expect(fallback).toBeInTheDocument();
     expect(fallback.querySelector("a[href='/dashboard']")).toBeTruthy();
@@ -143,14 +119,6 @@ describe("SignInPage — post-auth destination fallback", () => {
 
   it("does NOT show the fallback when callbackURL is present (the redirect will go to callbackURL)", () => {
     renderAtUrl("/auth/signin?callbackURL=/events/abc");
-    // The fallback is for the "no destination" case; with a callbackURL,
-    // the redirect will handle it.
     expect(screen.queryByTestId("post-login-fallback")).toBeNull();
-  });
-
-  it("shows the fallback on iOS PWA too (the picker is auth-method-agnostic)", () => {
-    vi.mocked(isIosPwa).mockReturnValue(true);
-    renderAtUrl("/auth/signin");
-    expect(screen.getByTestId("post-login-fallback")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

Two related fixes so users (including Google-only users) can actually log in everywhere.

### Part A — re-enable Google sign-in on iOS PWA, correctly
The popup flow from #508 could never work: `window.open` on iOS always opens Safari / SFSafariViewController, which has a **separate cookie jar** from the standalone PWA. The session cookie landed in Safari's jar, so the PWA stayed logged out.

- Drop the popup + `disableRedirect` + poll logic.
- Use the same plain **top-level redirect** (`signIn.social`) on every platform. On iOS 16.4+ a same-window top-level navigation stays inside the PWA's browsing context, so the cookie sticks.
- Remove the misleading "Google sign-in opens Safari" notice and its `signInIosPwaNotice` i18n key (all 6 locales).

### Part B — sign in without leaving the page
Answers the UX request: open an event, click sign in, end up back on the **same** event logged in.

- Extract `SignInForm` (shared body) from `SignInPage`.
- New `SignInModal` wrapping it in a MUI `Dialog`.
- The app-bar **Sign in** button now opens the modal instead of navigating to `/auth/signin`. Email/password resolves **in place** (close + `refetch` session, no navigation). Google redirect returns to the current path.
- `/auth/signin` route kept as a fallback for deep links / push notifications.

This also removes the root cause of the `callbackURL`-loss problem for the common case — the modal never navigates away for email/password.

## Known limitation
`ponytail:` iOS < 16.4 may still hand the Google cross-origin redirect to Safari (cookie lost). Those users fall back to email/password. Upgrade path: Sign in with Apple JS (in-jar, requires Apple Developer credentials).

## Tested
- `npm run typecheck` — clean
- `npm run lint` — 0 errors, 54 warnings (< 530)
- `npm run test` (full suite, coverage) — 2778 pass, 4 skipped, 0 fail
- New tests: `SignInModal.test.tsx` (4), rewritten `SignInPage.iosPwa.test.tsx` (redirect flow, no popup, no notice)

Closes #506