### PR TITLE
fix: clear stale teams after recurring event reset

### DIFF
--- a/src/pages/api/events/[id]/cancel.ts
+++ b/src/pages/api/events/[id]/cancel.ts
@@ -104,6 +104,17 @@ export const PUT: APIRoute = async ({ params, request }) => {
           });
         }
 
+        // Clear team members for the new game (old teams were snapshotted in GameHistory)
+        const teamResults = await prisma.teamResult.findMany({
+          where: { eventId: event.id },
+          select: { id: true },
+        });
+        if (teamResults.length > 0) {
+          await prisma.teamMember.deleteMany({
+            where: { teamResultId: { in: teamResults.map((tr) => tr.id) } },
+          });
+        }
+
         // Reset notification dedup flags so the next occurrence gets a fresh
         // recruitment / RSVP cycle (T-48h + T-24h reminders schedule separately).
         await prisma.event.update({

--- a/src/pages/api/events/[id]/index.ts
+++ b/src/pages/api/events/[id]/index.ts
@@ -124,6 +124,10 @@ export const GET: APIRoute = async ({ params, request }) => {
             prisma.playerPayment.deleteMany({ where: { eventCostId: eventCost.id } }),
             prisma.eventCost.update({ where: { id: eventCost.id }, data: { tempPaymentMethods: null, tempPaymentDetails: null } }),
           ] : []),
+          // Clear team members for the new game (teams are snapshotted in GameHistory above)
+          ...event.teamResults.map((tr) =>
+            prisma.teamMember.deleteMany({ where: { teamResultId: tr.id } }),
+          ),
           prisma.event.update({
             where: { id: event.id },
             data: { dateTime: newDateTime, rsvpCutoffSent: false, recruitment48hSent: false, recruitment24hSent: false },
@@ -203,9 +207,19 @@ export const GET: APIRoute = async ({ params, request }) => {
     gameStatus = currentGame?.status ?? null;
   }
 
+  // ADR 0016: filter teamResults to only include members in the current game's player list.
+  // After a recurrence reset, old team members linger in TeamResult but the player list
+  // is now game-scoped via GameParticipant. Only show team members who are active players.
+  const activePlayerNames = new Set(playersPayload.map((p: { name: string }) => p.name));
+  const filteredTeamResults = event.teamResults.map((tr) => ({
+    ...tr,
+    members: tr.members.filter((m) => activePlayerNames.has(m.name)),
+  }));
+
   return Response.json({
     wasReset,
     ...event,
+    teamResults: filteredTeamResults,
     gameId: event.currentGameId ?? null,
     gameStatus,
     accessPassword: undefined, // never expose the hash


### PR DESCRIPTION
After a recurrence reset, old TeamMember records from the previous game lingered because they were never cleared. This caused the event page to display last week's teams even when the new game had different (or zero) players.

**Fixes:**
1. The reset transaction now deletes TeamMember records after snapshotting them into GameHistory (both in index.ts lazy reset and cancel.ts).
2. The GET response filters `teamResults.members` to only include players who are in the current game's participant list — so even for events that already reset in the past, only current players appear in teams.