### PR TITLE
fix(android): add status bar inset padding (#459)

### DIFF
--- a/android-app/app/src/main/java/dev/convocados/ui/navigation/AppNavigation.kt
+++ b/android-app/app/src/main/java/dev/convocados/ui/navigation/AppNavigation.kt
@@ -4,6 +4,9 @@ import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionLayout
 import androidx.compose.animation.SharedTransitionScope
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffold
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffoldDefaults
@@ -126,6 +129,7 @@ fun AppNavigation(isAuthenticated: Boolean, deepLink: String? = null, processing
             NavHost(
                 navController = navController,
                 startDestination = startDestination,
+                modifier = Modifier.windowInsetsPadding(WindowInsets.statusBars),
             ) {
                 composable(Route.Login.route) {
                     // ADR-0012: post-login navigation is owned by the LaunchedEffect


### PR DESCRIPTION
## Problem

With `enableEdgeToEdge()` in `MainActivity`, the app renders behind the system status bar. `NavigationSuiteScaffold` handles bottom/side navigation insets but **not** the top status bar. This causes the top of screen content (titles, tabs) to be clipped behind the status bar and camera notch.

## Fix

Add `Modifier.windowInsetsPadding(WindowInsets.statusBars)` to the `NavHost` — applies to all screens uniformly. One line, zero per-screen changes needed.

## Why at NavHost level

- All screens share this issue (none have a `TopAppBar` that would consume the inset)
- Single point of change vs. modifying 15+ screen composables
- `NavigationSuiteScaffold` already handles the navigation bar insets, so no double-padding risk at the bottom

Closes #459