### PR TITLE
fix: allow players to join new game after recurring reset

### DIFF
--- a/src/pages/api/events/[id]/players.ts
+++ b/src/pages/api/events/[id]/players.ts
@@ -530,6 +530,34 @@ export const POST: APIRoute = async ({ params, request }) => {
         }
         return Response.json({ ok: true, invited: null, resolvedName: trimmed, reactivated: true });
       }
+      // ── ADR 0016: game-scoped re-join after recurring reset ─────────────
+      // Player record exists at event level (from last week) but may not be in
+      // the current game yet. If so, add them to the new game instead of erroring.
+      if (existing && !existing.archivedAt && event.currentGameId) {
+        const eventPlayer = await prisma.eventPlayer.upsert({
+          where: { eventId_name: { eventId, name: trimmed } },
+          create: { eventId, name: trimmed, userId: linkedUserId ?? existing.userId },
+          update: {},
+        });
+        const alreadyInGame = await prisma.gameParticipant.findUnique({
+          where: { gameId_eventPlayerId: { gameId: event.currentGameId, eventPlayerId: eventPlayer.id } },
+        });
+        if (!alreadyInGame) {
+          const gpCount = await prisma.gameParticipant.count({
+            where: { gameId: event.currentGameId, archivedAt: null },
+          });
+          await prisma.gameParticipant.create({
+            data: { gameId: event.currentGameId, eventPlayerId: eventPlayer.id, order: gpCount },
+          });
+          // Link user if not already linked
+          if (linkedUserId && !existing.userId) {
+            await prisma.player.update({ where: { id: existing.id }, data: { userId: linkedUserId } });
+          }
+          return Response.json({ ok: true, invited: null, resolvedName: trimmed });
+        }
+        // Already in the current game — fall through to duplicate error
+      }
+
       if (resolvedUser) {
         if (existing) {
           if (!existing.userId) {

--- a/src/pages/api/events/[id]/priority/confirm.ts
+++ b/src/pages/api/events/[id]/priority/confirm.ts
@@ -14,7 +14,7 @@ export const POST: APIRoute = async ({ params, request }) => {
 
   const event = await prisma.event.findUnique({
     where: { id: params.id },
-    select: { id: true, dateTime: true },
+    select: { id: true, dateTime: true, currentGameId: true },
   });
   if (!event) return Response.json({ error: "Not found." }, { status: 404 });
 
@@ -38,6 +38,20 @@ export const POST: APIRoute = async ({ params, request }) => {
           userId: session.user.id,
           order: (maxOrder._max.order ?? -1) + 1,
         },
+      });
+    }
+
+    // ADR 0016: also add to current game via GameParticipant
+    if (event.currentGameId) {
+      const eventPlayer = await prisma.eventPlayer.upsert({
+        where: { eventId_name: { eventId: event.id, name: session.user.name } },
+        create: { eventId: event.id, name: session.user.name, userId: session.user.id },
+        update: {},
+      });
+      await prisma.gameParticipant.upsert({
+        where: { gameId_eventPlayerId: { gameId: event.currentGameId, eventPlayerId: eventPlayer.id } },
+        create: { gameId: event.currentGameId, eventPlayerId: eventPlayer.id, order: 0 },
+        update: {},
       });
     }
   }


### PR DESCRIPTION
## Problem

After a recurring event resets (e.g., weekly Ninjas game), players cannot Quick Join — they get "José Cabeda is already in the list" even though the player list shows 0/10.

## Root Cause

ADR 0016 introduced game-scoped display via `GameParticipant` + `EventPlayer`. After a recurring reset:
1. A new `Game` is created (empty — no `GameParticipant` records)
2. The UI reads from `GameParticipant` for the current game → shows 0 players correctly
3. But the event-level `Player` records persist (not archived)
4. When someone tries to join, `prisma.player.create` hits the P2002 unique constraint on `[eventId, name]`
5. The P2002 handler saw the player wasn't archived → returned 409 "already in the list"

## Fix

- **`players.ts`**: The P2002 handler now checks if the existing player has a `GameParticipant` for the current game. If not, it creates one (treating it as a new-week join) instead of returning 409.
- **`priority/confirm.ts`**: When a priority player confirms their spot, it now also creates a `GameParticipant` for the current game (previously only created the `Player` record).

## Testing

- All player-related tests pass
- Priority API tests pass
- Typecheck clean (after regenerating Prisma client)