### PR TITLE
fix: RSVP 'Player not found' after recurring event rejoin

### DIFF
--- a/src/pages/api/events/[id]/index.ts
+++ b/src/pages/api/events/[id]/index.ts
@@ -185,12 +185,22 @@ export const GET: APIRoute = async ({ params, request }) => {
       include: { eventPlayer: true },
       orderBy: { order: "asc" },
     });
+
+    // ponytail: EventPlayer.userId may be stale (null) if the player rejoined
+    // after a reset and the upsert didn't update it. Fall back to the event-level
+    // Player.userId which is the authoritative link.
+    const playersByName = new Map(
+      event.players
+        .filter((p) => p.userId)
+        .map((p) => [p.name, p.userId]),
+    );
+
     playersPayload = participants.map((gp) => ({
       id: gp.eventPlayer.id,
       name: gp.eventPlayer.name,
       order: gp.order,
       eventId: gp.eventPlayer.eventId,
-      userId: gp.eventPlayer.userId ?? null,
+      userId: gp.eventPlayer.userId ?? playersByName.get(gp.eventPlayer.name) ?? null,
       createdAt: gp.createdAt.toISOString(),
     }));
   } else {

--- a/src/pages/api/events/[id]/players.ts
+++ b/src/pages/api/events/[id]/players.ts
@@ -537,7 +537,7 @@ export const POST: APIRoute = async ({ params, request }) => {
         const eventPlayer = await prisma.eventPlayer.upsert({
           where: { eventId_name: { eventId, name: trimmed } },
           create: { eventId, name: trimmed, userId: linkedUserId ?? existing.userId },
-          update: {},
+          update: { ...(linkedUserId ? { userId: linkedUserId } : {}) },
         });
         const alreadyInGame = await prisma.gameParticipant.findUnique({
           where: { gameId_eventPlayerId: { gameId: event.currentGameId, eventPlayerId: eventPlayer.id } },


### PR DESCRIPTION
After joining the new game week, RSVP shows 'Player not found' because:

1. `EventPlayer.upsert` used `update: {}` — existing EventPlayer without userId stayed null
2. Event page returned `userId: null` → frontend thought user wasn't on the list
3. Clicking 'Going' triggered Quick Join loop instead of RSVP

**Fixes:**
- `EventPlayer.upsert` now sets userId on update (not just create)
- Event GET response falls back to `Player.userId` (event-level) when `EventPlayer.userId` is null — fixes existing broken data without migration