### PR TITLE
fix: canonical-host redirect (both domains work) + dismissible update banner

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -6,6 +6,12 @@ self.addEventListener("message", (event) => {
   if (event.data === "SKIP_WAITING") self.skipWaiting();
 });
 
+// Take control of open pages as soon as this worker activates, so the page's
+// `controllerchange` listener fires and the app reloads onto the new build.
+self.addEventListener("activate", (event) => {
+  event.waitUntil(self.clients.claim());
+});
+
 self.addEventListener("push", (event) => {
   const data = event.data ? event.data.json() : {};
   const title = data.title ?? "Convocados";

--- a/src/components/ResponsiveLayout.tsx
+++ b/src/components/ResponsiveLayout.tsx
@@ -111,6 +111,15 @@ function UpdateBanner() {
       };
       add(reg, "updatefound", onUpdateFound);
     });
+    // Reload once the new service worker takes control — the reliable signal
+    // that the update has activated (covers browsers where the per-worker
+    // statechange handler in handleUpdate doesn't fire as expected).
+    let reloaded = false;
+    add(navigator.serviceWorker, "controllerchange", () => {
+      if (reloaded) return;
+      reloaded = true;
+      window.location.reload();
+    });
     return () => {
       cancelled = true;
       for (const { target, type, listener } of registrations) {
@@ -119,40 +128,62 @@ function UpdateBanner() {
     };
   }, []);
 
-  if (!waiting) return null;
+  const [dismissed, setDismissed] = useState(false);
+
+  if (!waiting || dismissed) return null;
 
   const handleUpdate = () => {
     waiting.postMessage("SKIP_WAITING");
-    waiting.addEventListener("statechange", () => {
-      if (waiting.state === "activated") window.location.reload();
-    });
+    // The controllerchange listener (registered in the effect) reloads as soon
+    // as the new worker takes control. This timeout is a last-resort fallback.
+    // ponytail: 3s heuristic — if the SW never activates we reload anyway so
+    // the user is never stuck on a stale build.
+    setTimeout(() => window.location.reload(), 3000);
   };
 
   const versionText = typeof __APP_VERSION__ !== "undefined"
     ? t("versionAvailable").replace("{version}", __APP_VERSION__)
     : t("updateAvailable");
 
