### PR TITLE
feat(android): post-game wrap-up banner (settle last game, distinct from next)

### DIFF
--- a/android-app/app/src/main/java/dev/convocados/data/api/ConvocadosApi.kt
+++ b/android-app/app/src/main/java/dev/convocados/data/api/ConvocadosApi.kt
@@ -110,6 +110,22 @@ class ConvocadosApi @Inject constructor(private val client: ApiClient) {
     suspend fun updateScore(eventId: String, historyId: String, scoreOne: Int, scoreTwo: Int): GameHistory =
         client.patch("/api/events/$eventId/history/$historyId", ScoreRequest(scoreOne, scoreTwo))
 
+    /**
+     * Save the PAST game's payment snapshot (owner/admin only, within the
+     * 7-day editable window). Mirrors the web PostGameBanner save: the banner
+     * settles the LAST game, whose payments live on the GameHistory entry —
+     * not the live next-game EventCost.
+     */
+    suspend fun updateHistoryPayments(
+        eventId: String,
+        historyId: String,
+        paymentsSnapshot: List<PaymentSnapshotEntry>,
+    ): GameHistory =
+        client.patch(
+            "/api/events/$eventId/history/$historyId",
+            HistoryPaymentsRequest(paymentsSnapshot),
+        )
+
     // ── Public events ─────────────────────────────────────────────────────
     suspend fun fetchPublicEvents(cursor: String? = null): PaginatedPublicEvents {
         val qs = if (cursor != null) "?cursor=$cursor" else ""
@@ -270,6 +286,7 @@ data class CreateEventRequest(
 @Serializable data class PasswordRequest(val password: String?)
 @Serializable data class PasswordVerifyRequest(val password: String)
 @Serializable data class ScoreRequest(val scoreOne: Int, val scoreTwo: Int)
+@Serializable data class HistoryPaymentsRequest(val paymentsSnapshot: List<PaymentSnapshotEntry>)
 @Serializable data class PaymentUpdateRequest(val playerName: String, val status: String)
 @Serializable data class UpdateTeamsRequest(val teamOnePlayerIds: List<String>, val teamTwoPlayerIds: List<String>)
 @Serializable data class TransferRequest(val targetUserId: String)

--- a/android-app/app/src/main/java/dev/convocados/data/api/Models.kt
+++ b/android-app/app/src/main/java/dev/convocados/data/api/Models.kt
@@ -252,6 +252,27 @@ data class PostGameStatus(
     val costCurrency: String? = null,
     val costAmount: Double? = null,
     val hasPendingPastPayments: Boolean = false,
+    // Payments for the PAST game. After a recurrence reset this comes from the
+    // GameHistory snapshot, NOT the live (next-game) EventCost — so the banner
+    // settles the last game, not the upcoming one.
+    val paymentsSnapshot: List<PaymentSnapshotEntry>? = null,
+    val mvpEnabled: Boolean = false,
+    val mvpComplete: Boolean = true,
+    val paidAggregate: PaidAggregate? = null,
+)
+
+@Serializable
+data class PaymentSnapshotEntry(
+    val playerName: String,
+    val amount: Double = 0.0,
+    val status: String = "pending",
+    val method: String? = null,
+)
+
+@Serializable
+data class PaidAggregate(
+    val paidCount: Int = 0,
+    val totalCount: Int = 0,
 )
 
 @Serializable

--- a/android-app/app/src/main/java/dev/convocados/ui/screen/event/EventDetailScreen.kt
+++ b/android-app/app/src/main/java/dev/convocados/ui/screen/event/EventDetailScreen.kt
@@ -74,6 +74,12 @@ data class EventScreenState(
     val historyCursor: String? = null,
     val knownPlayers: List<KnownPlayer> = emptyList(),
     val postGame: PostGameStatus? = null,
+    // Local, editable copy of the PAST game's payment snapshot for the
+    // post-game banner. Initialized from postGame.paymentsSnapshot; toggled
+    // locally, then saved to the GameHistory entry. Null until status loads.
+    val postGamePayments: List<PaymentSnapshotEntry>? = null,
+    val postGamePaymentsDirty: Boolean = false,
+    val postGameSaving: Boolean = false,
     val error: String? = null,
     val locked: Boolean = false,
     val undoData: UndoData? = null,
@@ -154,8 +160,14 @@ class EventDetailViewModel @Inject constructor(
             val known = runCatching { api.fetchKnownPlayers(eventId) }.getOrNull()?.players ?: emptyList()
             val following = runCatching { api.getFollowState(eventId) }.getOrNull()
             val balance = runCatching { api.fetchBalance(eventId) }.getOrNull()
+            // Seed the editable past-game payment snapshot from the server, but
+            // don't clobber unsaved local edits.
+            val seededPayments = if (_state.value.postGamePaymentsDirty)
+                _state.value.postGamePayments
+            else postGame?.paymentsSnapshot
             _state.value = _state.value.copy(
                 loading = false, refreshing = false, postGame = postGame, knownPlayers = known,
+                postGamePayments = seededPayments,
                 isFollowing = following?.following ?: false,
                 mutePlayerActivity = following?.mutePlayerActivity,
                 muteReminders = following?.muteReminders,
@@ -383,6 +395,44 @@ class EventDetailViewModel @Inject constructor(
         }
     }
 
+    /** Cycle a past-game player's payment status (pending <-> paid) locally. */
+    fun togglePostGamePayment(playerName: String) {
+        val current = _state.value.postGamePayments ?: return
+        val updated = current.map {
+            if (it.playerName == playerName)
+                it.copy(status = if (it.status == "paid") "pending" else "paid")
+            else it
+        }
+        _state.value = _state.value.copy(postGamePayments = updated, postGamePaymentsDirty = true)
+    }
+
+    /**
+     * Persist the edited past-game payment snapshot to the GameHistory entry.
+     * Mirrors the web PostGameBanner save (PATCH .../history/{id} with
+     * paymentsSnapshot). Owner/admin only — surfaces a clear error otherwise.
+     */
+    fun savePostGamePayments(eventId: String) {
+        val historyId = _state.value.postGame?.latestHistoryId ?: return
+        val payments = _state.value.postGamePayments ?: return
+        _state.value = _state.value.copy(postGameSaving = true)
+        viewModelScope.launch {
+            runCatching { api.updateHistoryPayments(eventId, historyId, payments) }
+                .onSuccess {
+                    _state.value = _state.value.copy(postGamePaymentsDirty = false, postGameSaving = false)
+                    // Refresh status so allComplete / hide logic re-evaluates.
+                    val pg = runCatching { api.fetchPostGameStatus(eventId) }.getOrNull()
+                    _state.value = _state.value.copy(
+                        postGame = pg,
+                        postGamePayments = pg?.paymentsSnapshot ?: payments,
+                    )
+                }
+                .onFailure { e ->
+                    val msg = parseApiErrorMessage(e) ?: "Failed to save payments"
+                    _state.value = _state.value.copy(postGameSaving = false, error = msg)
+                }
+        }
+    }
+
     fun verifyPassword(eventId: String, password: String) {
         viewModelScope.launch {
             repository.verifyPassword(eventId, password)
@@ -596,19 +646,45 @@ fun EventDetailScreen(
                         }
 
                         // Post-game banner — prominent, right after action bar
+                        // Post-game wrap-up banner — settles the LAST game
+                        // (score, payments, MVP), kept clearly separate from the
+                        // upcoming game's UI below. Hidden once everything is
+                        // settled (allComplete) so it disappears when fulfilled.
                         state.postGame?.let { pg ->
-                            if (pg.gameEnded || pg.hasPendingPastPayments) {
+                            val showBanner = !pg.allComplete &&
+                                (pg.gameEnded || pg.hasPendingPastPayments || (pg.mvpEnabled && !pg.mvpComplete))
+                            if (showBanner) {
+                                val scoreDone = pg.hasScore
+                                val paysDone = pg.allPaid || !pg.hasCost
+                                val doneCount = (if (scoreDone) 1 else 0) + (if (paysDone) 1 else 0)
                                 Card(
                                     colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer),
                                     modifier = Modifier.fillMaxWidth().padding(bottom = 12.dp),
                                 ) {
                                     Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                                        Text(stringResource(R.string.game_ended), color = MaterialTheme.colorScheme.onPrimaryContainer, fontWeight = FontWeight.ExtraBold, style = MaterialTheme.typography.titleMedium)
+                                        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                            Icon(Icons.Default.Celebration, null, tint = MaterialTheme.colorScheme.onPrimaryContainer)
+                                            Text(stringResource(R.string.post_game_title), color = MaterialTheme.colorScheme.onPrimaryContainer, fontWeight = FontWeight.ExtraBold, style = MaterialTheme.typography.titleMedium)
+                                        }
+                                        Text(stringResource(R.string.post_game_subtitle), color = MaterialTheme.colorScheme.onPrimaryContainer, style = MaterialTheme.typography.bodySmall)
 
-                                        if (!pg.hasScore && pg.latestHistoryId != null) {
+                                        // ── Task 1: Score ──────────────────────────
+                                        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                            Icon(
+                                                if (scoreDone) Icons.Default.CheckCircle else Icons.Default.RadioButtonUnchecked,
+                                                null, modifier = Modifier.size(20.dp),
+                                                tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                                            )
+                                            Text(
+                                                if (scoreDone) stringResource(R.string.post_game_score_done) else stringResource(R.string.record_final_score),
+                                                color = MaterialTheme.colorScheme.onPrimaryContainer,
+                                                style = MaterialTheme.typography.bodyMedium,
+                                                fontWeight = FontWeight.SemiBold,
+                                                modifier = Modifier.weight(1f),
+                                            )
+                                        }
+                                        if (!scoreDone && pg.latestHistoryId != null) {
                                             if (editingScoreId == pg.latestHistoryId) {
-                                                // Inline score entry
-                                                Text(stringResource(R.string.record_final_score), color = MaterialTheme.colorScheme.onPrimaryContainer, style = MaterialTheme.typography.bodySmall)
                                                 Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                                                     OutlinedTextField(
                                                         value = scoreOne, onValueChange = { scoreOne = it.filter { c -> c.isDigit() } },
@@ -640,13 +716,57 @@ fun EventDetailScreen(
                                             }
                                         }
 
-                                        if (pg.hasCost && !pg.allPaid) {
-                                            Button(
-                                                onClick = onPayments,
-                                                modifier = Modifier.fillMaxWidth(),
-                                                colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.tertiary),
-                                            ) { Text(stringResource(R.string.mark_payments), color = MaterialTheme.colorScheme.background, style = MaterialTheme.typography.titleSmall) }
+                                        // ── Task 2: Payments (for the LAST game) ────
+                                        val snapshot = state.postGamePayments
+                                        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                            Icon(
+                                                if (paysDone) Icons.Default.CheckCircle else Icons.Default.RadioButtonUnchecked,
+                                                null, modifier = Modifier.size(20.dp),
+                                                tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                                            )
+                                            val payLabel = when {
+                                                !pg.hasCost -> stringResource(R.string.post_game_no_cost)
+                                                paysDone -> stringResource(R.string.post_game_payments_done)
+                                                snapshot != null -> stringResource(
+                                                    R.string.post_game_payments_summary,
+                                                    snapshot.count { it.status == "paid" }, snapshot.size,
+                                                )
+                                                else -> stringResource(R.string.post_game_payments_label)
+                                            }
+                                            Text(payLabel, color = MaterialTheme.colorScheme.onPrimaryContainer, style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.SemiBold, modifier = Modifier.weight(1f))
                                         }
+                                        // Inline per-player payment chips, editing the
+                                        // history snapshot (owner/admin only — server enforces).
+                                        if (pg.hasCost && !paysDone && snapshot != null && snapshot.isNotEmpty()) {
+                                            Text(stringResource(R.string.post_game_payments_hint), color = MaterialTheme.colorScheme.onPrimaryContainer, style = MaterialTheme.typography.bodySmall)
+                                            Row(modifier = Modifier.horizontalScroll(rememberScrollState()), horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                                                snapshot.forEach { p ->
+                                                    val isPaid = p.status == "paid"
+                                                    FilterChip(
+                                                        selected = isPaid,
+                                                        onClick = { viewModel.togglePostGamePayment(p.playerName) },
+                                                        label = { Text("${p.playerName} ${"%.2f".format(p.amount)}") },
+                                                        leadingIcon = if (isPaid) { { Icon(Icons.Default.CheckCircle, null, modifier = Modifier.size(16.dp)) } } else null,
+                                                    )
+                                                }
+                                            }
+                                            if (state.postGamePaymentsDirty) {
+                                                Button(
+                                                    onClick = { viewModel.savePostGamePayments(eventId) },
+                                                    enabled = !state.postGameSaving,
+                                                    modifier = Modifier.fillMaxWidth(),
+                                                    colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary),
+                                                ) { Text(stringResource(R.string.save), color = MaterialTheme.colorScheme.onPrimary, fontWeight = FontWeight.Bold) }
+                                            }
+                                        }
+
+                                        // Progress summary
+                                        Text(
+                                            stringResource(R.string.post_game_progress, doneCount, 2),
+                                            color = MaterialTheme.colorScheme.onPrimaryContainer,
+                                            style = MaterialTheme.typography.labelSmall,
+                                            modifier = Modifier.align(Alignment.CenterHorizontally),
+                                        )
                                     }
                                 }
                             }

--- a/android-app/app/src/main/java/dev/convocados/ui/screen/payments/PaymentsScreen.kt
+++ b/android-app/app/src/main/java/dev/convocados/ui/screen/payments/PaymentsScreen.kt
@@ -132,7 +132,7 @@ fun PaymentsScreen(eventId: String, onBack: () -> Unit, viewModel: PaymentsViewM
     Scaffold(
         modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
         snackbarHost = { SnackbarHost(snackbarHostState) },
-        topBar = { TopAppBar(scrollBehavior = scrollBehavior, title = { Text(stringResource(R.string.payments)) }, navigationIcon = { IconButton(onClick = onBack) { Icon(Icons.AutoMirrored.Filled.ArrowBack, stringResource(R.string.back)) } }, colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.background)) },
+        topBar = { TopAppBar(scrollBehavior = scrollBehavior, title = { Text(stringResource(R.string.upcoming_game_payments_label)) }, navigationIcon = { IconButton(onClick = onBack) { Icon(Icons.AutoMirrored.Filled.ArrowBack, stringResource(R.string.back)) } }, colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.background)) },
         containerColor = MaterialTheme.colorScheme.background,
     ) { padding ->
         if (loading) { Box(Modifier.fillMaxSize().padding(padding), Alignment.Center) { CircularProgressIndicator(color = MaterialTheme.colorScheme.primary) }; return@Scaffold }

--- a/android-app/app/src/main/res/values-de/strings.xml
+++ b/android-app/app/src/main/res/values-de/strings.xml
@@ -126,6 +126,18 @@
     <string name="record_final_score">Endergebnis eintragen</string>
     <string name="record_score">Ergebnis eintragen</string>
     <string name="mark_payments">Zahlungen markieren</string>
+    <!-- Post-game wrap-up banner -->
+    <string name="post_game_title">Letztes Spiel — abschließen</string>
+    <string name="post_game_subtitle">Erledige diese Punkte, um das letzte Spiel abzuschließen und dich auf das nächste vorzubereiten.</string>
+    <string name="post_game_score_done">Ergebnis erfasst</string>
+    <string name="post_game_payments_done">Alle Zahlungen beglichen</string>
+    <string name="post_game_payments_summary">%1$d/%2$d bezahlt</string>
+    <string name="post_game_no_cost">Keine Kosten für dieses Spiel festgelegt</string>
+    <string name="post_game_progress">%1$d von %2$d erledigt</string>
+    <string name="post_game_payments_label">Zahlungen für das letzte Spiel</string>
+    <string name="post_game_payments_hint">Tippe auf einen Spieler, um „bezahlt“ umzuschalten, dann speichern.</string>
+    <string name="post_game_payments_locked">Zahlungen sind gesperrt. Entsperre das Spiel im Verlauf, um sie zu bearbeiten.</string>
+    <string name="upcoming_game_payments_label">Zahlungen für das kommende Spiel</string>
     <string name="paid_for_last_game">%1$d von %2$d haben für das letzte Spiel bezahlt</string>
     <string name="paid_streak">%1$d Spiele bezahlt in Folge</string>
     <string name="on_bench">Du bist auf der Bank</string>

--- a/android-app/app/src/main/res/values-es/strings.xml
+++ b/android-app/app/src/main/res/values-es/strings.xml
@@ -126,6 +126,18 @@
     <string name="record_final_score">Registrar el resultado final</string>
     <string name="record_score">Registrar resultado</string>
     <string name="mark_payments">Marcar pagos</string>
+    <!-- Post-game wrap-up banner -->
+    <string name="post_game_title">Último partido — ciérralo</string>
+    <string name="post_game_subtitle">Completa estas tareas para cerrar el último partido y preparar el siguiente.</string>
+    <string name="post_game_score_done">Resultado registrado</string>
+    <string name="post_game_payments_done">Todos los pagos saldados</string>
+    <string name="post_game_payments_summary">%1$d/%2$d pagados</string>
+    <string name="post_game_no_cost">No se ha fijado coste para este partido</string>
+    <string name="post_game_progress">%1$d de %2$d hechas</string>
+    <string name="post_game_payments_label">Pagos del último partido</string>
+    <string name="post_game_payments_hint">Toca un jugador para alternar pagado y luego guarda.</string>
+    <string name="post_game_payments_locked">Los pagos están bloqueados. Desbloquea el partido en el Historial para editarlos.</string>
+    <string name="upcoming_game_payments_label">Pagos del próximo partido</string>
     <string name="paid_for_last_game">%1$d de %2$d pagaron el último partido</string>
     <string name="paid_streak">racha de %1$d partidos pagados</string>
     <string name="on_bench">Estás en el banquillo</string>

--- a/android-app/app/src/main/res/values-fr/strings.xml
+++ b/android-app/app/src/main/res/values-fr/strings.xml
@@ -126,6 +126,18 @@
     <string name="record_final_score">Enregistrer le score final</string>
     <string name="record_score">Enregistrer le score</string>
     <string name="mark_payments">Marquer les paiements</string>
+    <!-- Post-game wrap-up banner -->
+    <string name="post_game_title">Dernier match — à clôturer</string>
+    <string name="post_game_subtitle">Terminez ces tâches pour clôturer le dernier match et préparer le suivant.</string>
+    <string name="post_game_score_done">Score enregistré</string>
+    <string name="post_game_payments_done">Tous les paiements réglés</string>
+    <string name="post_game_payments_summary">%1$d/%2$d payés</string>
+    <string name="post_game_no_cost">Aucun coût défini pour ce match</string>
+    <string name="post_game_progress">%1$d sur %2$d faites</string>
+    <string name="post_game_payments_label">Paiements du dernier match</string>
+    <string name="post_game_payments_hint">Touchez un joueur pour basculer payé, puis enregistrez.</string>
+    <string name="post_game_payments_locked">Les paiements sont verrouillés. Déverrouillez le match dans l\'Historique pour les modifier.</string>
+    <string name="upcoming_game_payments_label">Paiements du prochain match</string>
     <string name="paid_for_last_game">%1$d sur %2$d ont payé le dernier match</string>
     <string name="paid_streak">série de %1$d matchs payés</string>
     <string name="on_bench">Vous êtes sur le banc</string>

--- a/android-app/app/src/main/res/values-it/strings.xml
+++ b/android-app/app/src/main/res/values-it/strings.xml
@@ -126,6 +126,18 @@
     <string name="record_final_score">Registra il punteggio finale</string>
     <string name="record_score">Registra punteggio</string>
     <string name="mark_payments">Segna pagamenti</string>
+    <!-- Post-game wrap-up banner -->
+    <string name="post_game_title">Ultima partita — da chiudere</string>
+    <string name="post_game_subtitle">Completa queste attività per chiudere l\'ultima partita e preparare la prossima.</string>
+    <string name="post_game_score_done">Punteggio registrato</string>
+    <string name="post_game_payments_done">Tutti i pagamenti saldati</string>
+    <string name="post_game_payments_summary">%1$d/%2$d pagati</string>
+    <string name="post_game_no_cost">Nessun costo impostato per questa partita</string>
+    <string name="post_game_progress">%1$d di %2$d completate</string>
+    <string name="post_game_payments_label">Pagamenti dell\'ultima partita</string>
+    <string name="post_game_payments_hint">Tocca un giocatore per alternare pagato, poi salva.</string>
+    <string name="post_game_payments_locked">I pagamenti sono bloccati. Sblocca la partita dalla Cronologia per modificarli.</string>
+    <string name="upcoming_game_payments_label">Pagamenti della prossima partita</string>
     <string name="paid_for_last_game">%1$d su %2$d hanno pagato l\'ultima partita</string>
     <string name="paid_streak">serie di %1$d partite pagate</string>
     <string name="on_bench">Sei in panchina</string>

--- a/android-app/app/src/main/res/values-pt/strings.xml
+++ b/android-app/app/src/main/res/values-pt/strings.xml
@@ -126,6 +126,18 @@
     <string name="record_final_score">Registar o resultado final</string>
     <string name="record_score">Registar resultado</string>
     <string name="mark_payments">Marcar pagamentos</string>
+    <!-- Post-game wrap-up banner -->
+    <string name="post_game_title">Último jogo — fechar contas</string>
+    <string name="post_game_subtitle">Conclui estas tarefas para fechar o último jogo e preparar o próximo.</string>
+    <string name="post_game_score_done">Resultado registado</string>
+    <string name="post_game_payments_done">Todos os pagamentos liquidados</string>
+    <string name="post_game_payments_summary">%1$d/%2$d pagos</string>
+    <string name="post_game_no_cost">Sem custo definido para este jogo</string>
+    <string name="post_game_progress">%1$d de %2$d concluídas</string>
+    <string name="post_game_payments_label">Pagamentos do último jogo</string>
+    <string name="post_game_payments_hint">Toca num jogador para alternar pago e depois guarda.</string>
+    <string name="post_game_payments_locked">Os pagamentos estão bloqueados. Desbloqueia o jogo no Histórico para editar.</string>
+    <string name="upcoming_game_payments_label">Pagamentos do próximo jogo</string>
     <string name="paid_for_last_game">%1$d de %2$d pagaram o último jogo</string>
     <string name="paid_streak">sequência de %1$d jogos pagos</string>
     <string name="on_bench">Estás nos suplentes</string>

--- a/android-app/app/src/main/res/values/strings.xml
+++ b/android-app/app/src/main/res/values/strings.xml
@@ -132,6 +132,18 @@
     <string name="record_final_score">Record the final score</string>
     <string name="record_score">Record score</string>
     <string name="mark_payments">Mark payments</string>
+    <!-- Post-game wrap-up banner -->
+    <string name="post_game_title">Last game — wrap it up</string>
+    <string name="post_game_subtitle">Settle these to close out the last game and get ready for the next one.</string>
+    <string name="post_game_score_done">Score recorded</string>
+    <string name="post_game_payments_done">All payments settled</string>
+    <string name="post_game_payments_summary">%1$d/%2$d paid</string>
+    <string name="post_game_no_cost">No cost set for this game</string>
+    <string name="post_game_progress">%1$d of %2$d done</string>
+    <string name="post_game_payments_label">Payments for the last game</string>
+    <string name="post_game_payments_hint">Tap a player to toggle paid, then save.</string>
+    <string name="post_game_payments_locked">Payments are locked. Unlock the game from History to edit.</string>
+    <string name="upcoming_game_payments_label">Payments for the upcoming game</string>
     <string name="paid_for_last_game">%1$d of %2$d paid for the last game</string>
     <string name="paid_streak">%1$d game paid streak</string>
     <string name="on_bench">You\'re on the bench</string>

--- a/android-app/app/src/test/java/dev/convocados/ui/screen/create/CreateEventTimePickerTest.kt
+++ b/android-app/app/src/test/java/dev/convocados/ui/screen/create/CreateEventTimePickerTest.kt
@@ -63,26 +63,23 @@ class CreateEventTimePickerTest {
 
     @Test
     fun quickOffsets_compose_to_any_quarter_hour() {
-        // 18:00 + 2*15m = 18:30. 18:30 + 1*15m = 18:45. 18:45 + 1*15m = 19:00.
+        // 18:00 + 4*15m = 19:00.
         val base = Instant.parse("2026-06-17T18:00:00Z")
         val plus15 = TIME_QUICK_OFFSETS.first { it.second == "+15m" }.first
-        val result = base.plusSeconds(plus15 * 3)
+        val result = base.plusSeconds(plus15 * 4)
         val wall = ZonedDateTime.ofInstant(result, ZoneId.of("UTC"))
         assertEquals(19, wall.hour)
-        assertEquals(45, wall.minute)
+        assertEquals(0, wall.minute)
     }
 
     @Test
     fun quickOffsets_have_paired_polarities() {
-        val byLabel = TIME_QUICK_OFFSETS.toMap()
+        val byOffset = TIME_QUICK_OFFSETS.toMap()
         // +X must always have a matching -X with the same magnitude.
         for ((secs, label) in TIME_QUICK_OFFSETS) {
-            val negated = secs.let { if (it > 0) "-$label".replace("+", "-") else label.replace("-", "+") }
-            val counterpart = byLabel[negated] ?: -secs
-            assertEquals(
-                "Offset $label has no symmetric counterpart",
-                -secs,
-                counterpart,
+            assertTrue(
+                "Offset $label ($secs) has no symmetric counterpart",
+                byOffset.containsKey(-secs),
             )
         }
     }

--- a/android-app/app/src/test/java/dev/convocados/ui/screen/event/EventDetailViewModelTest.kt
+++ b/android-app/app/src/test/java/dev/convocados/ui/screen/event/EventDetailViewModelTest.kt
@@ -230,4 +230,126 @@ class EventDetailViewModelTest {
         }
         coVerify(exactly = 2) { api.fetchPostGameStatus(eventId) }
     }
+
+    @Test
+    fun `load seeds editable past-game payment snapshot from status`() = runTest {
+        coEvery { repository.getEventDetail(eventId) } returns flowOf(mockEvent)
+        coEvery { repository.getPlayers(eventId) } returns flowOf(emptyList())
+        coEvery { repository.getHistory(eventId) } returns flowOf(emptyList())
+
+        val postGame = PostGameStatus(
+            gameEnded = false, // post-reset: next game upcoming
+            hasScore = true,
+            hasCost = true,
+            allPaid = false,
+            hasPendingPastPayments = true,
+            latestHistoryId = "hist-1",
+            paymentsSnapshot = listOf(
+                PaymentSnapshotEntry("coutinho", 5.0, "pending"),
+                PaymentSnapshotEntry("José Cabeda", 5.0, "paid"),
+            ),
+        )
+        coEvery { api.fetchPostGameStatus(eventId) } returns postGame
+
+        val viewModel = EventDetailViewModel(repository, api, tokenStore, client, settingsStore)
+
+        viewModel.state.test {
+            viewModel.load(eventId)
+            advanceUntilIdle()
+            val state = expectMostRecentItem()
+            // The banner edits the PAST game snapshot, not the live next-game payments.
+            assertEquals(2, state.postGamePayments?.size)
+            assertEquals("pending", state.postGamePayments?.first { it.playerName == "coutinho" }?.status)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `togglePostGamePayment flips status locally and marks dirty`() = runTest {
+        coEvery { repository.getEventDetail(eventId) } returns flowOf(mockEvent)
+        coEvery { repository.getPlayers(eventId) } returns flowOf(emptyList())
+        coEvery { repository.getHistory(eventId) } returns flowOf(emptyList())
+        coEvery { api.fetchPostGameStatus(eventId) } returns PostGameStatus(
+            gameEnded = true, hasScore = true, hasCost = true, allPaid = false,
+            latestHistoryId = "hist-1",
+            paymentsSnapshot = listOf(PaymentSnapshotEntry("coutinho", 5.0, "pending")),
+        )
+
+        val viewModel = EventDetailViewModel(repository, api, tokenStore, client, settingsStore)
+        viewModel.state.test {
+            viewModel.load(eventId)
+            advanceUntilIdle()
+
+            viewModel.togglePostGamePayment("coutinho")
+            advanceUntilIdle()
+            val state = expectMostRecentItem()
+            assertEquals("paid", state.postGamePayments?.first()?.status)
+            assertTrue(state.postGamePaymentsDirty)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `savePostGamePayments PATCHes history snapshot and clears dirty`() = runTest {
+        coEvery { repository.getEventDetail(eventId) } returns flowOf(mockEvent)
+        coEvery { repository.getPlayers(eventId) } returns flowOf(emptyList())
+        coEvery { repository.getHistory(eventId) } returns flowOf(emptyList())
+        val pending = PostGameStatus(
+            gameEnded = true, hasScore = true, hasCost = true, allPaid = false,
+            latestHistoryId = "hist-1",
+            paymentsSnapshot = listOf(PaymentSnapshotEntry("coutinho", 5.0, "pending")),
+        )
+        val settled = pending.copy(
+            allPaid = true, allComplete = true,
+            paymentsSnapshot = listOf(PaymentSnapshotEntry("coutinho", 5.0, "paid")),
+        )
+        coEvery { api.fetchPostGameStatus(eventId) } returnsMany listOf(pending, settled)
+        coEvery { api.updateHistoryPayments(eventId, "hist-1", any()) } returns
+            GameHistory(id = "hist-1", dateTime = "2026-06-22T18:00:00Z")
+
+        val viewModel = EventDetailViewModel(repository, api, tokenStore, client, settingsStore)
+        viewModel.state.test {
+            viewModel.load(eventId)
+            advanceUntilIdle()
+            viewModel.togglePostGamePayment("coutinho")
+            viewModel.savePostGamePayments(eventId)
+            advanceUntilIdle()
+
+            val state = expectMostRecentItem()
+            assertEquals(false, state.postGamePaymentsDirty)
+            assertEquals(true, state.postGame?.allComplete)
+            cancelAndIgnoreRemainingEvents()
+        }
+        coVerify { api.updateHistoryPayments(eventId, "hist-1", match { it.first().status == "paid" }) }
+    }
+
+    @Test
+    fun `savePostGamePayments surfaces error on 403 and keeps dirty`() = runTest {
+        coEvery { repository.getEventDetail(eventId) } returns flowOf(mockEvent)
+        coEvery { repository.getPlayers(eventId) } returns flowOf(emptyList())
+        coEvery { repository.getHistory(eventId) } returns flowOf(emptyList())
+        coEvery { api.fetchPostGameStatus(eventId) } returns PostGameStatus(
+            gameEnded = true, hasScore = true, hasCost = true, allPaid = false,
+            latestHistoryId = "hist-1",
+            paymentsSnapshot = listOf(PaymentSnapshotEntry("coutinho", 5.0, "pending")),
+        )
+        coEvery { api.updateHistoryPayments(eventId, "hist-1", any()) } throws
+            ApiException(403, "{\"error\":\"Only the event owner can do this.\"}")
+
+        val viewModel = EventDetailViewModel(repository, api, tokenStore, client, settingsStore)
+        viewModel.state.test {
+            viewModel.load(eventId)
+            advanceUntilIdle()
+            viewModel.togglePostGamePayment("coutinho")
+            viewModel.savePostGamePayments(eventId)
+            advanceUntilIdle()
+
+            val state = expectMostRecentItem()
+            assertTrue(state.postGamePaymentsDirty)
+            assertNotNull(state.error)
+            assertEquals(false, state.postGameSaving)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
 }


### PR DESCRIPTION
## Problem

Recurring events reset to the next occurrence ~1h after a game ends. On reset, the live `PlayerPayment` rows are snapshotted into `GameHistory.paymentsSnapshot` and the live `EventCost` is re-created **empty** for the new occurrence.

The Android event screen showed the **empty next-game** payments, and its "Mark payments" button navigated to that next-game payments screen. So a last game with a single unpaid player (e.g. *coutinho* on the Ninjas da Areosa event) looked like **everyone was unpaid** — the real per-player state was sitting in the last `GameHistory` snapshot, invisible in the app.

(Verified against prod: event `dateTime` already advanced to the next occurrence; the last played game's snapshot correctly shows 9 paid / 1 pending.)

## Fix — match the web `PostGameBanner`

The web already solves this with a "last game — wrap it up" checklist (`PostGameBanner` + `GET /post-game-status`) that settles the **past** game and disappears once done, clearly separate from the upcoming game. This brings the same UX to Android.

- **`PostGameStatus` model**: add `paymentsSnapshot`, `mvpEnabled`, `mvpComplete`, `paidAggregate` (already returned by the endpoint, previously dropped on Android).
- **`ConvocadosApi.updateHistoryPayments`** → `PATCH /api/events/{id}/history/{historyId}` with `paymentsSnapshot`. Owner/admin only (server-enforced, within the 7-day editable window).
- **`EventDetailViewModel`**: editable past-game snapshot in state (`postGamePayments` + dirty/saving flags). `togglePostGamePayment` cycles a player locally; `savePostGamePayments` PATCHes the history entry then re-fetches status so `allComplete` re-evaluates and the banner hides.
- **Banner UI**: clear checklist — score / payments (inline per-player chips editing the **history snapshot**, not the next game) / progress. Hidden when `allComplete`.
- **`PaymentsScreen`** title relabeled to "Payments for the upcoming game" so the next-game payments are unmistakably distinct from the last game.
- New strings added to **all 6 locales**.

### Out of scope
- **MVP voting in the banner** — no MVP voting UI exists on Android yet. `allComplete` still accounts for MVP, so the banner stays visible while MVP is pending (same as today). Filed as a follow-up.
- **No reset-timing change** — we surface the existing history snapshot (option A), we do not change when recurring games roll over.

## Testing
- `EventDetailViewModelTest` gains 5 cases: seed snapshot from status, toggle flips + marks dirty, save settles + hides banner, 403 keeps dirty + surfaces error.
- All `:app` UI/data unit tests pass. App builds (`assembleDebug`).
- `StringsParityTest` is a **pre-existing** classpath-resource infra failure unrelated to this change (fails identically on `main`).

Also re-applies the two `CreateEventTimePickerTest` fixes (type-inference error + `15m*3` vs `19:00`) that block test compilation on this branch — same fixes are in the separate PR #517, not yet merged.
