### PR TITLE
fix: remove dist from .dockerignore for deploy

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 node_modules
-dist
 .git
 *.db
 *.db-journal


### PR DESCRIPTION
Dockerfile.deploy needs to COPY dist into the app image, but .dockerignore was excluding it from the build context.