### PR TITLE
fix: played live Game score "Not found." + missing players in history

### DIFF
--- a/src/components/HistoryPage.tsx
+++ b/src/components/HistoryPage.tsx
@@ -67,6 +67,7 @@ interface HistoryEntry {
   eloProcessed: boolean;
   isFriendly: boolean;
   eloUpdates?: { name: string; delta: number }[] | null;
+  participants?: string[];
 }
 
 /** Reusable section wrapper with optional title + icon */
@@ -438,7 +439,9 @@ function HistoryCardFull({
     if (!userName) return false;
     const teams: TeamSnapshot[] = entry.teamsSnapshot ? JSON.parse(entry.teamsSnapshot) : [];
     const allNames = teams.flatMap((t) => t.players.map((p) => p.name.toLowerCase()));
-    return allNames.includes(userName.toLowerCase());
+    if (allNames.includes(userName.toLowerCase())) return true;
+    // Fallback: live Games surface participants as a flat list
+    return (entry.participants ?? []).some((n) => n.toLowerCase() === userName.toLowerCase());
   })();
   const canEditScore = entry.editable && isAuthenticated && isParticipantInGame;
   const canEditTeams = entry.editable && isAuthenticated && (isOwner || isParticipantInGame);

--- a/src/pages/api/events/[id]/history/[historyId].ts
+++ b/src/pages/api/events/[id]/history/[historyId].ts
@@ -9,6 +9,59 @@ import { createLogger } from "../../../../../lib/logger.server";
 
 const log = createLogger("history-patch");
 
