### PR TITLE
fix: remove explicit pnpm version from CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
-        with:
-          version: 11
       - uses: actions/setup-node@v6
         with:
           node-version: 24
@@ -46,8 +44,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
-        with:
-          version: 11
       - uses: actions/setup-node@v6
         with:
           node-version: 24
@@ -66,8 +62,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
-        with:
-          version: 11
       - uses: actions/setup-node@v6
         with:
           node-version: 24
@@ -95,8 +89,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
-        with:
-          version: 11
       - uses: actions/setup-node@v6
         with:
           node-version: 24
@@ -121,8 +113,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
-        with:
-          version: 11
       - uses: actions/setup-node@v6
         with:
           node-version: 24
@@ -150,8 +140,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
-        with:
-          version: 11
       - uses: actions/setup-node@v6
         with:
           node-version: 24


### PR DESCRIPTION
pnpm/action-setup@v4 reads the version from package.json `packageManager` field (`pnpm@11.6.0`). Specifying `version: 11` in the workflow causes a conflict error. Let the action pick up the version from package.json instead.

This unblocks CI on main (broken since #547 merge).