### PR TITLE
fix: use pnpx for prisma generate in base Docker image

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -14,7 +14,7 @@ RUN pnpm install --frozen-lockfile --prod
 
 # Prisma client (runtime query engine)
 COPY prisma ./prisma
-RUN pnpm prisma generate
+RUN pnpx prisma generate
 
 # Litestream for SQLite replication
 ADD https://github.com/benbjohnson/litestream/releases/download/v0.5.13/litestream-0.5.13-linux-x86_64.tar.gz /tmp/litestream.tar.gz


### PR DESCRIPTION
prisma is a devDependency, not available after `--prod` install. Use `pnpx` to download it on the fly for the generate step. This fixes the base image rebuild triggered by the litestream version bump.