### PR TITLE
fix: pin prisma@6 in Dockerfile.base

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -14,7 +14,7 @@ RUN pnpm install --frozen-lockfile --prod
 
 # Prisma client (runtime query engine)
 COPY prisma ./prisma
-RUN pnpx prisma generate
+RUN pnpx prisma@6 generate
 
 # Litestream for SQLite replication
 ADD https://github.com/benbjohnson/litestream/releases/download/v0.5.13/litestream-0.5.13-linux-x86_64.tar.gz /tmp/litestream.tar.gz


### PR DESCRIPTION
pnpx without version pin downloads prisma v7.8.0 which is incompatible with our v6.x schema. Pin to major version 6.