### PR TITLE
test: restore coverage gate for history/recurrence fix

### DIFF
--- a/src/test/history-backfill.test.ts
+++ b/src/test/history-backfill.test.ts
@@ -484,7 +484,8 @@ describe("Delete Historical Game API", () => {
 // the bare live Game (no teamsSnapshot, uneditable id) which hid the players
 // and made PATCH return "Not found.".
 import { GET as getHistory } from "~/pages/api/events/[id]/history/index";
-import { PATCH as patchHistory } from "~/pages/api/events/[id]/history/[historyId]";
+import { GET as getEvent } from "~/pages/api/events/[id]/index";
+import { PATCH as patchHistory, DELETE as deleteHistory } from "~/pages/api/events/[id]/history/[historyId]";
 
 describe("Played live Game resolves to editable GameHistory (regression)", () => {
   beforeEach(async () => {
@@ -558,5 +559,177 @@ describe("Played live Game resolves to editable GameHistory (regression)", () =>
     const gh = await prisma.gameHistory.findFirst({ where: { eventId: event.id, dateTime: dt } });
     expect(gh).toBeTruthy();
     expect(gh!.teamsSnapshot).not.toBeNull();
+  });
+
+  it("PATCH on a played live Game id captures the EventCost payments snapshot", async () => {
+    const event = await seedEvent("owner1");
+    const dt = new Date(Date.now() - 1 * 86400_000);
+    const game = await prisma.game.create({
+      data: { eventId: event.id, dateTime: dt, status: "played", scoreOne: null, scoreTwo: null },
+    });
+    const trA = await prisma.teamResult.create({ data: { name: "A", eventId: event.id } });
+    await prisma.teamMember.create({ data: { name: "Alice", order: 0, teamResultId: trA.id } });
+    const trB = await prisma.teamResult.create({ data: { name: "B", eventId: event.id } });
+    await prisma.teamMember.create({ data: { name: "Bob", order: 0, teamResultId: trB.id } });
+    await prisma.eventCost.create({
+      data: {
+        eventId: event.id,
+        totalAmount: 10,
+        currency: "EUR",
+        payments: {
+          create: [
+            { playerName: "Alice", amount: 5, status: "paid", method: "cash" },
+            { playerName: "Bob", amount: 5, status: "pending", method: "revolut" },
+          ],
+        },
+      },
+    });
+
+    const res = await patchHistory(
+      ctx({ id: event.id, historyId: game.id }, { scoreOne: 2, scoreTwo: 2 }, "PATCH"),
+    );
+    expect(res.status).toBe(200);
+
+    const gh = await prisma.gameHistory.findFirst({ where: { eventId: event.id, dateTime: dt } });
+    expect(gh).toBeTruthy();
+    expect(gh!.paymentsSnapshot).not.toBeNull();
+  });
+
+  it("DELETE on a played live Game id removes the derived history but keeps the Game played", async () => {
+    const event = await seedEvent("owner1");
+    const dt = new Date(Date.now() - 1 * 86400_000);
+    const game = await prisma.game.create({
+      data: { eventId: event.id, dateTime: dt, status: "played" },
+    });
+    const trA = await prisma.teamResult.create({ data: { name: "A", eventId: event.id } });
+    await prisma.teamMember.create({ data: { name: "Alice", order: 0, teamResultId: trA.id } });
+    const trB = await prisma.teamResult.create({ data: { name: "B", eventId: event.id } });
+    await prisma.teamMember.create({ data: { name: "Bob", order: 0, teamResultId: trB.id } });
+
+    const res = await deleteHistory(
+      ctx({ id: event.id, historyId: game.id }, undefined, "DELETE"),
+    );
+    expect(res.status).toBe(204);
+
+    const gh = await prisma.gameHistory.findFirst({ where: { eventId: event.id, dateTime: dt } });
+    expect(gh).toBeNull();
+    const stillGame = await prisma.game.findUnique({ where: { id: game.id } });
+    expect(stillGame).toBeTruthy();
+    // Must NOT be flipped to "cancelled" — that's a skipped game, not a played one
+    expect(stillGame!.status).toBe("played");
+  });
+
+  it("GET history reconstructs teamsSnapshot for a played live Game from event teamResults", async () => {
+    const event = await seedEvent("owner1");
+    const dt = new Date("2025-03-12T18:00:00Z");
+    await prisma.game.create({
+      data: { eventId: event.id, dateTime: dt, status: "played" },
+    });
+    // No GameHistory yet — the live Game must still expose its players via the
+    // reconstructed teamsSnapshot (ADR 0016 comments in history/index.ts:50-57).
+    const trA = await prisma.teamResult.create({ data: { name: "A", eventId: event.id } });
+    await prisma.teamMember.create({ data: { name: "Alice", order: 0, teamResultId: trA.id } });
+    const trB = await prisma.teamResult.create({ data: { name: "B", eventId: event.id } });
+    await prisma.teamMember.create({ data: { name: "Bob", order: 0, teamResultId: trB.id } });
+
+    const res = await getHistory(ctx({ id: event.id }, undefined, "GET"));
+    const body = await res.json();
+
+    const entry = body.data.find((e: any) => e.dateTime === dt.toISOString());
+    expect(entry).toBeTruthy();
+    expect(entry.teamsSnapshot).not.toBeNull();
+    const parsed = JSON.parse(entry.teamsSnapshot);
+    expect(parsed[0].players.map((p: any) => p.name)).toContain("Alice");
+    expect(parsed[1].players.map((p: any) => p.name)).toContain("Bob");
+  });
+
+  it("GET history dedup prefers the GameHistory that carries a teamsSnapshot", async () => {
+    const event = await seedEvent("owner1");
+    const dt = new Date("2025-03-14T18:00:00Z");
+    // Two legacy rows share a dateTime; only one carries the players snapshot.
+    await prisma.gameHistory.create({
+      data: {
+        eventId: event.id,
+        dateTime: dt,
+        status: "played",
+        teamOneName: "A",
+        teamTwoName: "B",
+        teamsSnapshot: JSON.stringify([
+          { team: "A", players: [{ name: "Alice", order: 0 }] },
+          { team: "B", players: [{ name: "Bob", order: 0 }] },
+        ]),
+        editableUntil: new Date(Date.now() + 86400_000),
+      },
+    });
+    await prisma.gameHistory.create({
+      data: {
+        eventId: event.id,
+        dateTime: dt,
+        status: "played",
+        teamOneName: "A",
+        teamTwoName: "B",
+        teamsSnapshot: null,
+        editableUntil: new Date(Date.now() + 86400_000),
+      },
+    });
+
+    const res = await getHistory(ctx({ id: event.id }, undefined, "GET"));
+    const body = await res.json();
+
+    const entries = body.data.filter((e: any) => e.dateTime === dt.toISOString());
+    // Dedup keeps a single entry...
+    expect(entries).toHaveLength(1);
+    // ...and it must be the one that carries the players snapshot.
+    expect(entries[0].teamsSnapshot).not.toBeNull();
+  });
+
+  it("recurrence reset does not duplicate a GameHistory already materialised on the played Game", async () => {
+    const pastDate = new Date(Date.now() - 2 * 86400_000);
+    const event = await prisma.event.create({
+      data: {
+        title: "Weekly",
+        location: "Pitch",
+        dateTime: pastDate,
+        isRecurring: true,
+        recurrenceRule: JSON.stringify({ freq: "weekly", interval: 1, byDay: "FR" }),
+        nextResetAt: new Date(pastDate.getTime() + 60 * 60 * 1000),
+        durationMinutes: 60,
+        teamOneName: "A",
+        teamTwoName: "B",
+      },
+    });
+    const game1 = await prisma.game.create({ data: { eventId: event.id, dateTime: pastDate } });
+    await prisma.event.update({
+      where: { id: event.id },
+      data: { currentGameId: game1.id },
+    });
+    await prisma.teamResult.create({
+      data: { eventId: event.id, name: "TeamA", members: { create: [{ name: "Keep Me", order: 0 }] } },
+    });
+    // A score was saved on the played Game before the reset ran (PATCH materialises
+    // a GameHistory on demand) — this must prevent the reset from creating a duplicate.
+    await prisma.gameHistory.create({
+      data: {
+        eventId: event.id,
+        dateTime: pastDate,
+        status: "played",
+        teamOneName: "A",
+        teamTwoName: "B",
+        teamsSnapshot: JSON.stringify([
+          { team: "A", players: [{ name: "Keep Me", order: 0 }] },
+          { team: "B", players: [] },
+        ]),
+        editableUntil: new Date(Date.now() + 86400_000),
+      },
+    });
+
+    const res = await getEvent(ctx({ id: event.id }, undefined, "GET"));
+    const body = await res.json();
+    expect(body.wasReset).toBe(true);
+
+    const snapshots = await prisma.gameHistory.findMany({
+      where: { eventId: event.id, dateTime: pastDate },
+    });
+    expect(snapshots).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary
Adds regression tests covering the new code paths introduced by the history/recurrence fix (PR #600) so the global coverage gate passes (lines ≥95%, statements ≥92%) and the Release/deploy workflow can run again.

- `GET /api/events/[id]/history` reconstructs `teamsSnapshot` for a played live Game from event-level `teamResults` (history/index.ts:50-57).
- Dedup prefers the `GameHistory` row that carries a `teamsSnapshot` when two legacy rows share a `dateTime` (history/index.ts:121).
- Recurrence reset does NOT duplicate a `GameHistory` already materialised on the played Game (events/[id]/index.ts reset guard).

## Verification
- `pnpm exec vitest run --coverage`: 180 files / 3027 tests pass, 0 coverage errors (lines 95.09%, statements 92.09%, functions 89.97%, branches 83.37%).
- `eslint src/ --max-warnings 259`: 0 errors.
- `tsc` (typecheck): clean.

## Note
CI was already red on coverage for `main` because the fix added server code that wasn't fully exercised. E2E/Lint/Typecheck/Build/Lighthouse were already green on the merged PR #600. Once this PR's CI is green, the Release workflow deploys.