### PR TITLE
feat: migrate RSVP to game-scoped (ADR-0016)

### DIFF
--- a/prisma/migrations/20260713161124_rsvp_game_scoped/migration.sql
+++ b/prisma/migrations/20260713161124_rsvp_game_scoped/migration.sql
@@ -1,0 +1,65 @@
+-- ADR 0016: Migrate Rsvp from event-scoped (userId/playerId + eventId) to
+-- game-scoped (eventPlayerId + gameId). Single key on EventPlayer identity.
+
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+
+CREATE TABLE "new_Rsvp" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "eventPlayerId" TEXT NOT NULL,
+    "gameId" TEXT NOT NULL,
+    "status" TEXT,
+    "respondedAt" DATETIME,
+    "respondedByUserId" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "Rsvp_eventPlayerId_fkey" FOREIGN KEY ("eventPlayerId") REFERENCES "EventPlayer" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "Rsvp_gameId_fkey" FOREIGN KEY ("gameId") REFERENCES "Game" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "Rsvp_respondedByUserId_fkey" FOREIGN KEY ("respondedByUserId") REFERENCES "User" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+-- Backfill: resolve eventPlayerId and gameId from existing RSVPs.
+-- Case 1: userId-keyed RSVPs → join through Player.userId to find the EventPlayer
+INSERT INTO "new_Rsvp" ("id", "eventPlayerId", "gameId", "status", "respondedAt", "respondedByUserId", "createdAt", "updatedAt")
+SELECT
+    r."id",
+    ep."id" AS "eventPlayerId",
+    e."currentGameId" AS "gameId",
+    r."status",
+    r."respondedAt",
+    r."respondedByUserId",
+    r."createdAt",
+    r."updatedAt"
+FROM "Rsvp" r
+JOIN "Event" e ON e."id" = r."eventId"
+JOIN "Player" p ON p."userId" = r."userId" AND p."eventId" = r."eventId"
+JOIN "EventPlayer" ep ON ep."eventId" = r."eventId" AND ep."name" = p."name"
+WHERE r."userId" IS NOT NULL
+  AND e."currentGameId" IS NOT NULL;
+
+-- Case 2: playerId-keyed RSVPs (guest players) → join through Player.name to EventPlayer
+INSERT OR IGNORE INTO "new_Rsvp" ("id", "eventPlayerId", "gameId", "status", "respondedAt", "respondedByUserId", "createdAt", "updatedAt")
+SELECT
+    r."id",
+    ep."id" AS "eventPlayerId",
+    e."currentGameId" AS "gameId",
+    r."status",
+    r."respondedAt",
+    r."respondedByUserId",
+    r."createdAt",
+    r."updatedAt"
+FROM "Rsvp" r
+JOIN "Player" p ON p."id" = r."playerId"
+JOIN "Event" e ON e."id" = r."eventId"
+JOIN "EventPlayer" ep ON ep."eventId" = r."eventId" AND ep."name" = p."name"
+WHERE r."playerId" IS NOT NULL
+  AND e."currentGameId" IS NOT NULL;
+
+DROP TABLE "Rsvp";
+ALTER TABLE "new_Rsvp" RENAME TO "Rsvp";
+CREATE INDEX "Rsvp_gameId_status_idx" ON "Rsvp"("gameId", "status");
+CREATE UNIQUE INDEX "Rsvp_eventPlayerId_gameId_key" ON "Rsvp"("eventPlayerId", "gameId");
+
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -31,7 +31,6 @@ model User {
   apiKeys        ApiKey[]
   notificationPreferences NotificationPreferences?
   priorityEnrollments     PriorityEnrollment[]
-  rsvps                   Rsvp[]
   rsvpsActedOn            Rsvp[]            @relation("RsvpActedBy")
   priorityConfirmations   PriorityConfirmation[]
   eventInvites            EventInvite[]
@@ -123,7 +122,6 @@ model Event {
   eventLogs      EventLog[]
   priorityEnrollments PriorityEnrollment[]
   priorityConfirmations PriorityConfirmation[]
-  rsvps                Rsvp[]
   invites         EventInvite[]
   admins          EventAdmin[]
   followers        EventFollow[]
@@ -246,7 +244,6 @@ model Player {
   invitedByUserId String?
   archivedAt      DateTime?
   createdAt       DateTime  @default(now())
-  rsvps           Rsvp[]
 
   @@unique([eventId, name])
   @@index([userId])
@@ -291,6 +288,7 @@ model Game {
 
   participants    GameParticipant[]
   payments        GamePayment[]
+  rsvps           Rsvp[]
 
   @@index([eventId, dateTime])
   @@index([eventId, status])
@@ -312,6 +310,7 @@ model EventPlayer {
 
   participations GameParticipant[]
   payments       GamePayment[]
+  rsvps          Rsvp[]
 
   @@unique([eventId, name])
   @@index([userId])
@@ -991,30 +990,24 @@ model PlaytomicAvailabilityCache {
 
 // #457 RSVP per (subject, Event). status null == pending.
 // A row is keyed by exactly one of {userId, playerId}: userId for linked accounts
-// (the user self-RSVPs), playerId for guest Players (the admin RSVPs on their
-// behalf). respondedByUserId audits who set a guest RSVP — null for self-RSVPs.
-// Application invariant: (userId IS NULL) XOR (playerId IS NULL) must be false
-// i.e. exactly one is set. SQLite unique constraints on nullable columns treat
-// NULL as distinct, so this is enforced in lib/rsvp.server.ts, not in the schema.
+// ADR 0016: Rsvp is game-scoped, keyed on EventPlayer (the series-level identity).
+// respondedByUserId audits who set the RSVP when an admin acts on behalf of a guest.
 model Rsvp {
   id                String    @id @default(cuid())
-  userId            String?
-  playerId          String?
-  eventId           String
+  eventPlayerId     String
+  gameId            String
   status            String?   // "yes" | "no" | null
   respondedAt       DateTime?
   respondedByUserId String?
   createdAt         DateTime  @default(now())
   updatedAt         DateTime  @updatedAt
 
-  user              User?     @relation(fields: [userId], references: [id], onDelete: Cascade)
-  player            Player?   @relation(fields: [playerId], references: [id], onDelete: Cascade)
-  respondedBy       User?     @relation("RsvpActedBy", fields: [respondedByUserId], references: [id], onDelete: SetNull)
-  event             Event     @relation(fields: [eventId], references: [id], onDelete: Cascade)
+  eventPlayer       EventPlayer @relation(fields: [eventPlayerId], references: [id], onDelete: Cascade)
+  game              Game        @relation(fields: [gameId], references: [id], onDelete: Cascade)
+  respondedBy       User?       @relation("RsvpActedBy", fields: [respondedByUserId], references: [id], onDelete: SetNull)
 
-  @@unique([userId, eventId])
-  @@unique([playerId, eventId])
-  @@index([eventId, status])
+  @@unique([eventPlayerId, gameId])
+  @@index([gameId, status])
 }
 
 // #457 daily heartbeat for "≥3 app-open days in rolling 7d" re-prompt rule.

--- a/src/lib/autoConfirm.server.ts
+++ b/src/lib/autoConfirm.server.ts
@@ -80,13 +80,22 @@ export async function applyAutoConfirm(eventId: string): Promise<string[]> {
   const autoConfirmed = await getAutoConfirmedUserIds(eventId);
   if (autoConfirmed.size === 0) return [];
 
+  const event = await prisma.event.findUnique({ where: { id: eventId }, select: { currentGameId: true } });
+  if (!event?.currentGameId) return [];
+
   const applied: string[] = [];
   for (const userId of autoConfirmed) {
     try {
-      // Create or update RSVP as "yes" (auto-confirmed)
+      // Resolve EventPlayer for this user
+      const ep = await prisma.eventPlayer.findFirst({
+        where: { eventId, userId },
+        select: { id: true },
+      });
+      if (!ep) continue;
+      // Create or update RSVP as "yes" (auto-confirmed) on the new game
       await prisma.rsvp.upsert({
-        where: { userId_eventId: { userId, eventId } },
-        create: { eventId, userId, status: "yes" },
+        where: { eventPlayerId_gameId: { eventPlayerId: ep.id, gameId: event.currentGameId } },
+        create: { eventPlayerId: ep.id, gameId: event.currentGameId, status: "yes" },
         update: { status: "yes" },
       });
       applied.push(userId);

--- a/src/lib/leave.server.ts
+++ b/src/lib/leave.server.ts
@@ -108,29 +108,28 @@ export async function archiveAndLeave(input: ArchiveAndLeaveInput): Promise<Arch
   //   - Self-leave (linked user): status="no" + respondedAt
   //   - Admin declining a guest (organizer + no userId): status="no" + respondedByUserId audit.
   //   - Organizer X on a linked user: do not touch Rsvp (the user can still respond later).
-  // The Rsvp audit is only written when there's a real actor userId (FK to User).
-  if (actor.kind === "self" && player.userId) {
-    await prisma.rsvp.upsert({
-      where: { userId_eventId: { userId: player.userId, eventId } },
-      create: { eventId, userId: player.userId, status: "no", respondedAt: new Date() },
-      update: { status: "no", respondedAt: new Date() },
+  // ADR 0016: RSVP is keyed on (eventPlayerId, gameId).
+  if (currentGameId && (actor.kind === "self" && player.userId || actor.kind === "organizer" && !player.userId && actor.userId)) {
+    const ep = await prisma.eventPlayer.findUnique({
+      where: { eventId_name: { eventId, name: player.name } },
     });
-  } else if (actor.kind === "organizer" && !player.userId && actor.userId) {
-    await prisma.rsvp.upsert({
-      where: { playerId_eventId: { playerId, eventId } },
-      create: {
-        eventId,
-        playerId,
-        status: "no",
-        respondedAt: new Date(),
-        respondedByUserId: actor.userId ?? undefined,
-      },
-      update: {
-        status: "no",
-        respondedAt: new Date(),
-        respondedByUserId: actor.userId ?? undefined,
-      },
-    });
+    if (ep) {
+      await prisma.rsvp.upsert({
+        where: { eventPlayerId_gameId: { eventPlayerId: ep.id, gameId: currentGameId } },
+        create: {
+          eventPlayerId: ep.id,
+          gameId: currentGameId,
+          status: "no",
+          respondedAt: new Date(),
+          ...(actor.kind === "organizer" ? { respondedByUserId: actor.userId ?? undefined } : {}),
+        },
+        update: {
+          status: "no",
+          respondedAt: new Date(),
+          ...(actor.kind === "organizer" ? { respondedByUserId: actor.userId ?? undefined } : {}),
+        },
+      });
+    }
   }
 
   // Auto-unfollow on self-removal

--- a/src/lib/rsvp.server.ts
+++ b/src/lib/rsvp.server.ts
@@ -37,7 +37,7 @@ export type PushPromptState = "default" | "granted" | "dismissed" | "denied";
 /** Resolve the EventPlayer for a linked user on an event. Creates one if missing (lazy). */
 export async function resolveEventPlayerId(eventId: string, userId: string): Promise<string> {
   // Try finding by userId first
-  let ep = await prisma.eventPlayer.findFirst({
+  const ep = await prisma.eventPlayer.findFirst({
     where: { eventId, userId },
     select: { id: true },
   });

--- a/src/lib/rsvp.server.ts
+++ b/src/lib/rsvp.server.ts
@@ -34,22 +34,71 @@ export type PushPromptState = "default" | "granted" | "dismissed" | "denied";
 
 // ─── RSVP upsert + read ────────────────────────────────────────────────────
 
-/** Idempotent RSVP upsert for a linked user. status ∈ {"yes", "no", "maybe"} — null is "pending" and represented as a missing row. */
+/** Resolve the EventPlayer for a linked user on an event. Creates one if missing (lazy). */
+export async function resolveEventPlayerId(eventId: string, userId: string): Promise<string> {
+  // Try finding by userId first
+  let ep = await prisma.eventPlayer.findFirst({
+    where: { eventId, userId },
+    select: { id: true },
+  });
+  if (ep) return ep.id;
+  // Fallback: find a Player row with this userId, match by name
+  const player = await prisma.player.findFirst({
+    where: { eventId, userId, archivedAt: null },
+    select: { name: true },
+  });
+  if (player) {
+    const created = await prisma.eventPlayer.upsert({
+      where: { eventId_name: { eventId, name: player.name } },
+      create: { eventId, name: player.name, userId },
+      update: { userId },
+    });
+    return created.id;
+  }
+  // Last resort: find by user's display name
+  const user = await prisma.user.findUnique({ where: { id: userId }, select: { name: true } });
+  if (!user) throw new Error("User not found.");
+  const created = await prisma.eventPlayer.upsert({
+    where: { eventId_name: { eventId, name: user.name } },
+    create: { eventId, name: user.name, userId },
+    update: { userId },
+  });
+  return created.id;
+}
+
+/** Idempotent RSVP upsert for a linked user. Resolves EventPlayer + currentGameId internally. */
 export async function upsertRsvp(eventId: string, userId: string, status: RsvpStatusValue) {
+  const event = await prisma.event.findUnique({ where: { id: eventId }, select: { currentGameId: true } });
+  if (!event?.currentGameId) throw new Error("Event has no active game.");
+  const eventPlayerId = await resolveEventPlayerId(eventId, userId);
   return prisma.rsvp.upsert({
-    where: { userId_eventId: { userId, eventId } },
-    create: { eventId, userId, status, respondedAt: new Date() },
+    where: { eventPlayerId_gameId: { eventPlayerId, gameId: event.currentGameId } },
+    create: { eventPlayerId, gameId: event.currentGameId, status, respondedAt: new Date() },
     update: { status, respondedAt: new Date() },
   });
 }
 
-export async function getRsvpForUser(eventId: string, userId: string) {
-  return prisma.rsvp.findUnique({
-    where: { userId_eventId: { userId, eventId } },
+/** Upsert RSVP when you already have the eventPlayerId and gameId (avoids extra lookups). */
+export async function upsertRsvpDirect(eventPlayerId: string, gameId: string, status: RsvpStatusValue | null, respondedByUserId?: string) {
+  const respondedAt = status === null ? null : new Date();
+  return prisma.rsvp.upsert({
+    where: { eventPlayerId_gameId: { eventPlayerId, gameId } },
+    create: { eventPlayerId, gameId, status, respondedAt, respondedByUserId },
+    update: { status, respondedAt, ...(respondedByUserId ? { respondedByUserId } : {}) },
   });
 }
 
-/** Idempotent RSVP upsert for a guest Player. Admin/owner acts on the guest's behalf — `actorUserId` is recorded for audit. Refuses if the player is linked to a User (linked users self-RSVP via upsertRsvp). */
+export async function getRsvpForUser(eventId: string, userId: string) {
+  const event = await prisma.event.findUnique({ where: { id: eventId }, select: { currentGameId: true } });
+  if (!event?.currentGameId) return null;
+  const ep = await prisma.eventPlayer.findFirst({ where: { eventId, userId }, select: { id: true } });
+  if (!ep) return null;
+  return prisma.rsvp.findUnique({
+    where: { eventPlayerId_gameId: { eventPlayerId: ep.id, gameId: event.currentGameId } },
+  });
+}
+
+/** Idempotent RSVP upsert for a guest Player. Admin/owner acts on the guest's behalf. */
 export async function upsertGuestRsvp(
   eventId: string,
   playerId: string,
@@ -58,60 +107,101 @@ export async function upsertGuestRsvp(
 ) {
   const player = await prisma.player.findUnique({
     where: { id: playerId },
-    select: { eventId: true, userId: true },
+    select: { eventId: true, userId: true, name: true },
   });
   if (!player) throw new Error("Player not found.");
   if (player.eventId !== eventId) throw new Error("Player does not belong to this event.");
   if (player.userId) throw new Error("Player is linked to a User — that user must self-RSVP.");
 
+  const event = await prisma.event.findUnique({ where: { id: eventId }, select: { currentGameId: true } });
+  if (!event?.currentGameId) throw new Error("Event has no active game.");
+
+  const ep = await prisma.eventPlayer.upsert({
+    where: { eventId_name: { eventId, name: player.name } },
+    create: { eventId, name: player.name },
+    update: {},
+  });
+
   const respondedAt = status === null ? null : new Date();
   return prisma.rsvp.upsert({
-    where: { playerId_eventId: { playerId, eventId } },
-    create: { eventId, playerId, status, respondedAt, respondedByUserId: actorUserId },
+    where: { eventPlayerId_gameId: { eventPlayerId: ep.id, gameId: event.currentGameId } },
+    create: { eventPlayerId: ep.id, gameId: event.currentGameId, status, respondedAt, respondedByUserId: actorUserId },
     update: { status, respondedAt, respondedByUserId: actorUserId },
   });
 }
 
 export async function getRsvpForGuest(eventId: string, playerId: string) {
+  const player = await prisma.player.findUnique({ where: { id: playerId }, select: { name: true } });
+  if (!player) return null;
+  const event = await prisma.event.findUnique({ where: { id: eventId }, select: { currentGameId: true } });
+  if (!event?.currentGameId) return null;
+  const ep = await prisma.eventPlayer.findFirst({ where: { eventId, name: player.name }, select: { id: true } });
+  if (!ep) return null;
   return prisma.rsvp.findUnique({
-    where: { playerId_eventId: { playerId, eventId } },
+    where: { eventPlayerId_gameId: { eventPlayerId: ep.id, gameId: event.currentGameId } },
   });
 }
 
-/** Map of playerId → status for all active (non-archived) guest Players in the event. Public — used to render the read-only pill on the player list for everyone (incl. anonymous viewers). */
+/** Map of playerId → RSVP status for all active guest Players in the current game. */
 export async function getGuestRsvpMap(eventId: string): Promise<Record<string, RsvpStatus>> {
+  const event = await prisma.event.findUnique({ where: { id: eventId }, select: { currentGameId: true } });
+  if (!event?.currentGameId) return {};
+
   const guests = await prisma.player.findMany({
     where: { eventId, userId: null, archivedAt: null },
-    select: { id: true },
+    select: { id: true, name: true },
   });
+  if (guests.length === 0) return {};
+
+  // Resolve EventPlayer IDs for these guests
+  const eventPlayers = await prisma.eventPlayer.findMany({
+    where: { eventId, name: { in: guests.map((g) => g.name) } },
+    select: { id: true, name: true },
+  });
+  const epByName = new Map(eventPlayers.map((ep) => [ep.name, ep.id]));
+
+  const epIds = eventPlayers.map((ep) => ep.id);
   const rsvps = await prisma.rsvp.findMany({
-    where: { eventId, playerId: { in: guests.map((g) => g.id) } },
-    select: { playerId: true, status: true },
+    where: { gameId: event.currentGameId, eventPlayerId: { in: epIds } },
+    select: { eventPlayerId: true, status: true },
   });
+  const rsvpByEpId = new Map(rsvps.map((r) => [r.eventPlayerId, r.status as RsvpStatus]));
+
+  // Map back to playerId for the UI (PlayerList renders by playerId)
   const map: Record<string, RsvpStatus> = {};
-  for (const g of guests) map[g.id] = null;
-  for (const r of rsvps) {
-    if (r.playerId) map[r.playerId] = (r.status as RsvpStatus) ?? null;
+  for (const g of guests) {
+    const epId = epByName.get(g.name);
+    map[g.id] = epId ? (rsvpByEpId.get(epId) ?? null) : null;
   }
   return map;
 }
 
-/**
- * Map of userId → RSVP status for every linked User who has an RSVP row on this event
- * (owner, followers, linked players). When `viewerIsLogged` is false (anonymous viewer)
- * the function returns an empty map to enforce one-way privacy — anonymous viewers
- * must not see logged users' answers. The caller is responsible for passing the
- * viewer's auth state; the server-side guard is here, not just the UI.
- */
+/** Map of userId → RSVP status for linked Users in the current game. */
 export async function getUserRsvpMap(eventId: string, viewerIsLogged: boolean): Promise<Record<string, RsvpStatus>> {
   if (!viewerIsLogged) return {};
-  const rsvps = await prisma.rsvp.findMany({
+  const event = await prisma.event.findUnique({ where: { id: eventId }, select: { currentGameId: true } });
+  if (!event?.currentGameId) return {};
+
+  // Get all EventPlayers with a userId for this event
+  const eventPlayers = await prisma.eventPlayer.findMany({
     where: { eventId, userId: { not: null } },
-    select: { userId: true, status: true },
+    select: { id: true, userId: true },
   });
+  if (eventPlayers.length === 0) return {};
+
+  const epIds = eventPlayers.map((ep) => ep.id);
+  const rsvps = await prisma.rsvp.findMany({
+    where: { gameId: event.currentGameId, eventPlayerId: { in: epIds } },
+    select: { eventPlayerId: true, status: true },
+  });
+  const rsvpByEpId = new Map(rsvps.map((r) => [r.eventPlayerId, r.status as RsvpStatus]));
+
+  // Map back to userId for the UI
   const map: Record<string, RsvpStatus> = {};
-  for (const r of rsvps) {
-    if (r.userId) map[r.userId] = (r.status as RsvpStatus) ?? null;
+  for (const ep of eventPlayers) {
+    if (ep.userId && rsvpByEpId.has(ep.id)) {
+      map[ep.userId] = rsvpByEpId.get(ep.id) ?? null;
+    }
   }
   return map;
 }
@@ -152,44 +242,54 @@ async function getActiveGuestPlayers(eventId: string): Promise<{ id: string }[]>
 }
 
 export async function getRsvpSummary(eventId: string): Promise<RsvpSummary> {
+  const event = await prisma.event.findUnique({ where: { id: eventId }, select: { currentGameId: true } });
+  if (!event?.currentGameId) return { yes: 0, no: 0, pending: 0, yesUserIds: [], noUserIds: [], pendingUserIds: [] };
+
   const recipientIds = await getRsvpRecipients(eventId);
   const guestPlayers = await getActiveGuestPlayers(eventId);
-  const guestIds = guestPlayers.map((p) => p.id);
 
-  const rsvps = await prisma.rsvp.findMany({
-    where: {
-      eventId,
-      OR: [
-        { userId: { in: recipientIds } },
-        { playerId: { in: guestIds } },
-      ],
-    },
-    select: { userId: true, playerId: true, status: true },
+  // Resolve EventPlayer IDs for recipients (linked users)
+  const linkedEps = await prisma.eventPlayer.findMany({
+    where: { eventId, userId: { in: recipientIds } },
+    select: { id: true, userId: true },
+  });
+  // Resolve EventPlayer IDs for guests
+  const guestNames = await prisma.player.findMany({
+    where: { id: { in: guestPlayers.map((g) => g.id) } },
+    select: { id: true, name: true },
+  });
+  const guestEps = await prisma.eventPlayer.findMany({
+    where: { eventId, name: { in: guestNames.map((g) => g.name) } },
+    select: { id: true, name: true },
   });
 
-  const respondedUser = new Map<string, RsvpStatusValue>();
-  const respondedGuest = new Map<string, RsvpStatusValue>();
-  for (const r of rsvps) {
-    if (r.status !== "yes" && r.status !== "no" && r.status !== "maybe") continue;
-    if (r.userId) respondedUser.set(r.userId, r.status);
-    else if (r.playerId) respondedGuest.set(r.playerId, r.status);
-  }
+  const allEpIds = [...linkedEps.map((e) => e.id), ...guestEps.map((e) => e.id)];
+  const rsvps = await prisma.rsvp.findMany({
+    where: { gameId: event.currentGameId, eventPlayerId: { in: allEpIds } },
+    select: { eventPlayerId: true, status: true },
+  });
+  const rsvpByEpId = new Map(rsvps.map((r) => [r.eventPlayerId, r.status]));
 
+  // Map linked user RSVPs back to userId
   const yesUserIds: string[] = [];
   const noUserIds: string[] = [];
   const pendingUserIds: string[] = [];
   for (const uid of recipientIds) {
-    const s = respondedUser.get(uid);
+    const ep = linkedEps.find((e) => e.userId === uid);
+    const s = ep ? rsvpByEpId.get(ep.id) : undefined;
     if (s === "yes") yesUserIds.push(uid);
     else if (s === "no") noUserIds.push(uid);
     else pendingUserIds.push(uid);
   }
 
+  // Map guest RSVPs
+  const guestEpByName = new Map(guestEps.map((e) => [e.name, e.id]));
   let yesGuestCount = 0;
   let noGuestCount = 0;
   let pendingGuestCount = 0;
-  for (const gid of guestIds) {
-    const s = respondedGuest.get(gid);
+  for (const gn of guestNames) {
+    const epId = guestEpByName.get(gn.name);
+    const s = epId ? rsvpByEpId.get(epId) : undefined;
     if (s === "yes") yesGuestCount++;
     else if (s === "no") noGuestCount++;
     else pendingGuestCount++;
@@ -199,9 +299,9 @@ export async function getRsvpSummary(eventId: string): Promise<RsvpSummary> {
     yes: yesUserIds.length + yesGuestCount,
     no: noUserIds.length + noGuestCount,
     pending: pendingUserIds.length + pendingGuestCount,
-    yesUserIds: yesUserIds,
-    noUserIds: noUserIds,
-    pendingUserIds: pendingUserIds,
+    yesUserIds,
+    noUserIds,
+    pendingUserIds,
   };
 }
 
@@ -333,10 +433,16 @@ export async function countAppOpenDays(userId: string, lookbackDays: number = AP
   });
 }
 
-/** Does the user have at least one pending RSVP (status=null) for a future event? */
+/** Does the user have at least one pending RSVP (status=null) for a future game? */
 export async function userHasPendingRsvp(userId: string, now: Date = new Date()): Promise<boolean> {
+  // Find EventPlayers for this user, then check if any have a pending RSVP on a future game
+  const eps = await prisma.eventPlayer.findMany({
+    where: { userId },
+    select: { id: true },
+  });
+  if (eps.length === 0) return false;
   const row = await prisma.rsvp.findFirst({
-    where: { userId, status: null, event: { dateTime: { gt: now } } },
+    where: { eventPlayerId: { in: eps.map((e) => e.id) }, status: null, game: { dateTime: { gt: now } } },
     select: { id: true },
   });
   return !!row;

--- a/src/pages/api/events/[id]/players.ts
+++ b/src/pages/api/events/[id]/players.ts
@@ -530,17 +530,28 @@ export const POST: APIRoute = async ({ params, request }) => {
             ...(resolvedUser && !existing.userId ? { userId: resolvedUser.id } : {}),
           },
         });
-        if (reactivatedUserId) {
+        if (reactivatedUserId && event.currentGameId) {
+          const ep = await prisma.eventPlayer.upsert({
+            where: { eventId_name: { eventId, name: trimmed } },
+            create: { eventId, name: trimmed, userId: reactivatedUserId },
+            update: { ...(reactivatedUserId ? { userId: reactivatedUserId } : {}) },
+          });
           await prisma.rsvp.upsert({
-            where: { userId_eventId: { userId: reactivatedUserId, eventId } },
-            create: { eventId, userId: reactivatedUserId, status: "yes", respondedAt: new Date() },
+            where: { eventPlayerId_gameId: { eventPlayerId: ep.id, gameId: event.currentGameId } },
+            create: { eventPlayerId: ep.id, gameId: event.currentGameId, status: "yes", respondedAt: new Date() },
             update: { status: "yes", respondedAt: new Date() },
           });
-        } else {
-          // Guest re-add: reset their guest Rsvp to "yes" if it was "no".
-          await prisma.rsvp.updateMany({
-            where: { playerId: existing.id, status: "no" },
-            data: { status: "yes", respondedAt: new Date() },
+        } else if (!reactivatedUserId && event.currentGameId) {
+          // Guest re-add: reset their RSVP to "yes" on the current game
+          const ep = await prisma.eventPlayer.upsert({
+            where: { eventId_name: { eventId, name: trimmed } },
+            create: { eventId, name: trimmed },
+            update: {},
+          });
+          await prisma.rsvp.upsert({
+            where: { eventPlayerId_gameId: { eventPlayerId: ep.id, gameId: event.currentGameId } },
+            create: { eventPlayerId: ep.id, gameId: event.currentGameId, status: "yes", respondedAt: new Date() },
+            update: { status: "yes", respondedAt: new Date() },
           });
         }
         return Response.json({ ok: true, invited: null, resolvedName: trimmed, reactivated: true });
@@ -564,10 +575,22 @@ export const POST: APIRoute = async ({ params, request }) => {
           await prisma.gameParticipant.create({
             data: { gameId: event.currentGameId, eventPlayerId: eventPlayer.id, order: gpCount },
           });
-          // Link user if not already linked
-          if (linkedUserId && !existing.userId) {
-            await prisma.player.update({ where: { id: existing.id }, data: { userId: linkedUserId } });
-          }
+          // Move player to end of list — their old order is stale from the previous game
+          const maxOrder = await prisma.player.aggregate({
+            where: { eventId, archivedAt: null },
+            _max: { order: true },
+          });
+          const newOrder = (maxOrder._max.order ?? -1) + 1;
+          await prisma.player.update({
+            where: { id: existing.id },
+            data: { order: newOrder, ...(linkedUserId && !existing.userId ? { userId: linkedUserId } : {}) },
+          });
+          // Reset stale RSVP from previous game occurrence — write "yes" on the new game
+          await prisma.rsvp.upsert({
+            where: { eventPlayerId_gameId: { eventPlayerId: eventPlayer.id, gameId: event.currentGameId } },
+            create: { eventPlayerId: eventPlayer.id, gameId: event.currentGameId, status: "yes", respondedAt: new Date() },
+            update: { status: "yes", respondedAt: new Date() },
+          });
           return Response.json({ ok: true, invited: null, resolvedName: trimmed });
         }
         // Already in the current game — fall through to duplicate error

--- a/src/test/adr-0018-organizer-automation.test.ts
+++ b/src/test/adr-0018-organizer-automation.test.ts
@@ -12,7 +12,7 @@ async function seedUser(name: string, id?: string) {
 }
 
 async function seedEvent(ownerId: string | null = null, overrides: Record<string, unknown> = {}) {
-  return prisma.event.create({
+  const event = await prisma.event.create({
     data: {
       title: "Weekly Futsal",
       location: "Pitch A",
@@ -24,6 +24,9 @@ async function seedEvent(ownerId: string | null = null, overrides: Record<string
       ...overrides,
     },
   });
+  const game = await prisma.game.create({ data: { eventId: event.id, dateTime: event.dateTime } });
+  await prisma.event.update({ where: { id: event.id }, data: { currentGameId: game.id } });
+  return { ...event, currentGameId: game.id };
 }
 
 beforeEach(async () => {
@@ -201,7 +204,7 @@ describe("Auto-confirm attendance", () => {
     const applied = await applyAutoConfirm(event.id);
     expect(applied).toContain(user.id);
 
-    const rsvp = await prisma.rsvp.findUnique({ where: { userId_eventId: { userId: user.id, eventId: event.id } } });
+    const rsvp = await prisma.rsvp.findFirst({ where: { gameId: event.currentGameId! } });
     expect(rsvp?.status).toBe("yes");
   });
 });

--- a/src/test/game-occurrence.test.ts
+++ b/src/test/game-occurrence.test.ts
@@ -374,14 +374,14 @@ describe("RSVP does not carry over after recurrence advancement", () => {
     });
 
     // User has RSVP "yes" for the old game
-    await prisma.rsvp.create({
-      data: { eventId: event.id, userId: user.id, status: "yes", respondedAt: new Date() },
-    });
     await prisma.player.create({
       data: { eventId: event.id, name: "José", order: 0, userId: user.id },
     });
     const ep = await prisma.eventPlayer.create({
       data: { eventId: event.id, name: "José", userId: user.id },
+    });
+    await prisma.rsvp.create({
+      data: { eventPlayerId: ep.id, gameId: game1.id, status: "yes", respondedAt: new Date() },
     });
     await prisma.gameParticipant.create({
       data: { gameId: game1.id, eventPlayerId: ep.id, order: 0 },
@@ -614,13 +614,12 @@ describe("Recurrence advancement preserves legacy data (no destructive reset)", 
         members: { create: [{ name: "Keep Me", order: 0 }] },
       },
     });
-    await prisma.rsvp.create({
-      data: { eventId: event.id, userId: user.id, status: "yes", respondedAt: new Date() },
-    });
-
     // Also seed new-model data
     const ep = await prisma.eventPlayer.create({
       data: { eventId: event.id, name: "Keep Me", userId: user.id },
+    });
+    await prisma.rsvp.create({
+      data: { eventPlayerId: ep.id, gameId: game1.id, status: "yes", respondedAt: new Date() },
     });
     await prisma.gameParticipant.create({
       data: { gameId: game1.id, eventPlayerId: ep.id, order: 0 },
@@ -640,9 +639,13 @@ describe("Recurrence advancement preserves legacy data (no destructive reset)", 
     const teams = await prisma.teamResult.findMany({ where: { eventId: event.id } });
     expect(teams).toHaveLength(1);
 
-    // RSVP should still exist (scoped to old game conceptually)
-    const rsvps = await prisma.rsvp.findMany({ where: { eventId: event.id } });
+    // RSVP stays on the OLD game (game-scoped — no destructive delete needed)
+    const rsvps = await prisma.rsvp.findMany({ where: { gameId: game1.id } });
     expect(rsvps).toHaveLength(1);
+    // New game has no RSVPs yet
+    const updatedEvt = await prisma.event.findUnique({ where: { id: event.id }, select: { currentGameId: true } });
+    const newRsvps = await prisma.rsvp.findMany({ where: { gameId: updatedEvt!.currentGameId! } });
+    expect(newRsvps).toHaveLength(0);
   });
 });
 

--- a/src/test/leave.test.ts
+++ b/src/test/leave.test.ts
@@ -47,7 +47,7 @@ async function seedUser(name = "Alice", id?: string) {
 }
 
 async function seedEvent(ownerId: string | null, dateOffsetMs = 7 * 86400_000) {
-  return prisma.event.create({
+  const event = await prisma.event.create({
     data: {
       title: "Game",
       location: "Pitch",
@@ -56,6 +56,9 @@ async function seedEvent(ownerId: string | null, dateOffsetMs = 7 * 86400_000) {
       maxPlayers: 5,
     },
   });
+  const game = await prisma.game.create({ data: { eventId: event.id, dateTime: event.dateTime } });
+  await prisma.event.update({ where: { id: event.id }, data: { currentGameId: game.id } });
+  return { ...event, currentGameId: game.id };
 }
 
 describe("isWithin48hBeforeKickoff", () => {
@@ -87,6 +90,9 @@ describe("archiveAndLeave — self-leave", () => {
     const player = await prisma.player.create({
       data: { eventId: event.id, name: "Alice", userId: user.id, order: 0 },
     });
+    await prisma.eventPlayer.create({
+      data: { eventId: event.id, name: "Alice", userId: user.id },
+    });
 
     const result = await archiveAndLeave({
       eventId: event.id,
@@ -97,8 +103,8 @@ describe("archiveAndLeave — self-leave", () => {
     expect(result.ok).toBe(true);
     const updated = await prisma.player.findUnique({ where: { id: player.id } });
     expect(updated?.archivedAt).not.toBeNull();
-    const rsvp = await prisma.rsvp.findUnique({
-      where: { userId_eventId: { userId: user.id, eventId: event.id } },
+    const rsvp = await prisma.rsvp.findFirst({
+      where: { gameId: event.currentGameId! },
     });
     expect(rsvp?.status).toBe("no");
   });
@@ -152,6 +158,9 @@ describe("archiveAndLeave — admin decline guest (organizer path)", () => {
     const guest = await prisma.player.create({
       data: { eventId: event.id, name: "Guest", order: 0 },
     });
+    await prisma.eventPlayer.create({
+      data: { eventId: event.id, name: "Guest" },
+    });
 
     await archiveAndLeave({
       eventId: event.id,
@@ -163,8 +172,8 @@ describe("archiveAndLeave — admin decline guest (organizer path)", () => {
     expect(updated?.archivedAt).not.toBeNull();
     // The organizer + guest branch writes Rsvp.status="no" with the respondedByUserId audit field,
     // so the summary chips reflect the decline even though the guest can't self-RSVP.
-    const rsvp = await prisma.rsvp.findUnique({
-      where: { playerId_eventId: { playerId: guest.id, eventId: event.id } },
+    const rsvp = await prisma.rsvp.findFirst({
+      where: { gameId: event.currentGameId! },
     });
     expect(rsvp?.status).toBe("no");
     expect(rsvp?.respondedByUserId).toBe(owner.id);

--- a/src/test/migration-safety.test.ts
+++ b/src/test/migration-safety.test.ts
@@ -187,19 +187,18 @@ describe("Data integrity during recurrence advancement", () => {
         members: { create: [{ name: "José", order: 0 }, { name: "Miguel", order: 1 }] },
       },
     });
-    await prisma.rsvp.create({
-      data: { eventId: event.id, userId: user.id, status: "yes", respondedAt: new Date() },
-    });
-
     const ep1 = await prisma.eventPlayer.create({ data: { eventId: event.id, name: "José", userId: user.id } });
     const ep2 = await prisma.eventPlayer.create({ data: { eventId: event.id, name: "Miguel" } });
+    await prisma.rsvp.create({
+      data: { eventPlayerId: ep1.id, gameId: game1.id, status: "yes", respondedAt: new Date() },
+    });
     await prisma.gameParticipant.create({ data: { gameId: game1.id, eventPlayerId: ep1.id, order: 0 } });
     await prisma.gameParticipant.create({ data: { gameId: game1.id, eventPlayerId: ep2.id, order: 1 } });
 
     // Record counts BEFORE advancement
     const beforePlayers = await prisma.player.count({ where: { eventId: event.id } });
     const beforeTeams = await prisma.teamResult.count({ where: { eventId: event.id } });
-    const beforeRsvps = await prisma.rsvp.count({ where: { eventId: event.id } });
+    const beforeRsvps = await prisma.rsvp.count({ where: { gameId: game1.id } });
     const beforeEventPlayers = await prisma.eventPlayer.count({ where: { eventId: event.id } });
     const beforeParticipants = await prisma.gameParticipant.count({ where: { gameId: game1.id } });
 
@@ -211,12 +210,13 @@ describe("Data integrity during recurrence advancement", () => {
     // Verify NO data was lost
     const afterPlayers = await prisma.player.count({ where: { eventId: event.id } });
     const afterTeams = await prisma.teamResult.count({ where: { eventId: event.id } });
-    const afterRsvps = await prisma.rsvp.count({ where: { eventId: event.id } });
+    const afterRsvps = await prisma.rsvp.count({ where: { gameId: game1.id } });
     const afterEventPlayers = await prisma.eventPlayer.count({ where: { eventId: event.id } });
     const afterParticipants = await prisma.gameParticipant.count({ where: { gameId: game1.id } });
 
     expect(afterPlayers).toBe(beforePlayers);
     expect(afterTeams).toBe(beforeTeams);
+    // RSVPs stay on the old game (game-scoped — preserved as historical record)
     expect(afterRsvps).toBe(beforeRsvps);
     expect(afterEventPlayers).toBe(beforeEventPlayers);
     expect(afterParticipants).toBe(beforeParticipants);

--- a/src/test/rsvp-api.test.ts
+++ b/src/test/rsvp-api.test.ts
@@ -63,7 +63,7 @@ function getCtx(eventId: string, session: { user: { id: string; name: string } }
 }
 
 async function seedEvent(dateOffsetMs: number) {
-  return testPrisma.event.create({
+  const event = await testPrisma.event.create({
     data: {
       title: "Game",
       location: "Pitch",
@@ -71,6 +71,9 @@ async function seedEvent(dateOffsetMs: number) {
       ownerId: null,
     },
   });
+  const game = await testPrisma.game.create({ data: { eventId: event.id, dateTime: event.dateTime } });
+  await testPrisma.event.update({ where: { id: event.id }, data: { currentGameId: game.id } });
+  return { ...event, currentGameId: game.id };
 }
 
 describe("POST /api/events/[id]/rsvp", () => {
@@ -116,7 +119,7 @@ describe("POST /api/events/[id]/rsvp", () => {
     const res = await rsvpPost(ctx(ev.id, { status: "no" }, user));
     const body = await res.json();
     expect(body.status).toBe("no");
-    const count = await testPrisma.rsvp.count({ where: { eventId: ev.id, userId: "u1" } });
+    const count = await testPrisma.rsvp.count({ where: { gameId: ev.currentGameId! } });
     expect(count).toBe(1);
   });
 
@@ -169,8 +172,9 @@ describe("POST /api/events/[id]/rsvp", () => {
     const firstBody = await firstRes.json();
 
     // Manually flip the DB row to a different status — replay should still return the original.
+    const rsvpRow = await testPrisma.rsvp.findFirst({ where: { gameId: ev.currentGameId! } });
     await testPrisma.rsvp.update({
-      where: { userId_eventId: { userId: "u1", eventId: ev.id } },
+      where: { id: rsvpRow!.id },
       data: { status: "no" },
     });
 
@@ -198,7 +202,8 @@ describe("GET /api/events/[id]/rsvp", () => {
   it("returns stored status", async () => {
     const ev = await seedEvent(7 * 86400_000);
     await testPrisma.user.create({ data: { id: "u1", name: "U", email: "u1@t.com", emailVerified: true } });
-    await testPrisma.rsvp.create({ data: { eventId: ev.id, userId: "u1", status: "yes", respondedAt: new Date() } });
+    const ep = await testPrisma.eventPlayer.create({ data: { eventId: ev.id, name: "U", userId: "u1" } });
+    await testPrisma.rsvp.create({ data: { eventPlayerId: ep.id, gameId: ev.currentGameId!, status: "yes", respondedAt: new Date() } });
     const res = await rsvpGet(getCtx(ev.id, { user: { id: "u1", name: "U" } }));
     const body = await res.json();
     expect(body.status).toBe("yes");

--- a/src/test/rsvp-cron.test.ts
+++ b/src/test/rsvp-cron.test.ts
@@ -22,9 +22,12 @@ async function seedUser(name: string) {
 }
 
 async function seedEvent(dateTime: Date, ownerId: string | null) {
-  return prisma.event.create({
+  const event = await prisma.event.create({
     data: { title: "Game", location: "Pitch", dateTime, ownerId },
   });
+  const game = await prisma.game.create({ data: { eventId: event.id, dateTime } });
+  await prisma.event.update({ where: { id: event.id }, data: { currentGameId: game.id } });
+  return { ...event, currentGameId: game.id };
 }
 
 describe("RSVP 48h tick windowing", () => {

--- a/src/test/rsvp-guest-api.test.ts
+++ b/src/test/rsvp-guest-api.test.ts
@@ -57,7 +57,7 @@ function ctx(eventId: string, playerId: string, body: unknown, session: { user: 
 }
 
 async function seedEvent(ownerId: string | null, dateOffsetMs = 7 * 86400_000) {
-  return testPrisma.event.create({
+  const event = await testPrisma.event.create({
     data: {
       title: "Game",
       location: "Pitch",
@@ -65,6 +65,9 @@ async function seedEvent(ownerId: string | null, dateOffsetMs = 7 * 86400_000) {
       ownerId,
     },
   });
+  const game = await testPrisma.game.create({ data: { eventId: event.id, dateTime: event.dateTime } });
+  await testPrisma.event.update({ where: { id: event.id }, data: { currentGameId: game.id } });
+  return { ...event, currentGameId: game.id };
 }
 
 describe("POST /api/events/[id]/players/[playerId]/rsvp", () => {
@@ -114,9 +117,9 @@ describe("POST /api/events/[id]/players/[playerId]/rsvp", () => {
     expect(body.status).toBe("yes");
     expect(body.respondedByUserId).toBe("owner");
 
-    const row = await testPrisma.rsvp.findFirst({ where: { eventId: ev.id, playerId: guest.id } });
+    const row = await testPrisma.rsvp.findFirst({ where: { gameId: ev.currentGameId! } });
     expect(row?.status).toBe("yes");
-    expect(row?.userId).toBeNull();
+    expect(row?.eventPlayerId).toBeTruthy();
   });
 
   it("admin (non-owner) can set guest attendance", async () => {
@@ -204,7 +207,7 @@ describe("POST /api/events/[id]/players/[playerId]/rsvp", () => {
     await guestRsvpPost(ctx(ev.id, guest.id, { status: "yes" }, { user: { id: "owner", name: "O" } }));
     await guestRsvpPost(ctx(ev.id, guest.id, { status: "no" }, { user: { id: "owner", name: "O" } }));
 
-    const count = await testPrisma.rsvp.count({ where: { eventId: ev.id, playerId: guest.id } });
+    const count = await testPrisma.rsvp.count({ where: { gameId: ev.currentGameId! } });
     expect(count).toBe(1);
   });
 });

--- a/src/test/rsvp-guests-api.test.ts
+++ b/src/test/rsvp-guests-api.test.ts
@@ -62,6 +62,9 @@ describe("GET /api/events/[id]/rsvp/guests", () => {
     const ev = await testPrisma.event.create({
       data: { title: "G", location: "P", dateTime: new Date(Date.now() + 86400_000), ownerId: owner.id },
     });
+    const game = await testPrisma.game.create({ data: { eventId: ev.id, dateTime: ev.dateTime } });
+    await testPrisma.event.update({ where: { id: ev.id }, data: { currentGameId: game.id } });
+    Object.assign(ev, { currentGameId: game.id });
 
     const g1 = await testPrisma.player.create({ data: { eventId: ev.id, name: "G1", order: 0 } });
     const g2 = await testPrisma.player.create({ data: { eventId: ev.id, name: "G2", order: 1 } });
@@ -72,10 +75,15 @@ describe("GET /api/events/[id]/rsvp/guests", () => {
       data: { eventId: ev.id, name: "L", userId: linked.id, order: 3 },
     });
 
-    await testPrisma.rsvp.create({ data: { eventId: ev.id, playerId: g1.id, status: "yes", respondedAt: new Date() } });
-    await testPrisma.rsvp.create({ data: { eventId: ev.id, playerId: g2.id, status: "no", respondedAt: new Date() } });
-    await testPrisma.rsvp.create({ data: { eventId: ev.id, playerId: archived.id, status: "yes", respondedAt: new Date() } });
-    await testPrisma.rsvp.create({ data: { eventId: ev.id, userId: linked.id, status: "yes", respondedAt: new Date() } });
+    const epG1 = await testPrisma.eventPlayer.create({ data: { eventId: ev.id, name: "G1" } });
+    const epG2 = await testPrisma.eventPlayer.create({ data: { eventId: ev.id, name: "G2" } });
+    const epArch = await testPrisma.eventPlayer.create({ data: { eventId: ev.id, name: "Arch" } });
+    const epLinked = await testPrisma.eventPlayer.create({ data: { eventId: ev.id, name: "L", userId: linked.id } });
+
+    await testPrisma.rsvp.create({ data: { eventPlayerId: epG1.id, gameId: ev.currentGameId!, status: "yes", respondedAt: new Date() } });
+    await testPrisma.rsvp.create({ data: { eventPlayerId: epG2.id, gameId: ev.currentGameId!, status: "no", respondedAt: new Date() } });
+    await testPrisma.rsvp.create({ data: { eventPlayerId: epArch.id, gameId: ev.currentGameId!, status: "yes", respondedAt: new Date() } });
+    await testPrisma.rsvp.create({ data: { eventPlayerId: epLinked.id, gameId: ev.currentGameId!, status: "yes", respondedAt: new Date() } });
 
     const res = await guestsGet(ctx(ev.id));
     expect(res.status).toBe(200);

--- a/src/test/rsvp-summary-api.test.ts
+++ b/src/test/rsvp-summary-api.test.ts
@@ -38,9 +38,12 @@ function ctx(eventId: string) {
 }
 
 async function seedEvent(ownerId: string | null) {
-  return testPrisma.event.create({
+  const event = await testPrisma.event.create({
     data: { title: "Game", location: "Pitch", dateTime: new Date(Date.now() + 86400_000), ownerId },
   });
+  const game = await testPrisma.game.create({ data: { eventId: event.id, dateTime: event.dateTime } });
+  await testPrisma.event.update({ where: { id: event.id }, data: { currentGameId: game.id } });
+  return { ...event, currentGameId: game.id };
 }
 
 beforeEach(async () => {

--- a/src/test/rsvp-users-api.test.ts
+++ b/src/test/rsvp-users-api.test.ts
@@ -96,7 +96,7 @@ describe("GET /api/events/[id]/rsvp/users", () => {
   it("excludes guest (playerId-keyed) RSVPs from the user map", async () => {
     const owner = await testPrisma.user.create({ data: { id: "owner", name: "O", email: "o@t.com", emailVerified: true } });
     const ev = await seedEvent(owner.id);
-    const guest = await testPrisma.player.create({ data: { eventId: ev.id, name: "G", order: 0 } });
+    const _guest = await testPrisma.player.create({ data: { eventId: ev.id, name: "G", order: 0 } });
     const epGuest = await testPrisma.eventPlayer.create({ data: { eventId: ev.id, name: "G" } });
     await testPrisma.rsvp.create({ data: { eventPlayerId: epGuest.id, gameId: ev.currentGameId!, status: "yes", respondedAt: new Date() } });
 

--- a/src/test/rsvp-users-api.test.ts
+++ b/src/test/rsvp-users-api.test.ts
@@ -45,7 +45,7 @@ function ctx(eventId: string, session: { user: { id: string; name: string } } | 
 }
 
 async function seedEvent(ownerId: string | null) {
-  return testPrisma.event.create({
+  const event = await testPrisma.event.create({
     data: {
       title: "Game",
       location: "Pitch",
@@ -53,6 +53,9 @@ async function seedEvent(ownerId: string | null) {
       ownerId,
     },
   });
+  const game = await testPrisma.game.create({ data: { eventId: event.id, dateTime: event.dateTime } });
+  await testPrisma.event.update({ where: { id: event.id }, data: { currentGameId: game.id } });
+  return { ...event, currentGameId: game.id };
 }
 
 describe("GET /api/events/[id]/rsvp/users", () => {
@@ -65,7 +68,8 @@ describe("GET /api/events/[id]/rsvp/users", () => {
     const owner = await testPrisma.user.create({ data: { id: "owner", name: "O", email: "o@t.com", emailVerified: true } });
     const other = await testPrisma.user.create({ data: { id: "other", name: "X", email: "x@t.com", emailVerified: true } });
     const ev = await seedEvent(owner.id);
-    await testPrisma.rsvp.create({ data: { eventId: ev.id, userId: other.id, status: "yes", respondedAt: new Date() } });
+    const epOther = await testPrisma.eventPlayer.create({ data: { eventId: ev.id, name: "X", userId: other.id } });
+    await testPrisma.rsvp.create({ data: { eventPlayerId: epOther.id, gameId: ev.currentGameId!, status: "yes", respondedAt: new Date() } });
 
     const res = await usersGet(ctx(ev.id, null));
     expect(res.status).toBe(200);
@@ -78,8 +82,10 @@ describe("GET /api/events/[id]/rsvp/users", () => {
     const a = await testPrisma.user.create({ data: { id: "a", name: "A", email: "a@t.com", emailVerified: true } });
     const b = await testPrisma.user.create({ data: { id: "b", name: "B", email: "b@t.com", emailVerified: true } });
     const ev = await seedEvent(owner.id);
-    await testPrisma.rsvp.create({ data: { eventId: ev.id, userId: a.id, status: "yes", respondedAt: new Date() } });
-    await testPrisma.rsvp.create({ data: { eventId: ev.id, userId: b.id, status: "maybe", respondedAt: new Date() } });
+    const epA = await testPrisma.eventPlayer.create({ data: { eventId: ev.id, name: "A", userId: a.id } });
+    const epB = await testPrisma.eventPlayer.create({ data: { eventId: ev.id, name: "B", userId: b.id } });
+    await testPrisma.rsvp.create({ data: { eventPlayerId: epA.id, gameId: ev.currentGameId!, status: "yes", respondedAt: new Date() } });
+    await testPrisma.rsvp.create({ data: { eventPlayerId: epB.id, gameId: ev.currentGameId!, status: "maybe", respondedAt: new Date() } });
 
     const res = await usersGet(ctx(ev.id, { user: { id: owner.id, name: "O" } }));
     expect(res.status).toBe(200);
@@ -91,7 +97,8 @@ describe("GET /api/events/[id]/rsvp/users", () => {
     const owner = await testPrisma.user.create({ data: { id: "owner", name: "O", email: "o@t.com", emailVerified: true } });
     const ev = await seedEvent(owner.id);
     const guest = await testPrisma.player.create({ data: { eventId: ev.id, name: "G", order: 0 } });
-    await testPrisma.rsvp.create({ data: { eventId: ev.id, playerId: guest.id, status: "yes", respondedAt: new Date() } });
+    const epGuest = await testPrisma.eventPlayer.create({ data: { eventId: ev.id, name: "G" } });
+    await testPrisma.rsvp.create({ data: { eventPlayerId: epGuest.id, gameId: ev.currentGameId!, status: "yes", respondedAt: new Date() } });
 
     const res = await usersGet(ctx(ev.id, { user: { id: owner.id, name: "O" } }));
     expect(res.status).toBe(200);

--- a/src/test/rsvp.test.ts
+++ b/src/test/rsvp.test.ts
@@ -56,7 +56,7 @@ async function seedUser(overrides: Record<string, unknown> = {}) {
 }
 
 async function seedEvent(ownerId: string | null, overrides: Record<string, unknown> = {}) {
-  return prisma.event.create({
+  const event = await prisma.event.create({
     data: {
       id: `e-${Math.random().toString(36).slice(2, 8)}`,
       title: "Game",
@@ -66,6 +66,12 @@ async function seedEvent(ownerId: string | null, overrides: Record<string, unkno
       ...overrides,
     },
   });
+  // ADR 0016: create a Game so RSVP operations work (game-scoped)
+  const game = await prisma.game.create({
+    data: { eventId: event.id, dateTime: event.dateTime },
+  });
+  await prisma.event.update({ where: { id: event.id }, data: { currentGameId: game.id } });
+  return { ...event, currentGameId: game.id };
 }
 
 describe("upsertRsvp", () => {
@@ -84,7 +90,7 @@ describe("upsertRsvp", () => {
     const rsvp = await upsertRsvp(event.id, user.id, "no");
     expect(rsvp.status).toBe("no");
 
-    const count = await prisma.rsvp.count({ where: { userId: user.id, eventId: event.id } });
+    const count = await prisma.rsvp.count({ where: { gameId: event.currentGameId } });
     expect(count).toBe(1);
   });
 
@@ -224,8 +230,8 @@ describe("upsertGuestRsvp", () => {
     const rsvp = await upsertGuestRsvp(event.id, guest.id, "yes", owner.id);
     expect(rsvp.status).toBe("yes");
     expect(rsvp.respondedAt).not.toBeNull();
-    expect(rsvp.playerId).toBe(guest.id);
-    expect(rsvp.userId).toBeNull();
+    expect(rsvp.eventPlayerId).toBeTruthy();
+    expect(rsvp.gameId).toBe(event.currentGameId);
     expect(rsvp.respondedByUserId).toBe(owner.id);
   });
 
@@ -240,7 +246,7 @@ describe("upsertGuestRsvp", () => {
     const rsvp = await upsertGuestRsvp(event.id, guest.id, "no", owner.id);
     expect(rsvp.status).toBe("no");
 
-    const count = await prisma.rsvp.count({ where: { playerId: guest.id, eventId: event.id } });
+    const count = await prisma.rsvp.count({ where: { gameId: event.currentGameId } });
     expect(count).toBe(1);
   });
 
@@ -421,10 +427,11 @@ describe("getEventsNeedingRsvpSummary", () => {
 });
 
 describe("userHasPendingRsvp", () => {
-  it("returns true when user has a null-status row on a future event", async () => {
+  it("returns true when user has a null-status row on a future game", async () => {
     const user = await seedUser();
     const ev = await seedEvent(null, { dateTime: new Date(Date.now() + 86400_000) });
-    await prisma.rsvp.create({ data: { userId: user.id, eventId: ev.id, status: null } });
+    const ep = await prisma.eventPlayer.create({ data: { eventId: ev.id, name: user.name, userId: user.id } });
+    await prisma.rsvp.create({ data: { eventPlayerId: ep.id, gameId: ev.currentGameId!, status: null } });
     expect(await userHasPendingRsvp(user.id)).toBe(true);
   });
 
@@ -436,14 +443,16 @@ describe("userHasPendingRsvp", () => {
   it("returns false for an answered (yes) row", async () => {
     const user = await seedUser();
     const ev = await seedEvent(null, { dateTime: new Date(Date.now() + 86400_000) });
-    await prisma.rsvp.create({ data: { userId: user.id, eventId: ev.id, status: "yes", respondedAt: new Date() } });
+    const ep = await prisma.eventPlayer.create({ data: { eventId: ev.id, name: user.name, userId: user.id } });
+    await prisma.rsvp.create({ data: { eventPlayerId: ep.id, gameId: ev.currentGameId!, status: "yes", respondedAt: new Date() } });
     expect(await userHasPendingRsvp(user.id)).toBe(false);
   });
 
-  it("returns false for a pending row on a past event", async () => {
+  it("returns false for a pending row on a past game", async () => {
     const user = await seedUser();
     const ev = await seedEvent(null, { dateTime: new Date(Date.now() - 86400_000) });
-    await prisma.rsvp.create({ data: { userId: user.id, eventId: ev.id, status: null } });
+    const ep = await prisma.eventPlayer.create({ data: { eventId: ev.id, name: user.name, userId: user.id } });
+    await prisma.rsvp.create({ data: { eventPlayerId: ep.id, gameId: ev.currentGameId!, status: null } });
     expect(await userHasPendingRsvp(user.id)).toBe(false);
   });
 });
@@ -530,7 +539,8 @@ describe("push prompt state machine", () => {
       await recordAppOpen(user.id, new Date(Date.now() - i * 86400_000));
     }
     // pending RSVP = row exists with status=null OR no row. We'll insert null-status row.
-    await prisma.rsvp.create({ data: { userId: user.id, eventId: e.id, status: null } });
+    const ep = await prisma.eventPlayer.create({ data: { eventId: e.id, name: user.name, userId: user.id } });
+    await prisma.rsvp.create({ data: { eventPlayerId: ep.id, gameId: e.currentGameId!, status: null } });
     expect(await shouldShowPushPrompt(user.id, true)).toBe(true);
   });
 


### PR DESCRIPTION
## Summary

Migrates the `Rsvp` table from event-scoped `(userId/playerId, eventId)` to game-scoped `(eventPlayerId, gameId)` per ADR-0016.

## Bugs Fixed

1. **Wrong position on re-join:** Player re-joining a new game occurrence kept their stale `Player.order` from the previous week. Now placed at end of list.
2. **Stale RSVP 'declined':** Previous game's `status='no'` carried over into the new game because RSVP was keyed on eventId (shared across games). Now each game has isolated RSVP records — no stale data leaks.

## Schema Change (BREAKING)

```prisma
model Rsvp {
  eventPlayerId  String
  gameId         String
  status         String?
  respondedAt    DateTime?
  respondedByUserId String?
  // ...
  @@unique([eventPlayerId, gameId])
}
```

- Single identity key on `EventPlayer` (the series-level participant identity)
- Game-scoping gives natural isolation between occurrences
- Migration SQL backfills existing RSVPs using Player→EventPlayer name joins

## Key Design Decisions

- **No destructive delete on reset:** Old game's RSVPs stay intact as historical record. New game starts clean by virtue of having a different `gameId`.
- **Single key on eventPlayerId:** Both self-RSVPs and admin-set guest RSVPs use the same key. `respondedByUserId` remains as audit trail.
- **resolveEventPlayerId helper:** Lazily creates EventPlayer when needed (fallback chain: EP by userId → Player by userId → User.name).

## What Changed

- `prisma/schema.prisma` — new Rsvp model
- `src/lib/rsvp.server.ts` — fully rewritten
- `src/lib/leave.server.ts` — RSVP on removal
- `src/lib/autoConfirm.server.ts` — writes to new game
- `src/pages/api/events/[id]/players.ts` — re-add/re-join paths + Player.order fix
- `src/pages/api/events/[id]/index.ts` — reverted deleteMany workaround
- 11 test files updated

## Testing

- All 2989 tests pass
- Typecheck clean
- Migration tested with backfill SQL