### PR TITLE
fix(e2e): stabilize flaky multi-player add test

### DIFF
--- a/e2e/add-player-confirmation.spec.ts
+++ b/e2e/add-player-confirmation.spec.ts
@@ -99,6 +99,10 @@ async function addPlayerViaUi(page: Page, name: string): Promise<void> {
   await input.press("Enter");
   // No dialog should open on Enter.
   await expect(page.getByRole("dialog")).not.toBeVisible();
+  // Wait for the player to appear on the roster and input to clear before
+  // returning — prevents race when adding multiple players in sequence.
+  await expect(page.getByText(name, { exact: true }).first()).toBeVisible({ timeout: 10_000 });
+  await expect(input).toHaveValue("", { timeout: 5_000 });
 }
 
 async function expectRosterContains(


### PR DESCRIPTION
## Problem

The E2E test "adds multiple specific players and confirms all of them by name" was flaky on CI, failing with:

```
Error: expect(locator).toBeVisible() failed
Locator: getByText('MultiTwo', { exact: true }).first()
```

This was blocking deployments since E2E is a required check.

## Root Cause

`addPlayerViaUi()` pressed Enter and returned immediately without waiting for the player to render in the DOM. When adding multiple players in a loop, the next iteration's `input.fill()` could fire before the previous player's optimistic UI update completed, causing a race condition where the second/third player never got added.

## Fix

After pressing Enter, `addPlayerViaUi()` now waits for:
1. The player name to become visible in the roster (`toBeVisible`)
2. The input to clear back to empty (`toHaveValue('')`)

This ensures each player is fully committed before the next is typed.

## Testing

- All 44 E2E tests pass locally (including the previously flaky test)
- The fix adds deterministic waits, not arbitrary sleeps