### PR TITLE
fix: teams endpoint uses positional slicing for active/bench split

### DIFF
--- a/src/pages/api/events/[id]/teams.ts
+++ b/src/pages/api/events/[id]/teams.ts
@@ -32,9 +32,9 @@ export const GET: APIRoute = async ({ params, request }) => {
 
 	const maxPlayers = event.maxPlayers;
 
-	// Active players (order < maxPlayers) vs bench
-	const activePlayers = event.players.filter((p) => p.order < maxPlayers);
-	const benchPlayers = event.players.filter((p) => p.order >= maxPlayers);
+	// Active players are the first N by order (not by order value — gaps possible after archives)
+	const activePlayers = event.players.slice(0, maxPlayers);
+	const benchPlayers = event.players.slice(maxPlayers);
 
 	// Build team member lookup: playerId -> teamResult id
 	const memberLookup = new Map<string, string>(); // playerName -> teamResultId
@@ -136,8 +136,8 @@ export const PUT: APIRoute = async ({ params, request }) => {
 		return Response.json({ error: "matches must be an array" }, { status: 400 });
 	}
 
-	// Validate that all player names in matches are active players
-	const activePlayers = event.players.filter((p) => p.order < event.maxPlayers);
+	// Validate that all player names in matches are active players (first N by position)
+	const activePlayers = event.players.slice(0, event.maxPlayers);
 	const activeNames = new Set(activePlayers.map((p) => p.name));
 
 	for (const match of body.matches) {
@@ -229,9 +229,9 @@ export const PATCH: APIRoute = async ({ params, request }) => {
 		return Response.json({ error: "Duplicate player IDs" }, { status: 400 });
 	}
 
-	// Only allow active players (order < maxPlayers) to be on teams
+	// Only allow active players (first N by position) to be on teams
 	const activePlayerIds = new Set(
-		event.players.filter((p) => p.order < event.maxPlayers).map((p) => p.id),
+		event.players.slice(0, event.maxPlayers).map((p) => p.id),
 	);
 	for (const id of requestedIds) {
 		if (!activePlayerIds.has(id)) {

--- a/src/test/api.test.ts
+++ b/src/test/api.test.ts
@@ -526,6 +526,31 @@ describe("PUT /api/events/[id]/teams", () => {
     const body = await res.json();
     expect(body.error).toContain("Carol");
   });
+
+  it("accepts active players with non-contiguous order values (gaps from archives)", async () => {
+    const id = await seedEvent();
+    await prisma.event.update({ where: { id }, data: { maxPlayers: 4 } });
+    // After archiving/re-adding, order values can have gaps (0, 1, 5, 7)
+    // but these are still the first 4 active players
+    await prisma.player.createMany({
+      data: [
+        { name: "Alice", eventId: id, order: 0 },
+        { name: "Bob", eventId: id, order: 1 },
+        { name: "Carol", eventId: id, order: 5 },
+        { name: "Dave", eventId: id, order: 7 },
+        { name: "Eve", eventId: id, order: 9 }, // bench
+      ],
+    });
+
+    // Carol and Dave are active (positions 3 & 4) despite order > maxPlayers
+    const matches = [
+      { team: "Ninjas", players: [{ name: "Alice", order: 0 }, { name: "Carol", order: 1 }] },
+      { team: "Gunas", players: [{ name: "Bob", order: 0 }, { name: "Dave", order: 1 }] },
+    ];
+
+    const res = await saveTeams(putCtx({ id }, { matches }));
+    expect(res.status).toBe(200);
+  });
 });
 
 // ─── PUT /api/events/[id]/team-names ────────────────────────────────────────


### PR DESCRIPTION
## Problem

Two related bugs reported on https://convocados.cabeda.dev/events/cmmkfrx8b0000o2ixrix1yp2m:

1. **Team randomize didn't distribute equally** — this was actually correct (randomize already uses `.slice()`), but the team *swap* endpoint rejected valid active players.
2. **"Player X is not an active player or is on the bench"** when trying to move a player between teams.

**Root cause:** The teams endpoints (GET, PUT, PATCH) used `p.order < maxPlayers` to determine active vs bench. After players are archived and re-added, `order` values have gaps (e.g., 0, 1, 5, 7). A player at position 3 with `order: 5` was wrongly classified as bench in a `maxPlayers: 4` event.

## Fix

Replace `event.players.filter(p => p.order < maxPlayers)` with `event.players.slice(0, maxPlayers)` — same pattern already used correctly in `randomize.ts` and `validateTeams()`. The array is ordered by `order: 'asc'`, so the first N elements are always the active players regardless of their order values.

## Test

Added regression test: creates players with non-contiguous orders (0, 1, 5, 7, 9), maxPlayers=4, and confirms team assignment of the 3rd and 4th players (orders 5 and 7) succeeds.