### PR TITLE
fix(android): use BuildConfig for Google Sign-In client ID

### DIFF
--- a/android-app/app/build.gradle.kts
+++ b/android-app/app/build.gradle.kts
@@ -17,6 +17,11 @@ plugins {
     alias(libs.plugins.roborazzi)
 }
 
+val localProperties = Properties().apply {
+    val file = rootProject.file("local.properties")
+    if (file.exists()) file.inputStream().use { load(it) }
+}
+
 val keystoreProperties = Properties().apply {
     val file = rootProject.file("keystore.properties")
     if (file.exists()) file.inputStream().use { load(it) }
@@ -48,6 +53,12 @@ android {
         versionCode = (System.currentTimeMillis() / 1000 / 60).toInt()
         versionName = "1.2.0"
         manifestPlaceholders["appAuthRedirectScheme"] = "convocados"
+
+        buildConfigField(
+            "String",
+            "GOOGLE_SERVER_CLIENT_ID",
+            "\"${localProperties.getProperty("GOOGLE_SERVER_CLIENT_ID", "")}\""
+        )
     }
 
     buildTypes {
@@ -74,6 +85,7 @@ android {
     }
     buildFeatures {
         compose = true
+        buildConfig = true
     }
     testOptions {
         unitTests {

--- a/android-app/app/src/debug/res/values/google_web_client.xml
+++ b/android-app/app/src/debug/res/values/google_web_client.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- ponytail: fallback web client ID for debug builds where google-services.json
-     doesn't include a web client entry. Production builds get this from the
-     google-services plugin automatically. -->
-<resources>
-    <string name="default_web_client_id" translatable="false">45519759180-drrbd2j4sfa9dm2r0s1opmcgks9nb7qo.apps.googleusercontent.com</string>
-</resources>

--- a/android-app/app/src/main/java/dev/convocados/data/auth/AuthManager.kt
+++ b/android-app/app/src/main/java/dev/convocados/data/auth/AuthManager.kt
@@ -12,6 +12,7 @@ import androidx.credentials.exceptions.NoCredentialException
 import com.google.android.libraries.identity.googleid.GetGoogleIdOption
 import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
 import dagger.hilt.android.qualifiers.ApplicationContext
+import dev.convocados.BuildConfig
 import dev.convocados.data.api.ApiClient
 import dev.convocados.data.api.OAuthTokenResponse
 import io.ktor.client.*
@@ -233,14 +234,8 @@ class AuthManager @Inject constructor(
     }
 
     private fun getWebClientId(): String {
-        // ponytail: uses the web client ID (not android client ID) for Credential Manager.
-        // The web client ID is what Google's ID token `aud` field will contain.
-        // Set via BuildConfig or fall back to env-injected string resource.
-        return try {
-            context.getString(context.resources.getIdentifier("default_web_client_id", "string", context.packageName))
-        } catch (_: Exception) {
-            // Fallback — should be set in google-services.json
-            ""
-        }
+        // ponytail: reads web client ID from BuildConfig (injected via local.properties in CI).
+        // Same approach as wear module — avoids dependency on google-services.json oauth_client.
+        return BuildConfig.GOOGLE_SERVER_CLIENT_ID
     }
 }


### PR DESCRIPTION
## Problem

The phone app crashed on Play Store builds with:
`Google Sign-in not configured: default_web_client_id is missing. Ensure google-services.json is present.`

**Root cause:** The Firebase project's `google-services.json` has empty `oauth_client: []` arrays — no web client (type 3) entry exists. The google-services Gradle plugin therefore never generates the `default_web_client_id` string resource that `AuthManager.getWebClientId()` was looking up at runtime.

## Fix

Switch the phone app to use `BuildConfig.GOOGLE_SERVER_CLIENT_ID` — the same approach the wear module already uses successfully. The value is injected from `local.properties`, which CI already populates from the `GOOGLE_SERVER_CLIENT_ID` GitHub secret.

## Changes

- `app/build.gradle.kts`: Add `localProperties` loading, `GOOGLE_SERVER_CLIENT_ID` BuildConfig field, and `buildConfig = true`
- `AuthManager.kt`: Replace resource lookup with direct `BuildConfig.GOOGLE_SERVER_CLIENT_ID` return
- Delete dead `app/src/debug/res/values/google_web_client.xml` (no longer referenced)

## Security

No secrets exposed — `local.properties` is gitignored, BuildConfig field is populated at build time only.