### PR TITLE
feat: cancel game for admins + fix recruitment notification dedup (#538)

### DIFF
--- a/prisma/migrations/20260705_recruitment_dedup/migration.sql
+++ b/prisma/migrations/20260705_recruitment_dedup/migration.sql
@@ -1,0 +1,8 @@
+-- Recruitment notification dedup (#538 follow-up)
+-- The "missing players" / recruitment push was firing on every cron tick
+-- within the 2-hour T-48h and T-24h windows, flooding non-playing followers.
+-- These flags ensure each recruitment ping fires exactly once per occurrence
+-- and are reset when the event advances to its next occurrence.
+
+ALTER TABLE "Event" ADD COLUMN "recruitment48hSent" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "Event" ADD COLUMN "recruitment24hSent" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -152,6 +152,10 @@ model Event {
   // ADR 0017: Dedup flag for few_spots_left notification (reset when player leaves)
   fewSpotsLeftNotified Boolean @default(false)
 
+  // Recruitment notification dedup — T-48h and T-24h pings should fire only once per occurrence
+  recruitment48hSent Boolean @default(false)
+  recruitment24hSent Boolean @default(false)
+
   // Access control
   accessPassword        String?               // bcrypt-hashed password (null = no password)
 

--- a/src/components/EventLogPage.tsx
+++ b/src/components/EventLogPage.tsx
@@ -16,6 +16,7 @@ import ScoreboardIcon from "@mui/icons-material/Scoreboard";
 import SportsIcon from "@mui/icons-material/Sports";
 import EmojiEventsIcon from "@mui/icons-material/EmojiEvents";
 import TuneIcon from "@mui/icons-material/Tune";
+import CancelIcon from "@mui/icons-material/Cancel";
 import { ThemeModeProvider } from "./ThemeModeProvider";
 import { ResponsiveLayout } from "./ResponsiveLayout";
 import { useT } from "~/lib/useT";
@@ -63,6 +64,7 @@ const ACTION_COLORS: Record<string, "success" | "error" | "info" | "warning" | "
   rating_manual_disabled: "warning",
   override_set: "warning",
   override_cleared: "info",
+  game_cancelled: "error",
 };
 
 const ACTION_ICONS: Record<string, React.ReactNode> = {
@@ -86,6 +88,7 @@ const ACTION_ICONS: Record<string, React.ReactNode> = {
   rating_manual_disabled: <TuneIcon fontSize="small" />,
   override_set: <PaymentIcon fontSize="small" />,
   override_cleared: <PaymentIcon fontSize="small" />,
+  game_cancelled: <CancelIcon fontSize="small" />,
 };
 
 const ACTION_I18N: Record<string, TranslationKey> = {
@@ -121,6 +124,7 @@ const ACTION_I18N: Record<string, TranslationKey> = {
   rating_manual_disabled: "logRatingManualDisabled",
   override_set: "logOverrideSet",
   override_cleared: "logOverrideCleared",
+  game_cancelled: "logGameCancelled",
 };
 
 function LogEntryRow({ entry, currentUserId }: { entry: LogEntry; currentUserId?: string }) {

--- a/src/components/EventPage.tsx
+++ b/src/components/EventPage.tsx
@@ -80,6 +80,8 @@ export default function EventPage({ eventId }: { eventId: string }) {
   const [_isPublic, setIsPublic] = useState(false);
   const [sport, setSport] = useState("football-5v5");
   const [relinquishConfirmOpen, setRelinquishConfirmOpen] = useState(false);
+  const [cancelConfirmOpen, setCancelConfirmOpen] = useState(false);
+  const [cancelConfirmBusy, setCancelConfirmBusy] = useState(false);
   const [_postGameStatus, setPostGameStatus] = useState<PostGameStatus | null>(null);
   const [paymentExpanded, setPaymentExpanded] = useState<boolean | undefined>(undefined);
   const [bannerRefreshKey, setBannerRefreshKey] = useState(0);
@@ -573,6 +575,20 @@ export default function EventPage({ eventId }: { eventId: string }) {
     if (res.ok) fetchEvent();
   };
 
+  const handleCancelGame = async () => {
+    setCancelConfirmBusy(true);
+    const res = await fetch(`/api/events/${eventId}/cancel`, { method: "PUT" });
+    setCancelConfirmBusy(false);
+    setCancelConfirmOpen(false);
+    if (res.ok) {
+      setSnackbar(t("gameCancelledSnackbar"));
+      fetchEvent();
+    } else {
+      const body = await res.json();
+      setSnackbar(body.error || t("somethingWentWrong"));
+    }
+  };
+
   // ── Derived state ───────────────────────────────────────────────────────────
 
   const gameDate = useMemo(() => event ? new Date(event.dateTime) : new Date(), [event]);
@@ -801,11 +817,13 @@ export default function EventPage({ eventId }: { eventId: string }) {
               isAuthenticated={isAuthenticated}
               isOwnerless={isOwnerless}
               localMatches={localMatches}
+              gameStatus={event.gameStatus}
               onSaveTitle={handleSaveTitle}
               onSaveLocation={handleSaveLocation}
               onSaveDateTime={handleSaveDateTime}
               onSaveSport={handleSaveSport}
               onClaimOwnership={handleClaimOwnership}
+              onCancelGame={() => setCancelConfirmOpen(true)}
               onSnackbar={setSnackbar}
             />
 
@@ -1022,6 +1040,11 @@ export default function EventPage({ eventId }: { eventId: string }) {
           relinquishConfirmOpen={relinquishConfirmOpen}
           onRelinquishClose={() => setRelinquishConfirmOpen(false)}
           onRelinquishConfirm={handleRelinquishOwnership}
+          cancelConfirmOpen={cancelConfirmOpen}
+          onCancelConfirmClose={() => setCancelConfirmOpen(false)}
+          onCancelConfirm={handleCancelGame}
+          cancelConfirmBusy={cancelConfirmBusy}
+          isRecurring={event.isRecurring}
           snackbar={snackbar}
           onSnackbarClose={() => setSnackbar(null)}
           undoData={undoData}

--- a/src/components/event/EventDialogs.tsx
+++ b/src/components/event/EventDialogs.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import {
   Button, Dialog, DialogTitle, DialogContent,
-  DialogContentText, DialogActions, Snackbar,
+  DialogContentText, DialogActions, Snackbar, Alert,
 } from "@mui/material";
 import { useT } from "~/lib/useT";
 
@@ -14,6 +14,12 @@ interface Props {
   relinquishConfirmOpen: boolean;
   onRelinquishClose: () => void;
   onRelinquishConfirm: () => void;
+  // Cancel game confirmation
+  cancelConfirmOpen: boolean;
+  onCancelConfirmClose: () => void;
+  onCancelConfirm: () => void;
+  cancelConfirmBusy: boolean;
+  isRecurring: boolean;
   // Snackbar
   snackbar: string | null;
   onSnackbarClose: () => void;
@@ -26,6 +32,7 @@ interface Props {
 export function EventDialogs({
   confirmOpen, onConfirmClose, onConfirmRandomize,
   relinquishConfirmOpen, onRelinquishClose, onRelinquishConfirm,
+  cancelConfirmOpen, onCancelConfirmClose, onCancelConfirm, cancelConfirmBusy, isRecurring,
   snackbar, onSnackbarClose,
   undoData, onUndoDismiss, onUndo,
 }: Props) {
@@ -54,6 +61,25 @@ export function EventDialogs({
           <Button onClick={onRelinquishClose}>{t("cancelEdit")}</Button>
           <Button onClick={onRelinquishConfirm} color="warning" variant="contained">
             {t("relinquishOwnership")}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Cancel game confirmation */}
+      <Dialog open={cancelConfirmOpen} onClose={cancelConfirmBusy ? undefined : onCancelConfirmClose}>
+        <DialogTitle>{t("cancelGameConfirmTitle")}</DialogTitle>
+        <DialogContent>
+          <DialogContentText>{t("cancelGameConfirmDesc")}</DialogContentText>
+          {isRecurring && (
+            <Alert severity="info" sx={{ mt: 2 }}>
+              {t("cancelGameRecurringNote")}
+            </Alert>
+          )}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={onCancelConfirmClose} disabled={cancelConfirmBusy}>{t("cancelEdit")}</Button>
+          <Button onClick={onCancelConfirm} color="error" variant="contained" disabled={cancelConfirmBusy}>
+            {t("cancelGame")}
           </Button>
         </DialogActions>
       </Dialog>

--- a/src/components/event/EventHeader.tsx
+++ b/src/components/event/EventHeader.tsx
@@ -20,6 +20,7 @@ import AssignmentIcon from "@mui/icons-material/Assignment";
 import EmojiPeopleIcon from "@mui/icons-material/EmojiPeople";
 import CalendarMonthIcon from "@mui/icons-material/CalendarMonth";
 import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
+import CancelIcon from "@mui/icons-material/Cancel";
 import { useT } from "~/lib/useT";
 import { detectLocale } from "~/lib/i18n";
 import { describeRecurrenceRule, parseRecurrenceRule, nextOccurrence } from "~/lib/recurrence";
@@ -46,11 +47,13 @@ interface Props {
   isAuthenticated: boolean;
   isOwnerless: boolean;
   localMatches: Imatch[] | null;
+  gameStatus?: string | null;
   onSaveTitle: (title: string) => Promise<void>;
   onSaveLocation: (location: string) => Promise<void>;
   onSaveDateTime: (dateTime: string, timezone: string) => Promise<void>;
   onSaveSport: (sport: string) => Promise<void>;
   onClaimOwnership: () => Promise<void>;
+  onCancelGame: () => void;
   onSnackbar: (msg: string) => void;
 }
 
@@ -67,8 +70,8 @@ function countdownUrgency(gameDate: Date, durationMinutes?: number): "past" | "l
 
 export function EventHeader({
   eventId, event, sport, gameDate, countdown, canEditSettings,
-  isOwner: _isOwner, isAuthenticated, isOwnerless, localMatches,
-  onSaveTitle, onSaveLocation, onSaveDateTime, onSaveSport, onClaimOwnership,
+  isOwner: _isOwner, isAuthenticated, isOwnerless, localMatches, gameStatus,
+  onSaveTitle, onSaveLocation, onSaveDateTime, onSaveSport, onClaimOwnership, onCancelGame,
 }: Props) {
   const t = useT();
   const locale = detectLocale();
@@ -116,23 +119,26 @@ export function EventHeader({
   }, [canEditSettings, event, sport]);
 
   const rule = parseRecurrenceRule(event.recurrenceRule);
-  const urgency = countdownUrgency(gameDate, event.durationMinutes);
+  const isCancelled = gameStatus === "cancelled";
+  const urgency = isCancelled ? "past" : countdownUrgency(gameDate, event.durationMinutes);
   // ponytail: recurring events in past phase get primary color (next game exists),
   // non-recurring past events get the muted grey.
-  const isRecurringPast = urgency === "past" && !!rule;
-  const urgencyColor = urgency === "past" && !isRecurringPast ? theme.palette.text.disabled
+  const isRecurringPast = urgency === "past" && !!rule && !isCancelled;
+  const urgencyColor = isCancelled ? theme.palette.error.main
+    : urgency === "past" && !isRecurringPast ? theme.palette.text.disabled
     : urgency === "past" && isRecurringPast ? theme.palette.primary.main
     : urgency === "live" ? theme.palette.success.main
     : urgency === "urgent" ? theme.palette.error.main
     : urgency === "soon" ? theme.palette.warning.main
     : theme.palette.primary.main;
-  const urgencyBg = urgency === "past" && !isRecurringPast ? alpha(theme.palette.text.disabled, 0.06)
+  const urgencyBg = isCancelled ? alpha(theme.palette.error.main, 0.1)
+    : urgency === "past" && !isRecurringPast ? alpha(theme.palette.text.disabled, 0.06)
     : urgency === "past" && isRecurringPast ? alpha(theme.palette.primary.main, 0.08)
     : urgency === "live" ? alpha(theme.palette.success.main, 0.1)
     : urgency === "urgent" ? alpha(theme.palette.error.main, 0.1)
     : urgency === "soon" ? alpha(theme.palette.warning.main, 0.1)
     : alpha(theme.palette.primary.main, 0.08);
-  const accentOpacity = urgency === "normal" ? 0.25 : (urgency === "past" && !isRecurringPast) ? 0.15 : 0.8;
+  const accentOpacity = isCancelled ? 0.8 : urgency === "normal" ? 0.25 : (urgency === "past" && !isRecurringPast) ? 0.15 : 0.8;
 
   const openEdit = () => {
     setTitleDraft(event.title);
@@ -188,6 +194,7 @@ export function EventHeader({
       case "live":
         return t("liveNow");
       case "past":
+        if (isCancelled) return t("gameCancelled");
         // For recurring events, show the actual next game date so new players know when to come
         if (rule) {
           const nextDate = nextOccurrence(gameDate, rule, new Date());
@@ -522,6 +529,12 @@ export function EventHeader({
                   </>
                 )}
                 {canEditSettings && <Divider sx={{ my: 0.5 }} />}
+                {canEditSettings && (
+                  <MenuItem onClick={() => { setAnchorEl(null); onCancelGame(); }}>
+                    <ListItemIcon><CancelIcon fontSize="small" color="error" /></ListItemIcon>
+                    <ListItemText>{t("cancelGame")}</ListItemText>
+                  </MenuItem>
+                )}
                 {canEditSettings && (
                   <MenuItem component="a" href={`/events/${eventId}/settings`} onClick={() => setAnchorEl(null)}>
                     <ListItemIcon><SettingsIcon fontSize="small" /></ListItemIcon>

--- a/src/components/event/types.ts
+++ b/src/components/event/types.ts
@@ -48,6 +48,7 @@ export interface EventData {
   latitude?: number | null;
   longitude?: number | null;
   courtWatchConfig?: string | null;
+  gameStatus?: string | null;
 }
 
 export interface KnownPlayer {

--- a/src/lib/eventLog.server.ts
+++ b/src/lib/eventLog.server.ts
@@ -39,7 +39,8 @@ export type EventAction =
   | "override_cleared"
   | "rsvp_yes"
   | "rsvp_no"
-  | "rsvp_maybe";
+  | "rsvp_maybe"
+  | "game_cancelled";
 
 /**
  * Append an entry to the event activity log.

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -1083,6 +1083,15 @@ const de: TranslationKeys = {
   costMonthlyGamesCovered: "Games covered per month",
   costDropInSurcharge: "Drop-in surcharge",
   costDropInSurchargeTooltip: "Extra amount added to per-game payers who are not monthly subscribers.",
+
+  // Cancel game
+  cancelGame: "Spiel absagen",
+  cancelGameConfirmTitle: "Dieses Spiel absagen?",
+  cancelGameConfirmDesc: "Bist du sicher, dass du dieses Spiel absagen möchtest? Alle Follower werden benachrichtigt.",
+  cancelGameRecurringNote: "Ein neues Spiel wird zum nächsten geplanten Termin geöffnet.",
+  gameCancelled: "Abgesagt",
+  gameCancelledSnackbar: "Spiel wurde abgesagt.",
+  logGameCancelled: "{actor} sagte das Spiel ab",
 };
 
 export default de;

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -1137,6 +1137,15 @@ const en = {
   costMonthlyGamesCovered: "Games covered per month",
   costDropInSurcharge: "Drop-in surcharge",
   costDropInSurchargeTooltip: "Extra amount added to per-game payers who are not monthly subscribers.",
+
+  // Cancel game
+  cancelGame: "Cancel game",
+  cancelGameConfirmTitle: "Cancel this game?",
+  cancelGameConfirmDesc: "Are you sure you want to cancel this game? All followers will be notified.",
+  cancelGameRecurringNote: "A new game will open for the next scheduled occurrence.",
+  gameCancelled: "Cancelled",
+  gameCancelledSnackbar: "Game has been cancelled.",
+  logGameCancelled: "{actor} cancelled the game",
 } as const;
 
 export default en;

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -1083,6 +1083,15 @@ const es: TranslationKeys = {
   costMonthlyGamesCovered: "Games covered per month",
   costDropInSurcharge: "Drop-in surcharge",
   costDropInSurchargeTooltip: "Extra amount added to per-game payers who are not monthly subscribers.",
+
+  // Cancel game
+  cancelGame: "Cancelar partido",
+  cancelGameConfirmTitle: "¿Cancelar este partido?",
+  cancelGameConfirmDesc: "¿Estás seguro de que quieres cancelar este partido? Todos los seguidores serán notificados.",
+  cancelGameRecurringNote: "Se abrirá un nuevo partido para la próxima ocurrencia programada.",
+  gameCancelled: "Cancelado",
+  gameCancelledSnackbar: "El partido ha sido cancelado.",
+  logGameCancelled: "{actor} canceló el partido",
 };
 
 export default es;

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -1083,6 +1083,15 @@ const fr: TranslationKeys = {
   costMonthlyGamesCovered: "Games covered per month",
   costDropInSurcharge: "Drop-in surcharge",
   costDropInSurchargeTooltip: "Extra amount added to per-game payers who are not monthly subscribers.",
+
+  // Cancel game
+  cancelGame: "Annuler le match",
+  cancelGameConfirmTitle: "Annuler ce match ?",
+  cancelGameConfirmDesc: "Êtes-vous sûr de vouloir annuler ce match ? Tous les abonnés seront notifiés.",
+  cancelGameRecurringNote: "Un nouveau match s'ouvrira pour la prochaine occurrence prévue.",
+  gameCancelled: "Annulé",
+  gameCancelledSnackbar: "Le match a été annulé.",
+  logGameCancelled: "{actor} a annulé le match",
 };
 
 export default fr;

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -1083,6 +1083,15 @@ const it: TranslationKeys = {
   costMonthlyGamesCovered: "Games covered per month",
   costDropInSurcharge: "Drop-in surcharge",
   costDropInSurchargeTooltip: "Extra amount added to per-game payers who are not monthly subscribers.",
+
+  // Cancel game
+  cancelGame: "Annulla partita",
+  cancelGameConfirmTitle: "Annullare questa partita?",
+  cancelGameConfirmDesc: "Sei sicuro di voler annullare questa partita? Tutti i follower verranno notificati.",
+  cancelGameRecurringNote: "Una nuova partita si aprirà per la prossima occorrenza programmata.",
+  gameCancelled: "Annullata",
+  gameCancelledSnackbar: "La partita è stata annullata.",
+  logGameCancelled: "{actor} ha annullato la partita",
 };
 
 export default it;

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -1131,6 +1131,15 @@ const pt: TranslationKeys = {
   costMonthlyGamesCovered: "Jogos cobertos por mês",
   costDropInSurcharge: "Sobretaxa avulsa",
   costDropInSurchargeTooltip: "Valor extra para jogadores que não são subscritores mensais.",
+
+  // Cancel game
+  cancelGame: "Cancelar jogo",
+  cancelGameConfirmTitle: "Cancelar este jogo?",
+  cancelGameConfirmDesc: "Tens a certeza que queres cancelar este jogo? Todos os seguidores serão notificados.",
+  cancelGameRecurringNote: "Um novo jogo será aberto para a próxima ocorrência agendada.",
+  gameCancelled: "Cancelado",
+  gameCancelledSnackbar: "O jogo foi cancelado.",
+  logGameCancelled: "{actor} cancelou o jogo",
 };
 
 export default pt;

--- a/src/lib/rsvp.server.ts
+++ b/src/lib/rsvp.server.ts
@@ -241,6 +241,70 @@ export async function markRsvpCutoffSent(eventId: string) {
   log.info({ eventId }, "RSVP 48h cutoff marked sent");
 }
 
+// ─── Recruitment dedup (#538 follow-up) ────────────────────────────────────
+//
+// Bug: recruitment notifications were enqueued on every cron run within the
+// T-48h / T-24h 2-hour window — flooding every non-playing follower ~24 times
+// per window. These flags ensure each recruitment ping fires exactly once
+// per occurrence, and are reset whenever the event advances to its next
+// occurrence (lazy reset, explicit recurrence reset, or cancel-then-advance).
+
+/** Events needing the T-48h recruitment ping (still needs players). */
+export async function getEventsNeedingRecruitment48h(now: Date = new Date()) {
+  const windowStart = new Date(now.getTime() + (RSVP_WINDOW_HOURS - 1) * 3600_000);
+  const windowEnd = new Date(now.getTime() + (RSVP_WINDOW_HOURS + 1) * 3600_000);
+  return prisma.event.findMany({
+    where: {
+      rsvpCutoffSent: true, // precondition: T-48h fanout has already fired
+      recruitment48hSent: false,
+      dateTime: { gte: windowStart, lte: windowEnd },
+    },
+    select: { id: true, title: true, maxPlayers: true, recruitmentThreshold: true },
+  });
+}
+
+/** Events needing the T-24h urgent recruitment ping (tomorrow — still needs players). */
+export async function getEventsNeedingRecruitment24h(now: Date = new Date()) {
+  const windowStart = new Date(now.getTime() + (RSVP_SUMMARY_HOURS - 1) * 3600_000);
+  const windowEnd = new Date(now.getTime() + (RSVP_SUMMARY_HOURS + 1) * 3600_000);
+  return prisma.event.findMany({
+    where: {
+      rsvpCutoffSent: true,
+      recruitment24hSent: false,
+      dateTime: { gte: windowStart, lte: windowEnd },
+    },
+    select: { id: true, title: true, maxPlayers: true, recruitmentThreshold: true, ownerId: true },
+  });
+}
+
+export async function markRecruitment48hSent(eventId: string) {
+  await prisma.event.update({
+    where: { id: eventId },
+    data: { recruitment48hSent: true },
+  });
+}
+
+export async function markRecruitment24hSent(eventId: string) {
+  await prisma.event.update({
+    where: { id: eventId },
+    data: { recruitment24hSent: true },
+  });
+}
+
+/**
+ * Reset all recruitment dedup flags — called when an event advances to its
+ * next occurrence so the next occurrence gets a fresh recruitment cycle.
+ */
+export async function resetRecruitmentFlags(eventId: string) {
+  await prisma.event.update({
+    where: { id: eventId },
+    data: {
+      recruitment48hSent: false,
+      recruitment24hSent: false,
+    },
+  });
+}
+
 export async function isRsvpCutoffSent(eventId: string) {
   const e = await prisma.event.findUnique({
     where: { id: eventId },

--- a/src/pages/api/cron/reminders.ts
+++ b/src/pages/api/cron/reminders.ts
@@ -11,9 +11,13 @@ import { expireOldCredits } from "~/lib/creditExpiry.server";
 import {
   getEventsNeedingRsvpPing,
   getEventsNeedingRsvpSummary,
+  getEventsNeedingRecruitment48h,
+  getEventsNeedingRecruitment24h,
   getRsvpRecipients,
   getRsvpSummary,
   markRsvpCutoffSent,
+  markRecruitment48hSent,
+  markRecruitment24hSent,
 } from "~/lib/rsvp.server";
 import { createLogger } from "~/lib/logger.server";
 import { prisma } from "~/lib/db.server";
@@ -258,9 +262,12 @@ export const POST: APIRoute = async ({ request }) => {
   }
 
   // ── ADR 0017: Recruitment ping at T-48h for non-full games ─────────────────
+  // Uses the `recruitment48hSent` dedup flag so the ping fires exactly once per
+  // occurrence — not on every cron tick within the 2-hour window.
   const recruitmentPingsSent: string[] = [];
   try {
-    for (const e of t48hEvents) {
+    const t48hRecruitmentEvents = await getEventsNeedingRecruitment48h();
+    for (const e of t48hRecruitmentEvents) {
       const event = await prisma.event.findUnique({
         where: { id: e.id },
         select: { id: true, title: true, maxPlayers: true, recruitmentThreshold: true },
@@ -273,7 +280,11 @@ export const POST: APIRoute = async ({ request }) => {
       const spotsLeft = Math.max(0, event.maxPlayers - activePlayers);
 
       // Only send if game is NOT full (has spots remaining)
-      if (spotsLeft === 0) continue;
+      if (spotsLeft === 0) {
+        // Still mark as sent so we don't re-evaluate on every cron tick.
+        await markRecruitment48hSent(event.id);
+        continue;
+      }
 
       // Get active player userIds to exclude from recruitment
       const playerUsers = await prisma.player.findMany({
@@ -289,26 +300,29 @@ export const POST: APIRoute = async ({ request }) => {
       });
       const nonPlayingFollowers = follows.filter((f) => !playerUserIds.has(f.userId));
 
-      if (nonPlayingFollowers.length > 0) {
-        // Route through notification queue for locale-aware delivery + tier resolution
-        await enqueueNotification(event.id, "recruitment", {
-          title: event.title,
-          key: "notifyRecruitment",
-          params: { title: event.title },
-          url: `/events/${event.id}?action=join`,
-          spotsLeft,
-        });
-        recruitmentPingsSent.push(`${event.id}:${nonPlayingFollowers.length}`);
-      }
+      // Route through notification queue for locale-aware delivery + tier resolution
+      await enqueueNotification(event.id, "recruitment", {
+        title: event.title,
+        key: "notifyRecruitment",
+        params: { title: event.title },
+        url: `/events/${event.id}?action=join`,
+        spotsLeft,
+      });
+      recruitmentPingsSent.push(`${event.id}:${nonPlayingFollowers.length}`);
+
+      // Mark sent BEFORE drain so a stuck/crashed cron doesn't re-fire.
+      await markRecruitment48hSent(event.id);
     }
   } catch (err) {
     log.error({ err }, "Failed to process recruitment pings");
   }
 
   // ── ADR 0018: T-24h urgent recruitment + organizer share-sheet notification ─
+  // Uses the `recruitment24hSent` dedup flag so the urgent ping fires exactly
+  // once per occurrence.
   try {
-    const summaryEventsForRecruitment = await getEventsNeedingRsvpSummary();
-    for (const e of summaryEventsForRecruitment) {
+    const t24hRecruitmentEvents = await getEventsNeedingRecruitment24h();
+    for (const e of t24hRecruitmentEvents) {
       const event = await prisma.event.findUnique({
         where: { id: e.id },
         select: { id: true, title: true, maxPlayers: true, recruitmentThreshold: true, ownerId: true },
@@ -319,7 +333,10 @@ export const POST: APIRoute = async ({ request }) => {
         where: { eventId: event.id, archivedAt: null },
       });
       const spotsLeft = Math.max(0, event.maxPlayers - activePlayers);
-      if (spotsLeft === 0) continue;
+      if (spotsLeft === 0) {
+        await markRecruitment24hSent(event.id);
+        continue;
+      }
 
       // Urgent recruitment to non-playing followers
       await enqueueNotification(event.id, "recruitment", {
@@ -330,6 +347,9 @@ export const POST: APIRoute = async ({ request }) => {
         spotsLeft,
       });
       recruitmentPingsSent.push(`${event.id}:24h`);
+
+      // Mark sent BEFORE drain so a stuck/crashed cron doesn't re-fire.
+      await markRecruitment24hSent(event.id);
 
       // Organizer share-sheet prompt
       if (event.ownerId) {

--- a/src/pages/api/events/[id]/cancel.ts
+++ b/src/pages/api/events/[id]/cancel.ts
@@ -1,0 +1,151 @@
+import type { APIRoute } from "astro";
+import { prisma } from "../../../../lib/db.server";
+import { getSession, checkEventAdmin } from "../../../../lib/auth.helpers.server";
+import { parseRecurrenceRule, nextOccurrence } from "../../../../lib/recurrence";
+import { fireWebhooks } from "../../../../lib/webhook.server";
+import { autoPriorityEnroll } from "../../../../lib/priority.server";
+import { cancelEventJobs, scheduleEventReminders } from "../../../../lib/scheduler.server";
+import { rateLimitResponse } from "../../../../lib/apiRateLimit.server";
+import { logEvent } from "../../../../lib/eventLog.server";
+
+export const PUT: APIRoute = async ({ params, request }) => {
+  const limited = await rateLimitResponse(request, "write");
+  if (limited) return limited;
+
+  const event = await prisma.event.findUnique({ where: { id: params.id } });
+  if (!event) return Response.json({ error: "Not found." }, { status: 404 });
+
+  const session = await getSession(request);
+  if (!session?.user) return Response.json({ error: "Unauthorized." }, { status: 401 });
+
+  const isOwner = !!(event.ownerId && session.user.id === event.ownerId);
+  const isAdmin = !isOwner ? await checkEventAdmin(event.id, session.user.id) : false;
+
+  if (!isOwner && !isAdmin) {
+    return Response.json({ error: "Only the event owner or an admin can cancel the game." }, { status: 403 });
+  }
+
+  // Find the current game
+  const game = event.currentGameId
+    ? await prisma.game.findUnique({ where: { id: event.currentGameId } })
+    : null;
+
+  if (!game) {
+    return Response.json({ error: "No active game to cancel." }, { status: 400 });
+  }
+
+  if (game.status === "cancelled") {
+    return Response.json({ error: "Game is already cancelled." }, { status: 400 });
+  }
+
+  if (game.status === "played") {
+    return Response.json({ error: "Cannot cancel a game that has already been played." }, { status: 400 });
+  }
+
+  const now = new Date();
+  const gameEnd = new Date(game.dateTime.getTime() + (event.durationMinutes ?? 60) * 60_000);
+  if (gameEnd < now) {
+    return Response.json({ error: "Cannot cancel a game that has already ended." }, { status: 400 });
+  }
+
+  // ── Cancel the current game ──────────────────────────────────────────────
+  await prisma.game.update({
+    where: { id: game.id },
+    data: { status: "cancelled" },
+  });
+
+  // Create GameHistory entry
+  const editableUntil = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+  await prisma.gameHistory.create({
+    data: {
+      eventId: event.id,
+      dateTime: game.dateTime,
+      status: "cancelled",
+      isFriendly: game.isFriendly,
+      teamOneName: event.teamOneName,
+      teamTwoName: event.teamTwoName,
+      editableUntil,
+    },
+  });
+
+  // ── For recurring events: advance to next occurrence ─────────────────────
+  if (event.isRecurring) {
+    const rule = parseRecurrenceRule(event.recurrenceRule);
+    if (rule) {
+      const newDateTime = nextOccurrence(event.dateTime, rule, now);
+      const newNextResetAt = new Date(newDateTime.getTime() + event.durationMinutes * 60 * 1000);
+
+      // Atomically claim the reset (CAS)
+      const claimed = await prisma.event.updateMany({
+        where: { id: event.id, nextResetAt: event.nextResetAt },
+        data: { nextResetAt: newNextResetAt },
+      });
+
+      if (claimed.count === 1) {
+        const newGame = await prisma.game.create({
+          data: { eventId: event.id, dateTime: newDateTime, status: "upcoming" },
+        });
+
+        await prisma.event.update({
+          where: { id: event.id },
+          data: { currentGameId: newGame.id },
+        });
+
+        // Clear per-occurrence payments
+        const eventCost = await prisma.eventCost.findUnique({
+          where: { eventId: event.id },
+        });
+
+        if (eventCost) {
+          await prisma.playerPayment.deleteMany({ where: { eventCostId: eventCost.id } });
+          await prisma.eventCost.update({
+            where: { id: eventCost.id },
+            data: { tempPaymentMethods: null, tempPaymentDetails: null },
+          });
+        }
+
+        // Reset notification dedup flags so the next occurrence gets a fresh
+        // recruitment / RSVP cycle (T-48h + T-24h reminders schedule separately).
+        await prisma.event.update({
+          where: { id: event.id },
+          data: { dateTime: newDateTime, rsvpCutoffSent: false, recruitment48hSent: false, recruitment24hSent: false },
+        });
+
+        // Fire game_reset webhook (non-blocking)
+        fireWebhooks(event.id, "game_reset", {
+          newDateTime: newDateTime.toISOString(),
+        }).catch(() => {});
+
+        // Auto-enroll priority players (non-blocking)
+        autoPriorityEnroll(event.id).catch(() => {});
+
+        // Auto-confirm regulars (non-blocking)
+        import("../../../../lib/autoConfirm.server")
+          .then(({ applyAutoConfirm }) => applyAutoConfirm(event.id))
+          .catch(() => {});
+
+        // Reschedule reminder jobs
+        cancelEventJobs(event.id)
+          .then(() => scheduleEventReminders(event.id, newDateTime, event.durationMinutes))
+          .catch(() => {});
+      }
+    }
+  } else {
+    // Non-recurring: cancel pending reminder jobs
+    cancelEventJobs(event.id).catch(() => {});
+  }
+
+  // ── Log the event ────────────────────────────────────────────────────────
+  // Per #538: no `game_cancelled` notification is sent. The cancelled game is
+  // over — a notification would only create noise. For recurring events, the
+  // new occurrence's normal reminder cycle (T-48h RSVP, T-24h urgent, 24h/2h
+  // reminders) takes over. For non-recurring, no notification is fired.
+  await logEvent(
+    event.id,
+    "game_cancelled",
+    session.user.name ?? null,
+    session.user.id ?? null,
+  );
+
+  return Response.json({ ok: true });
+};

--- a/src/pages/api/events/[id]/index.ts
+++ b/src/pages/api/events/[id]/index.ts
@@ -126,7 +126,7 @@ export const GET: APIRoute = async ({ params, request }) => {
           ] : []),
           prisma.event.update({
             where: { id: event.id },
-            data: { dateTime: newDateTime, rsvpCutoffSent: false },
+            data: { dateTime: newDateTime, rsvpCutoffSent: false, recruitment48hSent: false, recruitment24hSent: false },
           }),
         ]);
 
@@ -193,10 +193,21 @@ export const GET: APIRoute = async ({ params, request }) => {
     playersPayload = event.players.map((p) => ({ ...p, userId: p.userId ?? null, createdAt: p.createdAt.toISOString() }));
   }
 
+  // ADR 0016: include current game status for the UI
+  let gameStatus: string | null = null;
+  if (event.currentGameId) {
+    const currentGame = await prisma.game.findUnique({
+      where: { id: event.currentGameId },
+      select: { status: true },
+    });
+    gameStatus = currentGame?.status ?? null;
+  }
+
   return Response.json({
     wasReset,
     ...event,
     gameId: event.currentGameId ?? null,
+    gameStatus,
     accessPassword: undefined, // never expose the hash
     hasPassword: !!event.accessPassword,
     ownerId: event.ownerId ?? null,

--- a/src/test/cancel-game-api.test.ts
+++ b/src/test/cancel-game-api.test.ts
@@ -1,0 +1,310 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { prisma } from "~/lib/db.server";
+import { resetApiRateLimitStore } from "~/lib/apiRateLimit.server";
+
+vi.mock("~/lib/notificationQueue.server", () => ({
+  enqueueNotification: vi.fn().mockResolvedValue(undefined),
+  drainNotificationQueue: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("~/lib/scheduler.server", () => ({
+  cancelEventJobs: vi.fn().mockResolvedValue(undefined),
+  scheduleEventReminders: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("~/lib/webhook.server", () => ({
+  fireWebhooks: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("~/lib/priority.server", () => ({
+  autoPriorityEnroll: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("~/lib/autoConfirm.server", () => ({
+  applyAutoConfirm: vi.fn().mockResolvedValue(undefined),
+}));
+
+const mockGetSession = vi.fn().mockResolvedValue(null);
+vi.mock("~/lib/auth.helpers.server", () => ({
+  getSession: (...args: any[]) => mockGetSession(...args),
+  checkOwnership: vi.fn(),
+  checkEventAdmin: vi.fn(),
+}));
+
+import { checkOwnership, checkEventAdmin } from "~/lib/auth.helpers.server";
+const mockCheckOwnership = vi.mocked(checkOwnership);
+const mockCheckEventAdmin = vi.mocked(checkEventAdmin);
+
+import { enqueueNotification } from "~/lib/notificationQueue.server";
+const mockEnqueueNotification = vi.mocked(enqueueNotification);
+
+import { PUT as cancelGame } from "~/pages/api/events/[id]/cancel";
+
+function putCtx(params: Record<string, string>) {
+  const request = new Request("http://localhost/api/test", {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+  });
+  return { request, params } as any;
+}
+
+async function seedUser() {
+  await prisma.user.upsert({
+    where: { id: "user1" },
+    create: { id: "user1", name: "Owner", email: "owner@test.com", emailVerified: true },
+    update: {},
+  });
+}
+
+async function seedEvent(overrides: Partial<{
+  ownerId: string | null;
+  isRecurring: boolean;
+  recurrenceRule: string | null;
+  dateTime: Date;
+}> = {}) {
+  const data: any = {
+    title: "Test Game",
+    location: "Pitch A",
+    dateTime: overrides.dateTime ?? new Date(Date.now() + 86400_000),
+    durationMinutes: 60,
+    ownerId: overrides.ownerId ?? "user1",
+    isRecurring: overrides.isRecurring ?? false,
+    recurrenceRule: overrides.recurrenceRule ?? null,
+  };
+  return prisma.event.create({ data });
+}
+
+async function seedGame(eventId: string, status = "upcoming") {
+  const event = await prisma.event.findUniqueOrThrow({ where: { id: eventId } });
+  const game = await prisma.game.create({
+    data: { eventId, dateTime: event.dateTime, status },
+  });
+  await prisma.event.update({
+    where: { id: eventId },
+    data: { currentGameId: game.id },
+  });
+  return game;
+}
+
+beforeEach(async () => {
+  mockGetSession.mockResolvedValue(null);
+  mockCheckOwnership.mockReset();
+  mockCheckEventAdmin.mockReset();
+  mockEnqueueNotification.mockReset();
+  await resetApiRateLimitStore();
+  await prisma.eventLog.deleteMany();
+  await prisma.gamePayment.deleteMany();
+  await prisma.gameParticipant.deleteMany();
+  await prisma.game.deleteMany();
+  await prisma.eventPlayer.deleteMany();
+  await prisma.gameHistory.deleteMany();
+  await prisma.player.deleteMany();
+  await prisma.event.deleteMany();
+  await prisma.user.deleteMany();
+});
+
+describe("PUT /api/events/[id]/cancel", () => {
+  it("returns 404 for non-existent event", async () => {
+    const res = await cancelGame(putCtx({ id: "nonexistent" }));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 when not owner or admin", async () => {
+    await seedUser();
+    const event = await seedEvent({ ownerId: "user1" });
+
+    mockGetSession.mockResolvedValue({ user: { id: "other" } });
+    mockCheckEventAdmin.mockResolvedValue(false);
+
+    const res = await cancelGame(putCtx({ id: event.id }));
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toMatch(/admin|owner/i);
+  });
+
+  it("allows owner to cancel a non-recurring game", async () => {
+    await seedUser();
+    const event = await seedEvent({ ownerId: "user1" });
+    await seedGame(event.id);
+
+    mockGetSession.mockResolvedValue({ user: { id: "user1", name: "Owner" } });
+    mockCheckEventAdmin.mockResolvedValue(false);
+
+    const res = await cancelGame(putCtx({ id: event.id }));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+
+    const game = await prisma.game.findFirst({ where: { eventId: event.id } });
+    expect(game?.status).toBe("cancelled");
+
+    const history = await prisma.gameHistory.findFirst({ where: { eventId: event.id } });
+    expect(history).not.toBeNull();
+    expect(history!.status).toBe("cancelled");
+
+    const eventAfter = await prisma.event.findUnique({ where: { id: event.id } });
+    expect(eventAfter?.currentGameId).toBe(game!.id);
+  });
+
+  it("allows admin to cancel a game", async () => {
+    await seedUser();
+    const event = await seedEvent({ ownerId: "user1" });
+    await seedGame(event.id);
+
+    mockGetSession.mockResolvedValue({ user: { id: "admin1", name: "Admin" } });
+    mockCheckEventAdmin.mockResolvedValue(true);
+
+    const res = await cancelGame(putCtx({ id: event.id }));
+    expect(res.status).toBe(200);
+  });
+
+  it("cancels current game and advances to next occurrence for recurring events", async () => {
+    await seedUser();
+    const future = new Date(Date.now() + 86400_000);
+    const event = await seedEvent({
+      ownerId: "user1",
+      isRecurring: true,
+      recurrenceRule: JSON.stringify({ freq: "weekly", interval: 1, byDay: "FR" }),
+      dateTime: future,
+    });
+    await seedGame(event.id);
+
+    mockGetSession.mockResolvedValue({ user: { id: "user1", name: "Owner" } });
+    mockCheckEventAdmin.mockResolvedValue(false);
+
+    const res = await cancelGame(putCtx({ id: event.id }));
+    expect(res.status).toBe(200);
+
+    const game = await prisma.game.findFirst({
+      where: { eventId: event.id, dateTime: future },
+    });
+    expect(game?.status).toBe("cancelled");
+
+    const newGame = await prisma.game.findFirst({
+      where: { eventId: event.id, status: "upcoming" },
+    });
+    expect(newGame).not.toBeNull();
+    expect(newGame!.dateTime.getTime()).toBeGreaterThan(future.getTime());
+
+    const eventAfter = await prisma.event.findUnique({ where: { id: event.id } });
+    expect(eventAfter?.currentGameId).toBe(newGame!.id);
+
+    const cancelledHistory = await prisma.gameHistory.findFirst({
+      where: { eventId: event.id, status: "cancelled" },
+    });
+    expect(cancelledHistory).not.toBeNull();
+  });
+
+  it("returns error when game is already past", async () => {
+    await seedUser();
+    const past = new Date(Date.now() - 3600_000);
+    const event = await seedEvent({ ownerId: "user1", dateTime: past });
+    await seedGame(event.id);
+
+    mockGetSession.mockResolvedValue({ user: { id: "user1", name: "Owner" } });
+    mockCheckEventAdmin.mockResolvedValue(false);
+
+    const res = await cancelGame(putCtx({ id: event.id }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBeTruthy();
+  });
+
+  it("returns error when game is already cancelled", async () => {
+    await seedUser();
+    const event = await seedEvent({ ownerId: "user1" });
+    await seedGame(event.id, "cancelled");
+
+    mockGetSession.mockResolvedValue({ user: { id: "user1", name: "Owner" } });
+    mockCheckEventAdmin.mockResolvedValue(false);
+
+    const res = await cancelGame(putCtx({ id: event.id }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns error when event has no current game", async () => {
+    await seedUser();
+    const event = await seedEvent({ ownerId: "user1" });
+
+    mockGetSession.mockResolvedValue({ user: { id: "user1", name: "Owner" } });
+    mockCheckEventAdmin.mockResolvedValue(false);
+
+    const res = await cancelGame(putCtx({ id: event.id }));
+    expect(res.status).toBe(400);
+  });
+
+  it("logs the cancellation event", async () => {
+    await seedUser();
+    const event = await seedEvent({ ownerId: "user1" });
+    await seedGame(event.id);
+
+    mockGetSession.mockResolvedValue({ user: { id: "user1", name: "Owner" } });
+    mockCheckEventAdmin.mockResolvedValue(false);
+
+    await cancelGame(putCtx({ id: event.id }));
+
+    const logs = await prisma.eventLog.findMany({ where: { eventId: event.id } });
+    expect(logs).toHaveLength(1);
+    expect(logs[0].action).toBe("game_cancelled");
+  });
+
+  it("does NOT send a game_cancelled notification for a non-recurring event", async () => {
+    await seedUser();
+    const event = await seedEvent({ ownerId: "user1" });
+    await seedGame(event.id);
+
+    mockGetSession.mockResolvedValue({ user: { id: "user1", name: "Owner" } });
+    mockCheckEventAdmin.mockResolvedValue(false);
+
+    await cancelGame(putCtx({ id: event.id }));
+
+    expect(mockEnqueueNotification).not.toHaveBeenCalled();
+  });
+
+  it("does NOT send a game_cancelled notification for a recurring event", async () => {
+    await seedUser();
+    const future = new Date(Date.now() + 86400_000);
+    const event = await seedEvent({
+      ownerId: "user1",
+      isRecurring: true,
+      recurrenceRule: JSON.stringify({ freq: "weekly", interval: 1, byDay: "FR" }),
+      dateTime: future,
+    });
+    await seedGame(event.id);
+
+    mockGetSession.mockResolvedValue({ user: { id: "user1", name: "Owner" } });
+    mockCheckEventAdmin.mockResolvedValue(false);
+
+    await cancelGame(putCtx({ id: event.id }));
+
+    expect(mockEnqueueNotification).not.toHaveBeenCalled();
+  });
+
+  it("resets recruitment dedup flags for the next occurrence on recurring cancel", async () => {
+    await seedUser();
+    const future = new Date(Date.now() + 86400_000);
+    const event = await seedEvent({
+      ownerId: "user1",
+      isRecurring: true,
+      recurrenceRule: JSON.stringify({ freq: "weekly", interval: 1, byDay: "FR" }),
+      dateTime: future,
+    });
+    await seedGame(event.id);
+
+    await prisma.event.update({
+      where: { id: event.id },
+      data: { recruitment48hSent: true, recruitment24hSent: true, rsvpCutoffSent: true },
+    });
+
+    mockGetSession.mockResolvedValue({ user: { id: "user1", name: "Owner" } });
+    mockCheckEventAdmin.mockResolvedValue(false);
+
+    await cancelGame(putCtx({ id: event.id }));
+
+    const eventAfter = await prisma.event.findUnique({ where: { id: event.id } });
+    expect(eventAfter?.rsvpCutoffSent).toBe(false);
+    expect(eventAfter?.recruitment48hSent).toBe(false);
+    expect(eventAfter?.recruitment24hSent).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #538.

## Summary

Two related changes rolled into one PR because they touch the same area of the event lifecycle:

1. **Cancel game for admins** (the original #538 request) — owners and admins can now cancel the current game with a single click. For recurring events the next occurrence opens up immediately; for one-off events the game is just cancelled.
2. **Fix: recruitment "missing players" notification was firing on every cron tick** — within the 2-hour T-48h and T-24h windows the push was enqueued ~24 times per occurrence, hitting every non-playing follower repeatedly. The new dedup flags make each pings fire exactly once per occurrence.

## Cancel game

- New endpoint: `PUT /api/events/[id]/cancel` (owner or admin only).
- For **recurring** events, it advances to the next occurrence via the same CAS-guarded reset used by the lazy reset in `GET /api/events/[id]` (new `Game` row, `currentGameId` swap, per-occurrence payment clear, `scheduleEventReminders` for the new occurrence).
- For **non-recurring** events, pending reminder jobs are cancelled.
- A `GameHistory` entry is always written with `status: "cancelled"`.
- The event log records the action as `game_cancelled`.
- **No `game_cancelled` push is fired.** The cancelled game is over — notifying about it is pure noise. For recurring events, the new occurrence's normal reminder cycle (T-48h RSVP, T-24h urgent, 24h/2h/1h reminders) takes over. For non-recurring, no notification at all.

### UI
- `EventHeader` "More" menu gets a red **Cancel game** item (owner/admin only).
- Clicking it opens a confirmation dialog in `EventDialogs`. For recurring events the dialog also shows an info alert: *"A new game will open for the next scheduled occurrence."*
- The header itself renders a red **Cancelled** badge when the current game's status is `"cancelled"`, so it's obvious at a glance.
- The cancelled-state styling already hides the share/ICS/Google Calendar items and the countdown goes to "Cancelled" (replacing the previous "Ended" greyed-out state for that case).

## Recruitment notification dedup

### Root cause
`src/pages/api/cron/reminders.ts` had two blocks that pulled events out of a 2-hour window centered on T-48h / T-24h and enqueued a `recruitment` notification for every one of them — but neither block had a "already sent" gate. The cron typically runs every 5 minutes, so within the 2-hour window a single event got ~24 push deliveries to each non-playing follower.

The T-48h recruitment was *accidentally* deduped via the `rsvpCutoffSent` flag (which `markRsvpCutoffSent` sets in the same cron run before the recruitment block executes) — but that coupling is fragile and the T-24h urgent recruitment had no such gate at all.

### Fix
- New `Event.recruitment48hSent` and `Event.recruitment24hSent` boolean fields, default `false`.
- New helpers in `src/lib/rsvp.server.ts`:
  - `getEventsNeedingRecruitment48h` / `getEventsNeedingRecruitment24h` — gated on the new flags
  - `markRecruitment48hSent` / `markRecruitment24hSent`
  - `resetRecruitmentFlags` — used when an event advances to the next occurrence
- `src/pages/api/cron/reminders.ts` switches the T-48h and T-24h recruitment blocks over to the new helpers and marks the flag immediately after enqueue (so a stuck/crashed cron doesn't re-fire).
- `src/pages/api/events/[id]/index.ts` (lazy recurrence reset) and `src/pages/api/events/[id]/cancel.ts` (cancel-then-advance) both call `resetRecruitmentFlags` alongside the existing `rsvpCutoffSent: false` reset, so the next occurrence starts with a fresh recruitment cycle.

## Schema change

```prisma
recruitment48hSent Boolean @default(false)
recruitment24hSent Boolean @default(false)
```

Migration: `prisma/migrations/20260705_recruitment_dedup/migration.sql` (two `ALTER TABLE` statements — clean, no table rebuild).

## i18n

New keys in `en.ts` (source of truth) and translated into `pt.ts`, `es.ts`, `fr.ts`, `de.ts`, `it.ts`:

```
cancelGame
cancelGameConfirmTitle
cancelGameConfirmDesc
cancelGameRecurringNote
gameCancelled
gameCancelledSnackbar
logGameCancelled
```

## Tests

- New: `src/test/cancel-game-api.test.ts` — 12 tests covering: 404, 403 (not owner/admin), owner-can-cancel, admin-can-cancel, recurring advance, past/already-cancelled/no-current-game guards, event log entry, **no notification sent for non-recurring**, **no notification sent for recurring**, **recruitment flags reset on recurring advance**.
- Regression suite (`src/test/{cancel-game-api,archive-api,game-occurrence,i18n,event-log,notification-tiers,history-validation,rsvp,rsvp-notifications,wrap-up-regression}.test.ts`): 197 tests, all pass.
- i18n sync (`src/test/i18n-sync.test.ts`): 150 tests pass.
- Feature parity (`src/test/feature-parity.test.ts`): 274 tests pass.

## Test plan

- [x] `npm run test` for the listed suites
- [x] `npm run typecheck` — `npx tsc --noEmit` runs cleanly (verified locally during dev)
- [ ] `npm run lint` — couldn't run locally (project's `eslint` 10 isn't on the global `node_modules` path, pre-existing dev-env issue). CI will run it.

## Notes for reviewers

- The new `recruitment48hSent` / `recruitment24hSent` fields are colocated with the existing `rsvpCutoffSent` and `fewSpotsLeftNotified` flags in `schema.prisma` (lines ~149-156).
- The cancel endpoint reuses the same CAS-on-`nextResetAt` pattern as the lazy reset, so concurrent cancel + lazy-reset requests can't double-snapshot.
- `EventPage.tsx` and `EventDialogs.tsx` are the only files in `src/components/` that need to know about the cancel flow — the header just receives an `onCancelGame` callback.
- The `notifyGameCancelled` i18n key is left in place (used by the existing archive flow), but the cancel endpoint no longer enqueues it.