### PR TITLE
fix: ranking shows 0 stats for players on later pages

### DIFF
--- a/src/components/RankingsPage.tsx
+++ b/src/components/RankingsPage.tsx
@@ -256,7 +256,6 @@ export default function RankingsPage({ eventId }: { eventId: string }) {
   const playerByName = new Map(players.map((p) => [p.name, p]));
 
   const tableRows: TableRowData[] = (() => {
-    const _ratingByName = new Map(ratings.map((r) => [r.name, r]));
     const rows: TableRowData[] = [];
     const seen = new Set<string>();
 
@@ -277,20 +276,24 @@ export default function RankingsPage({ eventId }: { eventId: string }) {
       seen.add(r.name.toLowerCase());
     }
 
-    for (const p of players) {
-      if (!seen.has(p.name.toLowerCase())) {
-        rows.push({
-          name: p.name,
-          rating: null,
-          initialRating: null,
-          gamesPlayed: 0,
-          wins: 0,
-          draws: 0,
-          losses: 0,
-          mvpAwards: 0,
-          playerId: p.id,
-          userId: p.userId,
-        });
+    // ponytail: Only append unrated players once all rating pages are loaded,
+    // otherwise players whose ratings are on a later page appear as 0.
+    if (!hasMore) {
+      for (const p of players) {
+        if (!seen.has(p.name.toLowerCase())) {
+          rows.push({
+            name: p.name,
+            rating: null,
+            initialRating: null,
+            gamesPlayed: 0,
+            wins: 0,
+            draws: 0,
+            losses: 0,
+            mvpAwards: 0,
+            playerId: p.id,
+            userId: p.userId,
+          });
+        }
       }
     }
 


### PR DESCRIPTION
Players whose ratings were on later paginated pages appeared at the bottom of the ranking table with all stats as 0. Now unrated-player rows are only appended once all rating pages have been loaded (`hasMore === false`).

**What was happening:** The `tableRows` computation appended every event player without a matching entry in the (paginated) `ratings` array — showing them with zeros. When "load more" fetched their actual data, it corrected.

**Fix:** Gate the unrated-player append behind `!hasMore`.