### PR TITLE
fix: suppress post-game banner for cancelled games

### DIFF
--- a/src/pages/api/events/[id]/post-game-status.ts
+++ b/src/pages/api/events/[id]/post-game-status.ts
@@ -34,7 +34,7 @@ export const GET: APIRoute = async ({ params, request }) => {
 
   // ponytail: cancelled games have no post-game actions (no score, no payments, no MVP).
   // Suppress the banner entirely when the most recent history is "cancelled".
-  if (latestHistory?.status === "cancelled" && gameEnded) {
+  if (latestHistory?.status === "cancelled") {
     return Response.json({
       gameEnded: false, hasScore: false, hasCost: false, allPaid: true,
       allComplete: true, isParticipant: false, latestHistoryId: null,


### PR DESCRIPTION
The previous fix (#552) only suppressed the banner when `gameEnded` was true. For recurring events that already advanced to the next occurrence (like the Ninjas event), `gameEnded` is false but the cancelled game's payment snapshot still triggered `hasPendingPastPayments`, showing the banner incorrectly.

Removes the `&& gameEnded` condition so cancelled games always suppress the banner.