### PR TITLE
fix: usage metrics — Android vs Web with browser/OS drill-down

### DIFF
--- a/src/components/AdminDashboardPage.tsx
+++ b/src/components/AdminDashboardPage.tsx
@@ -51,15 +51,15 @@ interface UsageSummary {
   dauToday: number;
   wau: number;
   mau: number;
-  platforms: { android: number; ios: number; desktop: number };
+  platforms: { android: number; web: number };
+  webDrillDown: { browsers: Record<string, number>; os: Record<string, number> };
 }
 
 interface UsagePoint {
   date: string;
   dau: number;
   android: number;
-  ios: number;
-  desktop: number;
+  web: number;
 }
 
 type GrowthRange = "30d" | "1y" | "all";
@@ -383,11 +383,32 @@ export default function AdminDashboardPage() {
                       {/* Platform breakdown */}
                       <Box>
                         <Typography variant="subtitle2" fontWeight={600} gutterBottom>{t("adminPlatformBreakdown")}</Typography>
-                        <Stack direction="row" spacing={1} flexWrap="wrap">
+                        <Stack direction="row" spacing={1} flexWrap="wrap" sx={{ mb: 2 }}>
                           <Chip label={`Android: ${usageSummary.platforms.android}`} color="success" variant="outlined" />
-                          <Chip label={`iOS: ${usageSummary.platforms.ios}`} color="info" variant="outlined" />
-                          <Chip label={`Desktop: ${usageSummary.platforms.desktop}`} variant="outlined" />
+                          <Chip label={`Web: ${usageSummary.platforms.web}`} color="primary" variant="outlined" />
                         </Stack>
+
+                        {/* Web drill-down */}
+                        {usageSummary.platforms.web > 0 && usageSummary.webDrillDown && (
+                          <Stack spacing={1} sx={{ pl: 2, borderLeft: 3, borderColor: "primary.main" }}>
+                            <Typography variant="caption" fontWeight={600} color="text.secondary">{t("adminWebBrowsers")}</Typography>
+                            <Stack direction="row" spacing={0.5} flexWrap="wrap" useFlexGap>
+                              {Object.entries(usageSummary.webDrillDown.browsers)
+                                .sort(([, a], [, b]) => b - a)
+                                .map(([name, count]) => (
+                                  <Chip key={name} label={`${name}: ${count}`} size="small" variant="outlined" />
+                                ))}
+                            </Stack>
+                            <Typography variant="caption" fontWeight={600} color="text.secondary">{t("adminWebOS")}</Typography>
+                            <Stack direction="row" spacing={0.5} flexWrap="wrap" useFlexGap>
+                              {Object.entries(usageSummary.webDrillDown.os)
+                                .sort(([, a], [, b]) => b - a)
+                                .map(([name, count]) => (
+                                  <Chip key={name} label={`${name}: ${count}`} size="small" variant="outlined" />
+                                ))}
+                            </Stack>
+                          </Stack>
+                        )}
                       </Box>
 
                       {/* DAU timeline chart */}
@@ -401,9 +422,8 @@ export default function AdminDashboardPage() {
                               <RechartsTooltip content={<ChartTooltip />} />
                               <Legend />
                               <Line type="monotone" dataKey="dau" name="DAU" stroke="#4caf50" strokeWidth={2} dot={false} />
-                              <Line type="monotone" dataKey="android" name="Android" stroke="#66bb6a" strokeWidth={1} dot={false} strokeDasharray="4 2" />
-                              <Line type="monotone" dataKey="ios" name="iOS" stroke="#42a5f5" strokeWidth={1} dot={false} strokeDasharray="4 2" />
-                              <Line type="monotone" dataKey="desktop" name="Desktop" stroke="#ab47bc" strokeWidth={1} dot={false} strokeDasharray="4 2" />
+                              <Line type="monotone" dataKey="android" name="Android" stroke="#66bb6a" strokeWidth={1.5} dot={false} strokeDasharray="4 2" />
+                              <Line type="monotone" dataKey="web" name="Web" stroke="#42a5f5" strokeWidth={1.5} dot={false} strokeDasharray="4 2" />
                             </LineChart>
                           </ResponsiveContainer>
                         </Box>

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -811,6 +811,8 @@ const de: TranslationKeys = {
   adminWau: "WAU (7d)",
   adminMau: "MAU (30d)",
   adminPlatformBreakdown: "Platform Breakdown (30d)",
+  adminWebBrowsers: "Web — Browsers",
+  adminWebOS: "Web — Operating Systems",
   adminNoUsageData: "No usage data available yet.",
 
   // Event archive (#161)

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -862,6 +862,8 @@ const en = {
   adminWau: "WAU (7d)",
   adminMau: "MAU (30d)",
   adminPlatformBreakdown: "Platform Breakdown (30d)",
+  adminWebBrowsers: "Web — Browsers",
+  adminWebOS: "Web — Operating Systems",
   adminNoUsageData: "No usage data available yet.",
   adminDeleteUser: "Delete user",
   adminDeleteUserConfirm: "Are you sure you want to permanently delete this user? This cannot be undone.",

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -811,6 +811,8 @@ const es: TranslationKeys = {
   adminWau: "WAU (7d)",
   adminMau: "MAU (30d)",
   adminPlatformBreakdown: "Platform Breakdown (30d)",
+  adminWebBrowsers: "Web — Browsers",
+  adminWebOS: "Web — Operating Systems",
   adminNoUsageData: "No usage data available yet.",
 
   // Event archive (#161)

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -811,6 +811,8 @@ const fr: TranslationKeys = {
   adminWau: "WAU (7d)",
   adminMau: "MAU (30d)",
   adminPlatformBreakdown: "Platform Breakdown (30d)",
+  adminWebBrowsers: "Web — Browsers",
+  adminWebOS: "Web — Operating Systems",
   adminNoUsageData: "No usage data available yet.",
 
   // Event archive (#161)

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -811,6 +811,8 @@ const it: TranslationKeys = {
   adminWau: "WAU (7d)",
   adminMau: "MAU (30d)",
   adminPlatformBreakdown: "Platform Breakdown (30d)",
+  adminWebBrowsers: "Web — Browsers",
+  adminWebOS: "Web — Operating Systems",
   adminNoUsageData: "No usage data available yet.",
 
   // Event archive (#161)

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -860,6 +860,8 @@ const pt: TranslationKeys = {
   adminWau: "WAU (7d)",
   adminMau: "MAU (30d)",
   adminPlatformBreakdown: "Platform Breakdown (30d)",
+  adminWebBrowsers: "Web — Browsers",
+  adminWebOS: "Web — Operating Systems",
   adminNoUsageData: "No usage data available yet.",
 
   // Event archive (#161)

--- a/src/lib/usageMetrics.server.ts
+++ b/src/lib/usageMetrics.server.ts
@@ -1,38 +1,65 @@
 /**
  * Anonymous usage metrics derived from existing Session + UserAppOpen tables.
  * No individual tracking — only aggregated counts.
+ *
+ * Platform split: Android (native app) vs Web (everything else).
+ * Web drill-down: browser (Chrome, Safari, Firefox, etc.) + OS (Windows, macOS, Linux, iOS, Android).
  */
 import { prisma } from "./db.server";
 
-// ponytail: parse platform from user-agent string. Intentionally coarse —
-// we only care about iOS/Android/Desktop, not specific device models.
-function parsePlatform(ua: string | null): "android" | "ios" | "desktop" | "unknown" {
-  if (!ua) return "unknown";
+// ponytail: "android" = native app (user-agent contains "Convocados" or specific
+// Android WebView patterns from the native app's Ktor client). Everything else = web.
+function isAndroidApp(ua: string | null): boolean {
+  if (!ua) return false;
   const lower = ua.toLowerCase();
-  if (lower.includes("android") || lower.includes("convocados")) return "android";
-  if (lower.includes("iphone") || lower.includes("ipad") || lower.includes("ipod")) return "ios";
-  if (lower.includes("mobile") && !lower.includes("android")) return "ios"; // Safari mobile
-  return "desktop";
+  // The native Android app uses Ktor which includes "ktor" or the app sets a custom UA with "Convocados"
+  return lower.includes("convocados") || (lower.includes("ktor") && lower.includes("android"));
+}
+
+function parseBrowser(ua: string | null): string {
+  if (!ua) return "Unknown";
+  if (ua.includes("Firefox/") || ua.includes("FxiOS/")) return "Firefox";
+  if (ua.includes("Edg/") || ua.includes("EdgA/") || ua.includes("EdgiOS/")) return "Edge";
+  if (ua.includes("OPR/") || ua.includes("Opera/")) return "Opera";
+  if (ua.includes("SamsungBrowser/")) return "Samsung";
+  if (ua.includes("CriOS/") || ua.includes("Chrome/")) return "Chrome";
+  if (ua.includes("Safari/") && !ua.includes("Chrome/")) return "Safari";
+  return "Other";
+}
+
+function parseOS(ua: string | null): string {
+  if (!ua) return "Unknown";
+  const lower = ua.toLowerCase();
+  if (lower.includes("iphone") || lower.includes("ipad") || lower.includes("ipod")) return "iOS";
+  if (lower.includes("android")) return "Android";
+  if (lower.includes("windows")) return "Windows";
+  if (lower.includes("mac os") || lower.includes("macintosh")) return "macOS";
+  if (lower.includes("linux") && !lower.includes("android")) return "Linux";
+  if (lower.includes("cros")) return "ChromeOS";
+  return "Other";
 }
 
 export interface DailyUsage {
   date: string;
   dau: number;
   android: number;
-  ios: number;
-  desktop: number;
+  web: number;
+}
+
+export interface WebDrillDown {
+  browsers: Record<string, number>;
+  os: Record<string, number>;
 }
 
 /**
  * DAU over time from UserAppOpen (one row per user per day).
- * Platform breakdown from Session.userAgent for sessions active on that day.
+ * Platform breakdown: Android (native) vs Web.
  */
 export async function getDailyUsage(days = 30): Promise<DailyUsage[]> {
   const since = new Date();
   since.setDate(since.getDate() - days);
   since.setHours(0, 0, 0, 0);
 
-  // DAU from UserAppOpen
   const appOpens = await prisma.userAppOpen.findMany({
     where: { day: { gte: since } },
     select: { userId: true, day: true },
@@ -45,11 +72,10 @@ export async function getDailyUsage(days = 30): Promise<DailyUsage[]> {
     orderBy: { createdAt: "desc" },
   });
 
-  // Build user → platform map (most recent session wins)
-  const userPlatform = new Map<string, "android" | "ios" | "desktop" | "unknown">();
+  const userIsAndroid = new Map<string, boolean>();
   for (const s of sessions) {
-    if (!userPlatform.has(s.userId)) {
-      userPlatform.set(s.userId, parsePlatform(s.userAgent));
+    if (!userIsAndroid.has(s.userId)) {
+      userIsAndroid.set(s.userId, isAndroidApp(s.userAgent));
     }
   }
 
@@ -62,20 +88,16 @@ export async function getDailyUsage(days = 30): Promise<DailyUsage[]> {
     dayMap.set(day, set);
   }
 
-  // Build result sorted by date
   const result: DailyUsage[] = [];
   const sortedDays = [...dayMap.keys()].sort();
   for (const day of sortedDays) {
     const users = dayMap.get(day)!;
-    let android = 0, ios = 0, desktop = 0;
+    let android = 0, web = 0;
     for (const userId of users) {
-      const platform = userPlatform.get(userId) ?? "unknown";
-      if (platform === "android") android++;
-      else if (platform === "ios") ios++;
-      else if (platform === "desktop") desktop++;
-      else desktop++; // unknown → desktop bucket
+      if (userIsAndroid.get(userId)) android++;
+      else web++;
     }
-    result.push({ date: day, dau: users.size, android, ios, desktop });
+    result.push({ date: day, dau: users.size, android, web });
   }
 
   return result;
@@ -102,19 +124,26 @@ export async function getUsageSummary() {
     }),
   ]);
 
-  // Platform breakdown from sessions in last 30 days
+  // Platform + web drill-down from sessions in last 30 days
   const recentSessions = await prisma.session.findMany({
     where: { createdAt: { gte: thirtyDaysAgo } },
     select: { userId: true, userAgent: true },
     distinct: ["userId"],
   });
 
-  const platforms = { android: 0, ios: 0, desktop: 0 };
+  const platforms = { android: 0, web: 0 };
+  const webDrillDown: WebDrillDown = { browsers: {}, os: {} };
+
   for (const s of recentSessions) {
-    const p = parsePlatform(s.userAgent);
-    if (p === "android") platforms.android++;
-    else if (p === "ios") platforms.ios++;
-    else platforms.desktop++;
+    if (isAndroidApp(s.userAgent)) {
+      platforms.android++;
+    } else {
+      platforms.web++;
+      const browser = parseBrowser(s.userAgent);
+      const os = parseOS(s.userAgent);
+      webDrillDown.browsers[browser] = (webDrillDown.browsers[browser] ?? 0) + 1;
+      webDrillDown.os[os] = (webDrillDown.os[os] ?? 0) + 1;
+    }
   }
 
   return {
@@ -122,5 +151,6 @@ export async function getUsageSummary() {
     wau: wau.length,
     mau: mau.length,
     platforms,
+    webDrillDown,
   };
 }


### PR DESCRIPTION
Updates the platform breakdown to match actual platforms:

**Before:** Android / iOS / Desktop (iOS doesn't exist for us)
**After:** Android (native app) / Web (PWA + browser)

Web drill-down shows:
- **Browsers:** Chrome, Safari, Firefox, Edge, Samsung, Opera, Other
- **OS:** Windows, macOS, iOS, Android, Linux, ChromeOS, Other

Android detection: looks for 'Convocados' or 'Ktor' + 'android' in user-agent (the native app's Ktor HTTP client). Everything else = web user.