### PR TITLE
fix(middleware): exempt /api/health from canonical-host redirect

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -63,6 +63,11 @@ function canonicalHostRedirect(request: Request, url: URL): Response | null {
   const canonicalUrl = process.env.BETTER_AUTH_URL;
   if (!canonicalUrl) return null;
 
+  // Never redirect the health-check endpoint: Fly's internal HTTP check hits
+  // /api/health with a non-public Host (machine IP / *.internal), which would
+  // otherwise be redirected and fail the check, aborting deploys.
+  if (url.pathname === "/api/health") return null;
+
   let canonicalHost: string;
   try {
     canonicalHost = new URL(canonicalUrl).host;

--- a/src/test/middleware.test.ts
+++ b/src/test/middleware.test.ts
@@ -76,4 +76,12 @@ describe("canonical host redirect", () => {
     );
     expect(res.status).toBe(200);
   });
+
+  it("never redirects /api/health (Fly health check hits it with a non-public host)", async () => {
+    const res = await run(
+      ctx("GET", "https://convocados.fly.dev/api/health"),
+      async () => new Response('{"status":"ok"}', { status: 200 }),
+    );
+    expect(res.status).toBe(200);
+  });
 });


### PR DESCRIPTION
## Hotfix

The canonical-host redirect from #513 redirected **all** non-canonical-host requests — including Fly's internal HTTP health check (`GET /api/health`, sent with a non-public `Host`). The check expected 200, got 301, failed (0/1), the deploy aborted, and prod went to **503**.

Fix: exempt `/api/health` from the redirect so health checks always get through. Regression test added.

Already deployed to prod via `fly deploy` to restore service — verified:
- `cabeda.dev/api/health` → 200, `fly.dev/api/health` → 200
- `fly.dev/events/abc` → 301 → `cabeda.dev/events/abc`
- `cabeda.dev/events/abc` → 200

## Tested
- middleware tests: 7 pass (incl. new health-exemption test)
- typecheck clean