+  // Bottom-anchored slim bar (shares the bottom slot with the install banner
+  // and never overlaps the app bar). Sits just above the install banner if
+  // both happen to show.
   return (
-    <Slide in direction="down">
-      <Paper elevation={4} sx={{
-        position: "fixed", top: 64, left: "50%", transform: "translateX(-50%)",
-        zIndex: theme.zIndex.snackbar,
-        display: "flex", alignItems: "center", gap: 2,
-        px: 3, py: 1.5, borderRadius: 3,
+    <Slide in direction="up">
+      <Paper elevation={6} sx={{
+        position: "fixed",
+        bottom: { xs: 0, sm: 16 },
+        left: { xs: 0, sm: "50%" },
+        right: { xs: 0, sm: "auto" },
+        transform: { sm: "translateX(-50%)" },
+        zIndex: theme.zIndex.snackbar + 1,
+        display: "flex", alignItems: "center", gap: 1.5,
+        px: 2, py: 1.25,
+        borderRadius: { xs: "16px 16px 0 0", sm: 3 },
+        maxWidth: "100%",
         backgroundColor: theme.palette.primary.main,
         color: theme.palette.primary.contrastText,
-        whiteSpace: "nowrap",
       }}>
-        <SystemUpdateAltIcon fontSize="small" />
-        <Typography variant="body2" fontWeight={600}>{versionText}</Typography>
+        <SystemUpdateAltIcon fontSize="small" sx={{ flexShrink: 0 }} />
+        <Typography variant="body2" fontWeight={600} sx={{ flex: 1, minWidth: 0 }} noWrap>
+          {versionText}
+        </Typography>
         <Button size="small" variant="contained" onClick={handleUpdate} sx={{
           backgroundColor: theme.palette.primary.contrastText,
           color: theme.palette.primary.main,
           "&:hover": { backgroundColor: theme.palette.primary.contrastText, opacity: 0.9 },
-          fontWeight: 700, ml: 1,
+          fontWeight: 700, flexShrink: 0,
         }}>
           {t("updateNow")}
         </Button>
+        <IconButton
+          size="small"
+          onClick={() => setDismissed(true)}
+          aria-label={t("installDismiss")}
+          sx={{ color: theme.palette.primary.contrastText, flexShrink: 0 }}
+        >
+          <CloseIcon fontSize="small" />
+        </IconButton>
       </Paper>
     </Slide>
   );
@@ -171,6 +202,14 @@ function InstallBanner() {
   useEffect(() => {
     // Don't show if already installed or recently dismissed
     if (isStandalone() || isDismissed()) return;
+
+    // Yield the bottom slot to the update banner when an app update is pending
+    // — they share the same anchor and we never want both at once.
+    if ("serviceWorker" in navigator) {
+      navigator.serviceWorker.getRegistration().then((reg) => {
+        if (reg?.waiting) setShowBanner(false);
+      }).catch(() => {});
+    }
 
     if (typeof Notification !== "undefined") {
       setPermission(Notification.permission);

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -47,6 +47,49 @@ const SECURITY_HEADERS: Record<string, string> = {
   ].join("; "),
 };
 
+/**
+ * If the request arrived on a non-canonical host, return a redirect Response
+ * to the canonical host (preserving path + query); otherwise null.
+ *
+ * Canonical host comes from BETTER_AUTH_URL. The public host is derived from
+ * proxy headers (Fly terminates TLS and proxies to localhost:3000, so url.host
+ * is the internal address, not what the user typed).
+ *
+ * - GET/HEAD → 301 (permanent, cacheable)
+ * - other methods → 308 (permanent, preserves method + body)
+ * Localhost / hostless requests are never redirected (dev + non-browser).
+ */
+function canonicalHostRedirect(request: Request, url: URL): Response | null {
+  const canonicalUrl = process.env.BETTER_AUTH_URL;
+  if (!canonicalUrl) return null;
+
+  let canonicalHost: string;
+  try {
+    canonicalHost = new URL(canonicalUrl).host;
+  } catch {
+    return null;
+  }
+
+  // If the canonical host is localhost (dev/test), don't redirect anything —
+  // we'd otherwise bounce real traffic to localhost.
+  const canonicalLower = canonicalHost.toLowerCase();
+  if (canonicalLower.startsWith("localhost") || canonicalLower.startsWith("127.0.0.1")) return null;
+
+  const publicHost = (request.headers.get("x-forwarded-host")
+    ?? request.headers.get("host")
+    ?? url.host).toLowerCase();
+
+  if (!publicHost) return null;
+  // Never redirect local dev or the internal proxy address.
+  if (publicHost.startsWith("localhost") || publicHost.startsWith("127.0.0.1")) return null;
+  if (publicHost === canonicalLower) return null;
+
+  const proto = (request.headers.get("x-forwarded-proto") ?? url.protocol.replace(":", "")) || "https";
+  const location = `${proto === "http" ? "https" : proto}://${canonicalHost}${url.pathname}${url.search}`;
+  const status = request.method === "GET" || request.method === "HEAD" ? 301 : 308;
+  return new Response(null, { status, headers: { Location: location } });
+}
+
 function addSecurityHeaders(response: Response): Response {
   try {
     for (const [key, value] of Object.entries(SECURITY_HEADERS)) {
@@ -74,6 +117,15 @@ function addSecurityHeaders(response: Response): Response {
 
 export const onRequest = defineMiddleware(async (context, next) => {
   const { request, url } = context;
+
+  // ── Canonical host redirect (Option B) ────────────────────────────────────
+  // Force a single canonical origin so the session cookie is never split
+  // across domains (e.g. convocados.fly.dev vs convocados.cabeda.dev). Without
+  // this, an OAuth round-trip started on the non-canonical host returns to the
+  // canonical host (BETTER_AUTH_URL) and the cookie lands on the wrong domain,
+  // leaving the user on the main page logged out.
+  const canonicalRedirect = canonicalHostRedirect(request, url);
+  if (canonicalRedirect) return canonicalRedirect;
 
   // Safe methods don't need CSRF protection
   if (SAFE_METHODS.has(request.method)) {

--- a/src/test/middleware.test.ts
+++ b/src/test/middleware.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 // defineMiddleware is just an identity wrapper at runtime.
 vi.mock("astro:middleware", () => ({
@@ -31,5 +31,49 @@ describe("security middleware", () => {
     expect(res.status).toBe(302);
     expect(res.headers.get("location")).toBe("https://convocados.cabeda.dev/auth/signin");
     expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
+  });
+});
+
+describe("canonical host redirect", () => {
+  const ORIGINAL = process.env.BETTER_AUTH_URL;
+  beforeEach(() => { process.env.BETTER_AUTH_URL = "https://convocados.cabeda.dev"; });
+  afterEach(() => {
+    if (ORIGINAL === undefined) delete process.env.BETTER_AUTH_URL;
+    else process.env.BETTER_AUTH_URL = ORIGINAL;
+  });
+
+  it("301-redirects a non-canonical host to the canonical host, preserving path + query", async () => {
+    const res = await run(
+      ctx("GET", "https://convocados.fly.dev/events/abc?x=1"),
+      async () => new Response("should not reach", { status: 200 }),
+    );
+    expect(res.status).toBe(301);
+    expect(res.headers.get("location")).toBe("https://convocados.cabeda.dev/events/abc?x=1");
+  });
+
+  it("does NOT redirect when already on the canonical host", async () => {
+    const res = await run(
+      ctx("GET", "https://convocados.cabeda.dev/events/abc"),
+      async () => new Response("ok", { status: 200 }),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("redirects non-GET methods to the canonical host too (308 to preserve method)", async () => {
+    const res = await run(
+      ctx("POST", "https://convocados.fly.dev/api/events/abc/rsvp"),
+      async () => new Response("should not reach", { status: 200 }),
+    );
+    // 308 preserves the POST method + body on redirect
+    expect(res.status).toBe(308);
+    expect(res.headers.get("location")).toBe("https://convocados.cabeda.dev/api/events/abc/rsvp");
+  });
+
+  it("does not redirect localhost (dev) even if it isn't the canonical host", async () => {
+    const res = await run(
+      ctx("GET", "http://localhost:4321/events/abc"),
+      async () => new Response("ok", { status: 200 }),
+    );
+    expect(res.status).toBe(200);
   });
 });


### PR DESCRIPTION
## Summary

Two fixes.

### 1. Login on both domains — canonical-host redirect (Option B)
Self-hosted better-auth pins the session cookie to `BETTER_AUTH_URL` (`convocados.cabeda.dev`). A cookie can't span two registrable domains, so when the app was reached on **convocados.fly.dev**, the Google OAuth round-trip returned to cabeda.dev, set the cookie there, and the user bounced back to fly.dev's main page **logged out**. (cabeda.dev always worked — same origin as the cookie.)

Fix: middleware now redirects any non-canonical public host to the canonical host (derived from `BETTER_AUTH_URL`), preserving path + query:
- GET/HEAD → **301** (permanent, cacheable)
- other methods → **308** (preserves method + body)

Both domains now "work": fly.dev forwards to cabeda.dev, so there's a single origin, single cookie, single session. No Google Console change needed (canonical redirect URI already registered).

Safety: localhost/dev is never redirected, and a localhost canonical host disables the redirect entirely (prevents bouncing real traffic to localhost in misconfigured envs).

### 2. Update banner — misplaced, undismissable, could get stuck
- Was `position: fixed; top: 64` — overlapped/misplaced on mobile, no safe-area awareness — and had **no dismiss**: once a waiting service worker was detected the bar was stuck until you updated.
- Now a **bottom-anchored** bar (full-width on mobile, centered pill on desktop) that shares the bottom slot with the install banner; the install banner **yields** when an update is pending so they never stack/double up.
- Added a **dismiss (X)** button.
- Reliable reload: SW `controllerchange` + `clients.claim()` in the worker's `activate` handler, plus a 3s fallback so the user is never stuck on a stale build.

## Tested
- `npm run typecheck` — clean
- `npm run lint` — 0 errors, 54 warnings (< 530)
- `npm run test` (full suite, coverage) — 2782 pass, 4 skipped, 0 fail
- 4 new middleware tests: redirect non-canonical host (301), preserve method (308), no-op on canonical host, no-op on localhost

## Note
This does **not** touch the iOS-PWA Google cookie-jar problem (separate, needs the GIS ID-token approach). It fixes the cross-domain login loss in regular Safari/browsers, which was the reported symptom.