### PR TITLE
fix: new player goes to middle of list when order values have gaps

### DIFF
--- a/src/pages/api/events/[id]/players.ts
+++ b/src/pages/api/events/[id]/players.ts
@@ -490,7 +490,12 @@ export const POST: APIRoute = async ({ params, request }) => {
   const invitedByUserId = (session?.user && linkToAccount !== true) ? session.user.id : null;
 
   try {
-    const nextOrder = event.players.length;
+    // ponytail: use max(order)+1 to avoid landing in gaps from past removals/reorders
+    const maxOrder = await prisma.player.aggregate({
+      where: { eventId, archivedAt: null },
+      _max: { order: true },
+    });
+    const nextOrder = (maxOrder._max.order ?? -1) + 1;
     await prisma.player.create({
       data: {
         name: trimmed,

--- a/src/test/player-order.test.ts
+++ b/src/test/player-order.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { prisma } from "~/lib/db.server";
+import { resetRateLimitStore } from "~/lib/rateLimit.server";
+import { resetApiRateLimitStore } from "~/lib/apiRateLimit.server";
+
+// Mock auth helpers — unauthenticated by default
+vi.mock("~/lib/auth.helpers.server", () => ({
+  getSession: vi.fn().mockResolvedValue(null),
+  checkOwnership: vi.fn().mockResolvedValue({ isOwner: true, isAdmin: false, session: null }),
+  checkEventAdmin: vi.fn().mockResolvedValue(false),
+}));
+
+import { POST as addPlayer } from "~/pages/api/events/[id]/players";
+import { GET as getEvent } from "~/pages/api/events/[id]/index";
+
+function postCtx(params: Record<string, string>, body: unknown) {
+  const request = new Request("http://localhost/api/test", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  return { request, params } as any;
+}
+
+function getCtx(params: Record<string, string>) {
+  const request = new Request("http://localhost/api/test", {
+    method: "GET",
+    headers: { "content-type": "application/json" },
+  });
+  return { request, params, url: new URL("http://localhost/api/test") } as any;
+}
+
+beforeEach(async () => {
+  await resetRateLimitStore();
+  await resetApiRateLimitStore();
+  await prisma.player.deleteMany();
+  await prisma.event.deleteMany();
+});
+
+describe("Player ordering — new players always go to the end", () => {
+  it("adds player at end even when order values have gaps", async () => {
+    // Seed an event with players that have non-contiguous order values
+    // (simulates state after removals/reorders over time)
+    const event = await prisma.event.create({
+      data: {
+        title: "Order Gap Test",
+        location: "Pitch A",
+        dateTime: new Date(Date.now() + 86400_000),
+      },
+    });
+
+    // Create players with gapped order values: 0, 1, 5, 9
+    const playerNames = ["Alice", "Bob", "Charlie", "Diana"];
+    const orders = [0, 1, 5, 9];
+    for (let i = 0; i < playerNames.length; i++) {
+      await prisma.player.create({
+        data: {
+          name: playerNames[i],
+          eventId: event.id,
+          order: orders[i],
+        },
+      });
+    }
+
+    // Add a new player via the API
+    const res = await addPlayer(postCtx({ id: event.id }, { name: "Manecas" }));
+    expect(res.status).toBe(200);
+
+    // Fetch the event and check player order
+    const getRes = await getEvent(getCtx({ id: event.id }));
+    const data = await getRes.json();
+    const names = data.players.map((p: any) => p.name);
+
+    // Manecas must be LAST — order should be max(existing) + 1 = 10
+    expect(names[names.length - 1]).toBe("Manecas");
+
+    // Verify the actual order value is 10 (9 + 1), not 4 (length of existing)
+    const manecas = await prisma.player.findFirst({
+      where: { eventId: event.id, name: "Manecas" },
+    });
+    expect(manecas!.order).toBe(10);
+  });
+});


### PR DESCRIPTION
## Problem

When adding a new player (e.g. Manecas) to an event, they could appear in the middle of the player list instead of at the end.

## Root Cause

The add-player code used `event.players.length` as the new player's `order` value. But existing players can have non-contiguous order values (gaps from past removals, reorders, or re-adds). For example, if existing orders are `0, 1, 5, 9` (4 players), `length=4` gives order 4 — which sorts between 3 and 5 instead of after 9.

The re-add (un-archive) path already handled this correctly using `MAX(order) + 1`.

## Fix

Use `prisma.player.aggregate({ _max: { order: true } })` + 1 for the new player's order, consistent with the re-add path.

## Test

Added `src/test/player-order.test.ts` — seeds an event with gapped order values (0, 1, 5, 9), adds a player via the API, asserts they get order=10 and appear last.