### PR TITLE
fix: bench position notification counts only active players

### DIFF
--- a/src/pages/api/events/[id]/players.ts
+++ b/src/pages/api/events/[id]/players.ts
@@ -350,7 +350,7 @@ export const POST: APIRoute = async ({ params, request }) => {
   const senderClientId = session?.user?.id ?? request.headers.get("x-client-id") ?? undefined;
   const event = await prisma.event.findUnique({
     where: { id: eventId },
-    include: { players: { orderBy: { order: "asc" } } },
+    include: { players: { where: { archivedAt: null }, orderBy: { order: "asc" } } },
   });
   if (!event) return Response.json({ error: "Not found." }, { status: 404 });
 

--- a/src/test/api.test.ts
+++ b/src/test/api.test.ts
@@ -376,6 +376,42 @@ describe("DELETE /api/events/[id]/players", () => {
     const archived = await prisma.player.findFirst({ where: { eventId: id } });
     expect(archived?.archivedAt).not.toBeNull();
   });
+
+  it("bench position notification excludes archived players from count", async () => {
+    const id = await seedEvent();
+    await prisma.event.update({ where: { id }, data: { maxPlayers: 2 } });
+
+    // Two active players fill the roster
+    await prisma.player.createMany({
+      data: [
+        { name: "Alice", eventId: id, order: 0 },
+        { name: "Bob", eventId: id, order: 1 },
+      ],
+    });
+    // Three archived (removed) players — should NOT inflate bench position
+    await prisma.player.createMany({
+      data: [
+        { name: "Gone1", eventId: id, order: 10, archivedAt: new Date() },
+        { name: "Gone2", eventId: id, order: 11, archivedAt: new Date() },
+        { name: "Gone3", eventId: id, order: 12, archivedAt: new Date() },
+      ],
+    });
+
+    // Clean notification jobs before adding the bench player
+    await prisma.notificationJob.deleteMany();
+
+    // Carol joins — she's the 1st bench player (position #1), not #4
+    const res = await addPlayer(ctx({ id }, { name: "Carol" }));
+    expect(res.status).toBe(200);
+
+    // Verify the notification payload has correct bench position
+    const job = await prisma.notificationJob.findFirst({
+      where: { eventId: id, type: "player_joined_bench" },
+    });
+    expect(job).not.toBeNull();
+    const payload = JSON.parse(job!.payload);
+    expect(payload.params.position).toBe("1");
+  });
 });
 
 // ─── POST /api/events/[id]/randomize ────────────────────────────────────────


### PR DESCRIPTION
## Problem

Bench position in push notifications was inflated — showing e.g. '#6' when the player was actually the 1st on the bench. This happened because the player join endpoint loaded `event.players` without filtering archived (soft-deleted) players, so `event.players.length` included removed players in the count.

## Fix

Add `where: { archivedAt: null }` to the players include query in the POST handler. This ensures `benchPosition = event.players.length - event.maxPlayers + 1` only counts active players.

## Test

Added regression test: creates an event with 2 active + 3 archived players, adds a bench player, and asserts the notification payload has `position: '1'` (not '4').