### PR TITLE
fix: update litestream to v0.5.13 (v0.5.11 release removed)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ FROM base AS production
 ENV NODE_ENV=production
 
 # Install Litestream for continuous SQLite replication to S3/R2
-ADD https://github.com/benbjohnson/litestream/releases/download/v0.5.11/litestream-0.5.11-linux-x86_64.tar.gz /tmp/litestream.tar.gz
+ADD https://github.com/benbjohnson/litestream/releases/download/v0.5.13/litestream-0.5.13-linux-x86_64.tar.gz /tmp/litestream.tar.gz
 RUN tar -C /usr/local/bin -xzf /tmp/litestream.tar.gz && rm /tmp/litestream.tar.gz
 
 COPY --from=build /app/node_modules ./node_modules

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -17,7 +17,7 @@ COPY prisma ./prisma
 RUN pnpm prisma generate
 
 # Litestream for SQLite replication
-ADD https://github.com/benbjohnson/litestream/releases/download/v0.5.11/litestream-v0.5.11-linux-amd64.tar.gz /tmp/litestream.tar.gz
+ADD https://github.com/benbjohnson/litestream/releases/download/v0.5.13/litestream-0.5.13-linux-x86_64.tar.gz /tmp/litestream.tar.gz
 RUN tar -C /usr/local/bin -xzf /tmp/litestream.tar.gz && rm /tmp/litestream.tar.gz
 
 ENV NODE_ENV=production


### PR DESCRIPTION
The v0.5.11 release was removed from GitHub, causing Docker build failures (404). Updated to v0.5.13 in both Dockerfile and Dockerfile.base.