### PR TITLE
fix: games list shows correct player count for recurring events

### DIFF
--- a/src/pages/api/me/games.ts
+++ b/src/pages/api/me/games.ts
@@ -29,6 +29,7 @@ export const GET: APIRoute = async ({ request }) => {
     maxPlayers: true,
     archivedAt: true,
     isRecurring: true,
+    currentGameId: true,
     _count: { select: { players: true } },
     history: {
       select: { scoreOne: true, scoreTwo: true },
@@ -38,11 +39,23 @@ export const GET: APIRoute = async ({ request }) => {
   } as const;
 
   type GameRow = Prisma.EventGetPayload<{ select: typeof gameSelect }>;
-  const mapGame = (e: GameRow) => ({
+
+  // ponytail: when currentGameId is set, player count comes from GameParticipant
+  // (game-scoped). Otherwise fall back to event-level Player count.
+  async function resolvePlayerCount(e: GameRow): Promise<number> {
+    if (e.currentGameId) {
+      return prisma.gameParticipant.count({
+        where: { gameId: e.currentGameId, archivedAt: null },
+      });
+    }
+    return e._count.players;
+  }
+
+  const mapGame = async (e: GameRow) => ({
     ...e,
     dateTime: e.dateTime.toISOString(),
     archivedAt: e.archivedAt?.toISOString() ?? null,
-    playerCount: e._count.players,
+    playerCount: await resolvePlayerCount(e),
     lastScoreOne: e.history[0]?.scoreOne ?? null,
     lastScoreTwo: e.history[0]?.scoreTwo ?? null,
   });
@@ -99,16 +112,9 @@ export const GET: APIRoute = async ({ request }) => {
   const followedHasMore = followedRecords.length > limit;
   const followedSlice = followedDeduped.slice(0, limit);
 
-  const allOwned = ownedSlice.map(mapGame);
-  const allAdmin = adminSlice.map(mapGame);
-  const allFollowed = followedSlice.map((r) => ({
-    ...r.event,
-    dateTime: r.event.dateTime.toISOString(),
-    archivedAt: r.event.archivedAt?.toISOString() ?? null,
-    playerCount: r.event._count.players,
-    lastScoreOne: r.event.history[0]?.scoreOne ?? null,
-    lastScoreTwo: r.event.history[0]?.scoreTwo ?? null,
-  }));
+  const allOwned = await Promise.all(ownedSlice.map(mapGame));
+  const allAdmin = await Promise.all(adminSlice.map(mapGame));
+  const allFollowed = await Promise.all(followedSlice.map((r) => mapGame(r.event as unknown as GameRow)));
 
   return Response.json({
     owned: allOwned.filter((g) => !g.archivedAt),

--- a/src/pages/events/[id].astro
+++ b/src/pages/events/[id].astro
@@ -21,12 +21,16 @@ try {
     select: {
       id: true, title: true, location: true, dateTime: true,
       sport: true, maxPlayers: true, isPublic: true,
+      currentGameId: true,
       _count: { select: { players: true } },
     },
   });
 
   if (event) {
-    const playerCount = event._count.players;
+    // ADR 0016: use GameParticipant count when currentGameId is set
+    const playerCount = event.currentGameId
+      ? await prisma.gameParticipant.count({ where: { gameId: event.currentGameId, archivedAt: null } })
+      : event._count.players;
     const spotsLeft = Math.max(0, event.maxPlayers - playerCount);
     title = `${event.title} — Convocados`;
     description = `${event.location || "Game"} · ${playerCount}/${event.maxPlayers} players · ${spotsLeft} spot(s) left`;


### PR DESCRIPTION
The 'My Games' list showed 10/10 for a recurring event that only has 1 player for this week.

**Root cause:** `_count: { select: { players: true } }` counts event-level `Player` records (which persist across resets). The event page correctly uses `GameParticipant` for the current game, but the games list didn't.

**Fix:** When `currentGameId` is set, count `GameParticipant` (game-scoped) instead of `Player` (event-scoped). Fixes both:
- `GET /api/me/games` (dashboard games list)
- Event page OG meta description (`X/Y players`)