+/**
+ * Build a GameHistory row from a "played" live Game. The live Game model does
+ * not store team assignments, so we reconstruct them from the event-level
+ * teamResults (the canonical source for the current occurrence) and the
+ * payments from the current EventCost. Used when the history PATCH is hit with
+ * a Game id that has no GameHistory snapshot yet (ADR 0016).
+ */
+async function buildSnapshotForGame(eventId: string, game: { id: string; dateTime: Date; status: string; scoreOne: number | null; scoreTwo: number | null; teamOneName: string | null; teamTwoName: string | null; isFriendly: boolean }) {
+  const event = await prisma.event.findUnique({
+    where: { id: eventId },
+    include: {
+      teamResults: { include: { members: { orderBy: { order: "asc" } } } },
+      eventCost: { include: { payments: true } },
+    },
+  });
+
+  const teamsSnapshot = event?.teamResults.length
+    ? JSON.stringify(
+        event.teamResults.map((tr) => ({
+          team: tr.name,
+          players: tr.members.map((m) => ({ name: m.name, order: m.order })),
+        })),
+      )
+    : null;
+
+  const paymentsSnapshot = event?.eventCost?.payments.length
+    ? JSON.stringify(
+        event.eventCost.payments.map((p) => ({
+          playerName: p.playerName,
+          amount: p.amount,
+          status: p.status,
+          method: p.method,
+        })),
+      )
+    : null;
+
+  return {
+    eventId,
+    dateTime: game.dateTime,
+    status: "played" as const,
+    scoreOne: game.scoreOne,
+    scoreTwo: game.scoreTwo,
+    teamOneName: game.teamOneName ?? event?.teamOneName ?? "Team 1",
+    teamTwoName: game.teamTwoName ?? event?.teamTwoName ?? "Team 2",
+    teamsSnapshot,
+    paymentsSnapshot,
+    editableUntil: new Date(game.dateTime.getTime() + 7 * 86400_000),
+    isFriendly: game.isFriendly,
+    source: "live" as const,
+    eloProcessed: false,
+  };
+}
+
 // PATCH /api/events/[id]/history/[historyId]
 export const PATCH: APIRoute = async ({ params, request }) => {
   const event = await prisma.event.findUnique({ where: { id: params.id } });
@@ -22,9 +75,25 @@ export const PATCH: APIRoute = async ({ params, request }) => {
 
   const { isOwner, isAdmin } = await checkOwnership(request, event.ownerId, session, params.id);
 
-  const entry = await prisma.gameHistory.findUnique({
+  let entry = await prisma.gameHistory.findUnique({
     where: { id: params.historyId, eventId: params.id },
   });
+
+  // ADR 0016: a "played" live Game may not yet have a GameHistory snapshot
+  // (e.g. the game just ended but the recurrence reset hasn't run, or the
+  // history entry was loaded directly). Materialise one so the score/teams
+  // can be edited through the same path.
+  let historyId = params.historyId;
+  if (!entry) {
+    const game = await prisma.game.findUnique({
+      where: { id: params.historyId, eventId: params.id },
+    });
+    if (game && game.status === "played") {
+      const snap = await buildSnapshotForGame(params.id ?? "", game);
+      entry = await prisma.gameHistory.create({ data: snap });
+      historyId = entry.id;
+    }
+  }
   if (!entry) return Response.json({ error: "Not found." }, { status: 404 });
 
   const body = await request.json();
@@ -36,7 +105,7 @@ export const PATCH: APIRoute = async ({ params, request }) => {
     }
     const newEditableUntil = new Date(Date.now() + 7 * 86400_000);
     const unlocked = await prisma.gameHistory.update({
-      where: { id: params.historyId },
+      where: { id: historyId },
       data: { editableUntil: newEditableUntil },
     });
 
@@ -64,7 +133,7 @@ export const PATCH: APIRoute = async ({ params, request }) => {
     }
     const newEditableUntil = new Date(Date.now() - 1000);
     const locked = await prisma.gameHistory.update({
-      where: { id: params.historyId },
+      where: { id: historyId },
       data: { editableUntil: newEditableUntil },
     });
 
@@ -91,7 +160,7 @@ export const PATCH: APIRoute = async ({ params, request }) => {
       return Response.json({ error: "Only the event owner or admin can toggle friendly." }, { status: 403 });
     }
     const updated = await prisma.gameHistory.update({
-      where: { id: params.historyId },
+      where: { id: historyId },
       data: { isFriendly: body.isFriendly },
     });
 
@@ -165,7 +234,7 @@ export const PATCH: APIRoute = async ({ params, request }) => {
     : undefined;
 
   const updated = await prisma.gameHistory.update({
-    where: { id: params.historyId },
+    where: { id: historyId },
     data: {
       ...(status !== undefined && { status }),
       ...(scoreOne !== undefined && { scoreOne: isNaN(scoreOne as number) ? null : scoreOne }),
@@ -220,7 +289,7 @@ export const PATCH: APIRoute = async ({ params, request }) => {
           },
         });
       } catch (err) {
-        log.error(`Failed to auto-sync payments after team update: eventId=${params.id} historyId=${params.historyId} error=${String(err)}`);
+        log.error(`Failed to auto-sync payments after team update: eventId=${params.id} historyId=${historyId} error=${String(err)}`);
       }
     }
   }
@@ -278,7 +347,7 @@ export const PATCH: APIRoute = async ({ params, request }) => {
       // Add MVP ELO bonus to displayed deltas
       if (event.mvpEloEnabled) {
         const votes = await prisma.mvpVote.findMany({
-          where: { gameHistoryId: params.historyId },
+          where: { gameHistoryId: historyId },
           select: { votedForName: true },
         });
         if (votes.length > 0) {
@@ -327,15 +396,31 @@ export const DELETE: APIRoute = async ({ params, request }) => {
     return Response.json({ error: "Only the event owner or admin can delete history entries." }, { status: 403 });
   }
 
-  const entry = await prisma.gameHistory.findUnique({
+  let entry = await prisma.gameHistory.findUnique({
     where: { id: params.historyId, eventId: params.id },
   });
+  let deleteHistoryId = params.historyId;
+
+  // ADR 0016: a "played" live Game may not yet have a GameHistory snapshot.
+  // Materialise one, then delete it and cancel the Game so it no longer
+  // surfaces as a played occurrence.
+  if (!entry) {
+    const game = await prisma.game.findUnique({
+      where: { id: params.historyId, eventId: params.id },
+    });
+    if (game && game.status === "played") {
+      const snap = await buildSnapshotForGame(params.id ?? "", game);
+      entry = await prisma.gameHistory.create({ data: snap });
+      deleteHistoryId = entry.id;
+      await prisma.game.update({ where: { id: game.id }, data: { status: "cancelled" } });
+    }
+  }
   if (!entry) return Response.json({ error: "Not found." }, { status: 404 });
 
   // If ELO was already processed, recalculate ratings after deletion
   const needsRecalc = entry.eloProcessed;
 
-  await prisma.gameHistory.delete({ where: { id: params.historyId } });
+  await prisma.gameHistory.delete({ where: { id: deleteHistoryId } });
 
   if (needsRecalc) {
     await recalculateAllRatings((params.id ?? ""));
@@ -343,7 +428,7 @@ export const DELETE: APIRoute = async ({ params, request }) => {
 
   const actor = session.user.name ?? session.user.email ?? "Unknown";
   logEvent((params.id ?? ""), "history_status_updated", actor, session.user.id, {
-    historyId: params.historyId,
+    historyId: deleteHistoryId,
     action: "deleted",
   });
 

--- a/src/pages/api/events/[id]/history/[historyId].ts
+++ b/src/pages/api/events/[id]/history/[historyId].ts
@@ -402,8 +402,10 @@ export const DELETE: APIRoute = async ({ params, request }) => {
   let deleteHistoryId = params.historyId;
 
   // ADR 0016: a "played" live Game may not yet have a GameHistory snapshot.
-  // Materialise one, then delete it and cancel the Game so it no longer
-  // surfaces as a played occurrence.
+  // Materialise one, then delete it. The source Game keeps its "played" status
+  // so it can be re-derived on demand — marking it "cancelled" would be wrong
+  // (cancelled means a skipped game) and would leak into the post-game banner
+  // and ELO skip filters.
   if (!entry) {
     const game = await prisma.game.findUnique({
       where: { id: params.historyId, eventId: params.id },
@@ -412,7 +414,6 @@ export const DELETE: APIRoute = async ({ params, request }) => {
       const snap = await buildSnapshotForGame(params.id ?? "", game);
       entry = await prisma.gameHistory.create({ data: snap });
       deleteHistoryId = entry.id;
-      await prisma.game.update({ where: { id: game.id }, data: { status: "cancelled" } });
     }
   }
   if (!entry) return Response.json({ error: "Not found." }, { status: 404 });

--- a/src/pages/api/events/[id]/history/index.ts
+++ b/src/pages/api/events/[id]/history/index.ts
@@ -40,6 +40,22 @@ export const GET: APIRoute = async ({ params, request }) => {
     orderBy: { dateTime: "desc" },
   });
 
+  // ADR 0016: live Games store team membership in the event-level teamResults
+  // (not in the Game row). Snapshot them so the UI can render the players that
+  // were on the game even before the recurrence reset materialises a GameHistory.
+  const teamResults = await prisma.teamResult.findMany({
+    where: { eventId: params.id },
+    include: { members: { orderBy: { order: "asc" } } },
+  });
+  const teamsSnapshotForGame = teamResults.length
+    ? JSON.stringify(
+        teamResults.map((tr) => ({
+          team: tr.name,
+          players: tr.members.map((m) => ({ name: m.name, order: m.order })),
+        })),
+      )
+    : null;
+
   // Fetch ALL history for ELO replay (needed for accurate deltas)
   const allHistory = await prisma.gameHistory.findMany({
     where: { eventId: params.id },
@@ -74,7 +90,7 @@ export const GET: APIRoute = async ({ params, request }) => {
     scoreTwo: hideCompetitive ? null : g.scoreTwo,
     teamOneName: g.teamOneName,
     teamTwoName: g.teamTwoName,
-    teamsSnapshot: null, // participants available as structured data
+    teamsSnapshot: teamsSnapshotForGame, // reconstructed from event teamResults
     paymentsSnapshot: null,
     editableUntil: new Date(g.dateTime.getTime() + 7 * 86400_000).toISOString(),
     createdAt: g.createdAt.toISOString(),
@@ -85,10 +101,32 @@ export const GET: APIRoute = async ({ params, request }) => {
     participants: g.participants.map((p) => p.eventPlayer.name),
   }));
 
-  // Merge and sort by dateTime descending, dedupe by dateTime (legacy GameHistory may overlap with Game)
-  const gameDateTimes = new Set(playedGames.map((g) => g.dateTime.toISOString()));
-  const dedupedLegacy = legacyMapped.filter((h) => !gameDateTimes.has(h.dateTime));
-  const merged = [...gameMapped, ...dedupedLegacy]
+  // Merge and sort by dateTime descending.
+  //
+  // ADR 0016 dedup: when the recurrence reset has already materialised a
+  // GameHistory row for a played Game (same dateTime), prefer the GameHistory
+  // — it carries the teamsSnapshot (players) and is the editable entity the
+  // PATCH endpoint understands. Keeping the bare live Game here caused the
+  // "Not found." error and hid the players who were on the game.
+  // We also dedupe legacy rows that share a dateTime (e.g. a reset-created
+  // snapshot plus one created on-demand by PATCH), keeping the most complete.
+  const legacyByDate = new Map<string, (typeof legacyMapped)[number]>();
+  for (const h of legacyMapped) {
+    const existing = legacyByDate.get(h.dateTime);
+    if (!existing) {
+      legacyByDate.set(h.dateTime, h);
+      continue;
+    }
+    const keepExisting =
+      (existing.teamsSnapshot && !h.teamsSnapshot) ||
+      (Boolean(existing.teamsSnapshot) === Boolean(h.teamsSnapshot) &&
+        new Date(existing.createdAt).getTime() >= new Date(h.createdAt).getTime());
+    if (!keepExisting) legacyByDate.set(h.dateTime, h);
+  }
+  const dedupedLegacy = [...legacyByDate.values()];
+  const legacyDateTimes = new Set(dedupedLegacy.map((h) => h.dateTime));
+  const dedupedGames = gameMapped.filter((g) => !legacyDateTimes.has(g.dateTime));
+  const merged = [...dedupedLegacy, ...dedupedGames]
     .sort((a, b) => new Date(b.dateTime).getTime() - new Date(a.dateTime).getTime());
 
   return Response.json(buildPaginatedResponse(merged.slice(0, limit + 1), limit));

--- a/src/pages/api/events/[id]/index.ts
+++ b/src/pages/api/events/[id]/index.ts
@@ -107,18 +107,26 @@ export const GET: APIRoute = async ({ params, request }) => {
 
         // ADR 0016: keep GameHistory for backward compat (read-only fallback),
         // but NO destructive deletes. Players/Teams/RSVPs stay intact on the old Game.
+        // Guard against a duplicate snapshot: one may already exist if a score was
+        // saved on the played Game before the reset ran (history PATCH materialises
+        // a GameHistory on demand).
+        const existingSnapshot = await prisma.gameHistory.findFirst({
+          where: { eventId: event.id, dateTime: event.dateTime },
+        });
         await prisma.$transaction([
-          prisma.gameHistory.create({
-            data: {
-              eventId: event.id,
-              dateTime: event.dateTime,
-              teamOneName: event.teamOneName,
-              teamTwoName: event.teamTwoName,
-              teamsSnapshot,
-              paymentsSnapshot,
-              editableUntil,
-            },
-          }),
+          ...(existingSnapshot
+            ? []
+            : [prisma.gameHistory.create({
+                data: {
+                  eventId: event.id,
+                  dateTime: event.dateTime,
+                  teamOneName: event.teamOneName,
+                  teamTwoName: event.teamTwoName,
+                  teamsSnapshot,
+                  paymentsSnapshot,
+                  editableUntil,
+                },
+              })]),
           // Clear per-occurrence payments (PlayerPayment is still current-game-scoped until GamePayment migration)
           ...(eventCost ? [
             prisma.playerPayment.deleteMany({ where: { eventCostId: eventCost.id } }),

--- a/src/test/history-backfill.test.ts
+++ b/src/test/history-backfill.test.ts
@@ -477,3 +477,86 @@ describe("Delete Historical Game API", () => {
     expect(res.status).toBe(401);
   });
 });
+
+// ─── ADR 0016 regression: played live Game resolves to an editable GameHistory ─
+// A recurring event's reset flips the old Game to "played" AND creates a
+// GameHistory snapshot with the same dateTime. The history list used to surface
+// the bare live Game (no teamsSnapshot, uneditable id) which hid the players
+// and made PATCH return "Not found.".
+import { GET as getHistory } from "~/pages/api/events/[id]/history/index";
+import { PATCH as patchHistory } from "~/pages/api/events/[id]/history/[historyId]";
+
+describe("Played live Game resolves to editable GameHistory (regression)", () => {
+  beforeEach(async () => {
+    await prisma.game.deleteMany();
+    await prisma.gameHistory.deleteMany();
+    await prisma.teamResult.deleteMany();
+    await prisma.teamMember.deleteMany();
+    await prisma.event.deleteMany();
+    await prisma.user.deleteMany();
+    mockGetSession.mockResolvedValue({ user: { id: "owner1", name: "Owner" } } as any);
+    mockCheckOwnership.mockResolvedValue({
+      isOwner: true,
+      isAdmin: false,
+      session: { user: { id: "owner1", name: "Owner" } },
+    } as any);
+  });
+
+  it("GET history returns the GameHistory snapshot (with players), not the bare live Game", async () => {
+    const event = await seedEvent("owner1");
+    const dt = new Date("2025-03-10T18:00:00Z");
+    const game = await prisma.game.create({
+      data: { eventId: event.id, dateTime: dt, status: "played" },
+    });
+    await prisma.gameHistory.create({
+      data: {
+        eventId: event.id,
+        dateTime: dt,
+        status: "played",
+        teamOneName: "A",
+        teamTwoName: "B",
+        teamsSnapshot: JSON.stringify([
+          { team: "A", players: [{ name: "Alice", order: 0 }] },
+          { team: "B", players: [{ name: "Bob", order: 0 }] },
+        ]),
+        editableUntil: new Date(Date.now() + 86400_000),
+      },
+    });
+
+    const res = await getHistory(ctx({ id: event.id }, undefined, "GET"));
+    const body = await res.json();
+
+    const entry = body.data.find((e: any) => e.dateTime === dt.toISOString());
+    expect(entry).toBeTruthy();
+    // Players are visible because the GameHistory snapshot is preferred
+    expect(entry.teamsSnapshot).not.toBeNull();
+    // The id must be the editable GameHistory id, not the bare live Game id
+    expect(entry.id).not.toBe(game.id);
+  });
+
+  it("PATCH on a played live Game id saves the score (materialises GameHistory)", async () => {
+    const event = await seedEvent("owner1");
+    // Recent date so the derived snapshot is still editable (dateTime + 7 days)
+    const dt = new Date(Date.now() - 1 * 86400_000);
+    const game = await prisma.game.create({
+      data: { eventId: event.id, dateTime: dt, status: "played", scoreOne: null, scoreTwo: null },
+    });
+    // Teams so the on-demand snapshot carries the players
+    const trA = await prisma.teamResult.create({ data: { name: "A", eventId: event.id } });
+    await prisma.teamMember.create({ data: { name: "Alice", order: 0, teamResultId: trA.id } });
+    const trB = await prisma.teamResult.create({ data: { name: "B", eventId: event.id } });
+    await prisma.teamMember.create({ data: { name: "Bob", order: 0, teamResultId: trB.id } });
+
+    const res = await patchHistory(
+      ctx({ id: event.id, historyId: game.id }, { scoreOne: 3, scoreTwo: 1 }, "PATCH"),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.scoreOne).toBe(3);
+    expect(body.scoreTwo).toBe(1);
+
+    const gh = await prisma.gameHistory.findFirst({ where: { eventId: event.id, dateTime: dt } });
+    expect(gh).toBeTruthy();
+    expect(gh!.teamsSnapshot).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
When a recurring game closes, the recurrence reset flips the old `Game` to `played` **and** writes a `GameHistory` snapshot (with `teamsSnapshot`) at the same `dateTime`. The history list's dedup was keeping the bare live `Game` instead of the `GameHistory` row, which:

- hid the players who were on the game (no `teamsSnapshot`), and
- made saving the score throw `Not found.` (PATCH only resolves `GameHistory` ids).

## Changes
- `src/pages/api/events/[id]/history/index.ts` — dedup now prefers the `GameHistory` snapshot on `dateTime` collision; live `Game` rows get `teamsSnapshot` reconstructed from `teamResults` so players render before the reset materialises.
- `src/pages/api/events/[id]/history/[historyId].ts` — PATCH/DELETE materialise a `GameHistory` snapshot on demand when given a `played` live `Game` id (ADR 0016), instead of 404.
- `src/pages/api/events/[id]/index.ts` — recurrence reset guarded against a duplicate `GameHistory` snapshot.
- `src/components/HistoryPage.tsx` — `HistoryEntry` gains `participants`; `isParticipantInGame` falls back to it.
- Added regression tests in `src/test/history-backfill.test.ts`.

## Test plan
- `pnpm test` → 179 passed, 1 skipped (pre-existing oauth-trusted-client skip)
- `pnpm lint` → 0 errors