### PR TITLE
fix: unify GameParticipant order assignment and guarantee priority spots

### DIFF
--- a/docs/adr/0020-player-ordering-and-priority-guaranteed-spots.md
+++ b/docs/adr/0020-player-ordering-and-priority-guaranteed-spots.md
@@ -1,0 +1,78 @@
+# ADR 0020 — Player Ordering and Priority Guaranteed Spots
+
+## Status
+
+Accepted
+
+## Context
+
+Production data for the recurring event "Ninjas da Areosa" (event
+`cmmkfrx8b0000o2ixrix1yp2m`) showed the current game's player list at orders
+`0, 1, 2, 3, 14` — a 9-slot gap. Issue #657 ("Player order issues").
+
+The root cause is that `GameParticipant.order` was assigned from three
+different, mutually inconsistent sources depending on the join path:
+
+| Path | Order source | Problem |
+|------|-------------|---------|
+| Fresh join | `event.players.length` (event-wide count) | Grows across games — a player who never played before lands at order 14 while this week's regulars sit at 0-3 |
+| Re-add / re-join | `gameParticipant.count()` (active count) | Collides with archived gaps left by players who left the game |
+| Priority confirm | `order: 0` + `update: {}` | Two players can end up with the same order; a previously-archived participant stays archived (issue #625) |
+
+The queue is game-scoped (ADR 0016): the Event is a series template, the Game
+holds one occurrence, and `GameParticipant` is the per-game link. Order is a
+per-game concept and must never be derived from event-wide state.
+
+## Decision
+
+### 1. Single source of truth for order
+
+All GameParticipant order assignment goes through one helper,
+`nextGameParticipantOrder(gameId)`, which returns `max(order) + 1` scoped to a
+single game. Every join path — fresh join, re-add, re-join after leave,
+priority confirm — appends at the end of the queue.
+
+- Game-scoped: never drifts toward the event-wide Player count.
+- Gap-safe: `max + 1` never collides with archived participants that kept
+  their old slot, unlike `count()`.
+
+### 2. Priority-confirmed players get a guaranteed active spot (evict-to-bench)
+
+"Guaranteed spot" for a priority-confirmed player means: they always land in
+an active slot (`order < maxPlayers`), never the bench. Implemented by
+`grantActiveSpot(eventId, gameId, eventPlayerId, maxPlayers)`:
+
+1. **Room available** (`activeCount < maxPlayers`): append at the end of the
+   queue — the player is active.
+2. **Game full** (`activeCount >= maxPlayers`): evict the **last non-priority
+   active player** (highest order, not priority-enrolled) to the bench (end of
+   queue), and give the priority player their slot.
+3. **No eviction target** (all active players are priority): append at the end
+   (bench). The priority cap (`priorityMaxPercent`) is the safety valve that
+   makes this the exception rather than the rule.
+
+Priority players are never evicted by another priority player. An anonymous
+player (no linked user) is never priority, so they are always an eviction
+target. The eviction cap on the active roster stays enforced by
+`rankAndCap` (`maxPlayers * priorityMaxPercent / 100`), unchanged.
+
+Teams are re-synced after any eviction/promotion: `validateTeams` removes
+bench players from generated teams, `addPlayerToTeams` slots the newly-active
+player in.
+
+## Consequences
+
+- Player list order is stable across join paths and game occurrences.
+- A confirmed priority player is never on the bench, at the cost of the last
+  non-priority active player dropping to the bench when the game is full.
+- `event.players.length`, `gameParticipant.count()`, and literal `order: 0`
+  are no longer used to derive GameParticipant order.
+- Existing polluted data (gaps like `0,1,2,3,14`) is not backfilled by this
+  ADR; it self-heals as players leave and rejoin, or via an owner reorder.
+
+## Tests
+
+- `src/test/player-order.test.ts` — regression tests for the prod gap and the
+  count-based collision (both failed before this ADR, pass after).
+- `src/test/priority-api.test.ts` — guaranteed-spot tests: append when room,
+  evict last non-priority when full, never evict a priority player.

--- a/src/lib/game.server.ts
+++ b/src/lib/game.server.ts
@@ -11,3 +11,102 @@ export async function shouldProcessGameElo(gameId: string): Promise<boolean> {
   if (!game) return false;
   return game.status === "played" && !game.isFriendly;
 }
+
+/**
+ * Next order slot for a GameParticipant appended to a game's queue.
+ *
+ * Single source of truth for GameParticipant order assignment (issue #657).
+ * Game-scoped and gap-safe: uses max(order)+1 so it never collides with
+ * archived participants that kept their old slot, and never drifts toward
+ * the event-wide Player count (which grows across games).
+ */
+export async function nextGameParticipantOrder(gameId: string): Promise<number> {
+  const agg = await prisma.gameParticipant.aggregate({
+    where: { gameId },
+    _max: { order: true },
+  });
+  return (agg._max.order ?? -1) + 1;
+}
+
+export interface GrantActiveSpotResult {
+  /** True when the player holds an active spot (order < maxPlayers). */
+  active: boolean;
+  /** EventPlayer id that was displaced to the bench, if an eviction happened. */
+  evictedEventPlayerId?: string;
+}
+
+/**
+ * Guarantee an active spot for a priority-confirmed player (ADR 0020).
+ *
+ * Rules:
+ * - Room available  → append at the end of the queue (order = max+1).
+ * - Game full       → evict the last NON-priority active player to the bench
+ *   (end of queue) and give their slot to the priority player. Priority
+ *   players are never evicted by another priority player.
+ * - No eviction target (all active are priority) → append at the end (bench).
+ */
+export async function grantActiveSpot(
+  eventId: string,
+  gameId: string,
+  eventPlayerId: string,
+  maxPlayers: number,
+): Promise<GrantActiveSpotResult> {
+  const existing = await prisma.gameParticipant.findUnique({
+    where: { gameId_eventPlayerId: { gameId, eventPlayerId } },
+  });
+  if (existing && !existing.archivedAt && existing.order < maxPlayers) {
+    return { active: true };
+  }
+
+  const active = await prisma.gameParticipant.findMany({
+    where: { gameId, archivedAt: null, order: { lt: maxPlayers } },
+    include: { eventPlayer: { select: { userId: true, name: true } } },
+    orderBy: { order: "asc" },
+  });
+
+  if (active.length < maxPlayers) {
+    const order = await nextGameParticipantOrder(gameId);
+    await prisma.gameParticipant.upsert({
+      where: { gameId_eventPlayerId: { gameId, eventPlayerId } },
+      create: { gameId, eventPlayerId, order },
+      update: { archivedAt: null, order },
+    });
+    return { active: true };
+  }
+
+  const priorityUserIds = new Set(
+    (await prisma.priorityEnrollment.findMany({
+      where: { eventId, optedIn: true },
+      select: { userId: true },
+    })).map((e) => e.userId),
+  );
+
+  const victim = [...active].reverse().find((p) => {
+    if (!p.eventPlayer.userId) return true;
+    return !priorityUserIds.has(p.eventPlayer.userId);
+  });
+
+  if (!victim) {
+    const order = await nextGameParticipantOrder(gameId);
+    await prisma.gameParticipant.upsert({
+      where: { gameId_eventPlayerId: { gameId, eventPlayerId } },
+      create: { gameId, eventPlayerId, order },
+      update: { archivedAt: null, order },
+    });
+    return { active: false };
+  }
+
+  const benchOrder = await nextGameParticipantOrder(gameId);
+  await prisma.$transaction([
+    prisma.gameParticipant.update({
+      where: { id: victim.id },
+      data: { order: benchOrder },
+    }),
+    prisma.gameParticipant.upsert({
+      where: { gameId_eventPlayerId: { gameId, eventPlayerId } },
+      create: { gameId, eventPlayerId, order: victim.order },
+      update: { archivedAt: null, order: victim.order },
+    }),
+  ]);
+  return { active: true, evictedEventPlayerId: victim.eventPlayerId };
+}

--- a/src/pages/api/events/[id]/players.ts
+++ b/src/pages/api/events/[id]/players.ts
@@ -16,6 +16,7 @@ import { normalizeForMatch } from "../../../../lib/stringMatch";
 import { archiveAndLeave } from "../../../../lib/leave.server";
 import { balanceTeams } from "../../../../lib/elo.server";
 import { Randomize } from "../../../../lib/random";
+import { nextGameParticipantOrder } from "../../../../lib/game.server";
 import { enqueuePushSetupHintSafe } from "../../../../lib/pushSetupHint";
 import {
   IDEMPOTENCY_HEADER,
@@ -595,13 +596,11 @@ export const POST: APIRoute = async ({ params, request }) => {
           });
           // Restore the GameParticipant too — a previous leave archived it, and
           // without this the re-added player stays invisible on the game list.
-          const gpCount = await prisma.gameParticipant.count({
-            where: { gameId: event.currentGameId, archivedAt: null },
-          });
+          const gpOrder = await nextGameParticipantOrder(event.currentGameId);
           await prisma.gameParticipant.upsert({
             where: { gameId_eventPlayerId: { gameId: event.currentGameId, eventPlayerId: ep.id } },
-            create: { gameId: event.currentGameId, eventPlayerId: ep.id, order: gpCount },
-            update: { archivedAt: null, order: gpCount },
+            create: { gameId: event.currentGameId, eventPlayerId: ep.id, order: gpOrder },
+            update: { archivedAt: null, order: gpOrder },
           });
         }
         // Bug fix: re-activated players must be added to teams if within active range
@@ -628,12 +627,10 @@ export const POST: APIRoute = async ({ params, request }) => {
           // Re-join after a leave: the GameParticipant was soft-archived by the
           // leave flow. Un-archive it (at the end of the list) instead of
           // falling through to the 409 "already in the list" error.
-          const gpCount = await prisma.gameParticipant.count({
-            where: { gameId: event.currentGameId, archivedAt: null },
-          });
+          const gpOrder = await nextGameParticipantOrder(event.currentGameId);
           await prisma.gameParticipant.update({
             where: { id: alreadyInGame.id },
-            data: { archivedAt: null, order: gpCount },
+            data: { archivedAt: null, order: gpOrder },
           });
           // Move player to end of list — same rule as a fresh re-join
           const maxOrder = await prisma.player.aggregate({
@@ -654,11 +651,9 @@ export const POST: APIRoute = async ({ params, request }) => {
           return Response.json({ ok: true, invited: null, resolvedName: trimmed });
         }
         if (!alreadyInGame) {
-          const gpCount = await prisma.gameParticipant.count({
-            where: { gameId: event.currentGameId, archivedAt: null },
-          });
+          const gpOrder = await nextGameParticipantOrder(event.currentGameId);
           await prisma.gameParticipant.create({
-            data: { gameId: event.currentGameId, eventPlayerId: eventPlayer.id, order: gpCount },
+            data: { gameId: event.currentGameId, eventPlayerId: eventPlayer.id, order: gpOrder },
           });
           // Move player to end of list — their old order is stale from the previous game
           const maxOrder = await prisma.player.aggregate({
@@ -734,9 +729,10 @@ export const POST: APIRoute = async ({ params, request }) => {
       create: { eventId, name: trimmed, userId: linkedUserId },
       update: {},
     });
+    const gpOrder = await nextGameParticipantOrder(event.currentGameId);
     await prisma.gameParticipant.upsert({
       where: { gameId_eventPlayerId: { gameId: event.currentGameId, eventPlayerId: eventPlayer.id } },
-      create: { gameId: event.currentGameId, eventPlayerId: eventPlayer.id, order: event.players.length },
+      create: { gameId: event.currentGameId, eventPlayerId: eventPlayer.id, order: gpOrder },
       // Clear archivedAt: an archived GameParticipant can linger (e.g. after a
       // merge removed the Player row) — joining must make the player visible.
       update: { archivedAt: null },

--- a/src/pages/api/events/[id]/priority/confirm.ts
+++ b/src/pages/api/events/[id]/priority/confirm.ts
@@ -3,6 +3,8 @@ import { prisma } from "../../../../../lib/db.server";
 import { getSession } from "../../../../../lib/auth.helpers.server";
 import { rateLimitResponse } from "../../../../../lib/apiRateLimit.server";
 import { confirmSpot } from "../../../../../lib/priority.server";
+import { grantActiveSpot } from "../../../../../lib/game.server";
+import { addPlayerToTeams, validateTeams } from "../players";
 
 /** POST — player confirms their priority spot */
 export const POST: APIRoute = async ({ params, request }) => {
@@ -14,7 +16,7 @@ export const POST: APIRoute = async ({ params, request }) => {
 
   const event = await prisma.event.findUnique({
     where: { id: params.id },
-    select: { id: true, dateTime: true, currentGameId: true },
+    select: { id: true, dateTime: true, currentGameId: true, maxPlayers: true },
   });
   if (!event) return Response.json({ error: "Not found." }, { status: 404 });
 
@@ -41,18 +43,26 @@ export const POST: APIRoute = async ({ params, request }) => {
       });
     }
 
-    // ADR 0016: also add to current game via GameParticipant
+    // ADR 0016/0020: guaranteed active spot via GameParticipant. Confirming a
+    // priority spot always yields an active slot — if the game is full, the
+    // last non-priority active player is evicted to the bench.
     if (event.currentGameId) {
       const eventPlayer = await prisma.eventPlayer.upsert({
         where: { eventId_name: { eventId: event.id, name: session.user.name } },
         create: { eventId: event.id, name: session.user.name, userId: session.user.id },
         update: {},
       });
-      await prisma.gameParticipant.upsert({
-        where: { gameId_eventPlayerId: { gameId: event.currentGameId, eventPlayerId: eventPlayer.id } },
-        create: { gameId: event.currentGameId, eventPlayerId: eventPlayer.id, order: 0 },
-        update: {},
-      });
+      const result = await grantActiveSpot(
+        event.id,
+        event.currentGameId,
+        eventPlayer.id,
+        event.maxPlayers,
+      );
+      // Resync teams after the roster changed (eviction or promotion).
+      await validateTeams(event.id, event.maxPlayers, event.currentGameId);
+      if (result.active) {
+        await addPlayerToTeams(event.id, session.user.name, event.currentGameId);
+      }
     }
   }
 

--- a/src/test/player-order.test.ts
+++ b/src/test/player-order.test.ts
@@ -1,46 +1,148 @@
+/**
+ * Ordering regression tests — prod repro: event cmmkfrx8b0000o2ixrix1yp2m
+ * ("Ninjas da Areosa") showed the current game's player list at orders
+ * 0,1,2,3,14 — a 9-slot gap. Issue #657 (Player order issues).
+ *
+ * Root cause: GameParticipant.order is computed from DIFFERENT sources
+ * depending on the join path:
+ *   - Fresh join:      order = event.players.length  (event-scoped, grows across games)
+ *   - Rejoin after reset: order = gameParticipant.count()  (game-scoped, collides with gaps)
+ * These diverge once the Player table accumulates players across games.
+ */
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { prisma } from "~/lib/db.server";
+import { POST as addPlayer } from "~/pages/api/events/[id]/players";
+import { GET as getEvent } from "~/pages/api/events/[id]/index";
+import { getSession } from "~/lib/auth.helpers.server";
 import { resetRateLimitStore } from "~/lib/rateLimit.server";
 import { resetApiRateLimitStore } from "~/lib/apiRateLimit.server";
 
-// Mock auth helpers — unauthenticated by default
 vi.mock("~/lib/auth.helpers.server", () => ({
-  getSession: vi.fn().mockResolvedValue(null),
-  checkOwnership: vi.fn().mockResolvedValue({ isOwner: true, isAdmin: false, session: null }),
-  checkEventAdmin: vi.fn().mockResolvedValue(false),
+  getSession: vi.fn(),
 }));
 
-import { POST as addPlayer } from "~/pages/api/events/[id]/players";
-import { GET as getEvent } from "~/pages/api/events/[id]/index";
+const mockGetSession = vi.mocked(getSession);
 
-function postCtx(params: Record<string, string>, body: unknown) {
-  const request = new Request("http://localhost/api/test", {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify(body),
-  });
-  return { request, params } as any;
+function ctx(eventId: string, body: any, session: { user: { id: string; name: string } } | null = null) {
+  mockGetSession.mockResolvedValue(session as any);
+  return {
+    params: { id: eventId },
+    request: new Request(`http://localhost/api/events/${eventId}/players`, {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-client-id": "test-client" },
+      body: JSON.stringify(body),
+    }),
+  } as any;
 }
 
-function getCtx(params: Record<string, string>) {
-  const request = new Request("http://localhost/api/test", {
-    method: "GET",
-    headers: { "content-type": "application/json" },
+/** Recurring event with a current (upcoming) Game — ADR 0016 game-scoped player list. */
+async function seedRecurringEvent(maxPlayers = 10) {
+  const event = await prisma.event.create({
+    data: {
+      title: "Ninjas da Areosa",
+      location: "Pitch",
+      dateTime: new Date(Date.now() + 86400_000),
+      maxPlayers,
+      isRecurring: true,
+      recurrenceRule: "FREQ=WEEKLY",
+    },
   });
-  return { request, params, url: new URL("http://localhost/api/test") } as any;
+  const game = await prisma.game.create({
+    data: { eventId: event.id, dateTime: event.dateTime, status: "upcoming" },
+  });
+  await prisma.event.update({ where: { id: event.id }, data: { currentGameId: game.id } });
+  return { ...event, currentGameId: game.id };
+}
+
+async function seedGameParticipant(eventId: string, gameId: string, name: string, order: number, opts: { archived?: boolean } = {}) {
+  const ep = await prisma.eventPlayer.upsert({
+    where: { eventId_name: { eventId, name } },
+    create: { eventId, name },
+    update: {},
+  });
+  return prisma.gameParticipant.create({
+    data: {
+      gameId,
+      eventPlayerId: ep.id,
+      order,
+      ...(opts.archived ? { archivedAt: new Date(Date.now() - 3600_000) } : {}),
+    },
+  });
 }
 
 beforeEach(async () => {
-  await resetRateLimitStore();
-  await resetApiRateLimitStore();
+  await prisma.rsvp.deleteMany();
+  await prisma.gameParticipant.deleteMany();
+  await prisma.eventPlayer.deleteMany();
+  await prisma.game.deleteMany();
+  await prisma.eventFollow.deleteMany();
+  await prisma.playerRating.deleteMany();
+  await prisma.teamResult.deleteMany();
   await prisma.player.deleteMany();
   await prisma.event.deleteMany();
+  await prisma.user.deleteMany();
+  resetRateLimitStore();
+  resetApiRateLimitStore();
+  vi.clearAllMocks();
 });
 
-describe("Player ordering — new players always go to the end", () => {
+describe("Player ordering — fresh join lands at end of the CURRENT game queue", () => {
+  it("does not use the event-wide player count when assigning GameParticipant.order", async () => {
+    const event = await seedRecurringEvent();
+
+    // Simulate a long-lived recurring event: the event-level Player table
+    // has accumulated 14 players across previous games (they persist).
+    for (let i = 0; i < 14; i++) {
+      await prisma.player.create({
+        data: { eventId: event.id, name: `Legacy ${i}`, order: i },
+      });
+    }
+    // The current game only has 4 active participants (orders 0..3)
+    await seedGameParticipant(event.id, event.currentGameId!, "Manuel", 0);
+    await seedGameParticipant(event.id, event.currentGameId!, "Tiago", 1);
+    await seedGameParticipant(event.id, event.currentGameId!, "João", 2);
+    await seedGameParticipant(event.id, event.currentGameId!, "TF", 3);
+
+    // A brand-new player joins the current game
+    const res = await addPlayer(ctx(event.id, { name: "Ruben Almeida" }));
+    expect(res.status).toBe(200);
+
+    const eventRes = await getEvent({ params: { id: event.id }, request: new Request("http://localhost/") } as any);
+    const body = await eventRes.json();
+    const orders = body.players.map((p: any) => p.order);
+
+    // The queue must be contiguous — the new player goes to position 4,
+    // NOT to order 14 (the event-wide Player count).
+    expect(orders).toEqual([0, 1, 2, 3, 4]);
+  });
+});
+
+describe("Player ordering — rejoin from an earlier game must not jump ahead", () => {
+  it("rejoining player lands AFTER players who joined the current game first", async () => {
+    const event = await seedRecurringEvent();
+
+    // Fresh player joins the current game first
+    await addPlayer(ctx(event.id, { name: "Newbie" }));
+
+    // Player from a previous game rejoins (Player row exists at event level,
+    // but has no GameParticipant in the current game)
+    await prisma.player.create({
+      data: { eventId: event.id, name: "OldTimer", order: 0 },
+    });
+    const res = await addPlayer(ctx(event.id, { name: "OldTimer" }));
+    expect(res.status).toBe(200);
+
+    const eventRes = await getEvent({ params: { id: event.id }, request: new Request("http://localhost/") } as any);
+    const body = await eventRes.json();
+    const names = body.players.map((p: any) => p.name);
+
+    // Newbie joined first → must stay ahead of the rejoining OldTimer
+    expect(names.indexOf("Newbie")).toBeLessThan(names.indexOf("OldTimer"));
+  });
+});
+
+describe("Player ordering — legacy event (no currentGameId) appends via Player table", () => {
   it("adds player at end even when order values have gaps", async () => {
-    // Seed an event with players that have non-contiguous order values
-    // (simulates state after removals/reorders over time)
     const event = await prisma.event.create({
       data: {
         title: "Order Gap Test",
@@ -49,35 +151,52 @@ describe("Player ordering — new players always go to the end", () => {
       },
     });
 
-    // Create players with gapped order values: 0, 1, 5, 9
     const playerNames = ["Alice", "Bob", "Charlie", "Diana"];
     const orders = [0, 1, 5, 9];
     for (let i = 0; i < playerNames.length; i++) {
       await prisma.player.create({
-        data: {
-          name: playerNames[i],
-          eventId: event.id,
-          order: orders[i],
-        },
+        data: { name: playerNames[i], eventId: event.id, order: orders[i] },
       });
     }
 
-    // Add a new player via the API
-    const res = await addPlayer(postCtx({ id: event.id }, { name: "Manecas" }));
+    const res = await addPlayer(ctx(event.id, { name: "Manecas" }));
     expect(res.status).toBe(200);
 
-    // Fetch the event and check player order
-    const getRes = await getEvent(getCtx({ id: event.id }));
-    const data = await getRes.json();
+    const eventRes = await getEvent({ params: { id: event.id }, request: new Request("http://localhost/") } as any);
+    const data = await eventRes.json();
     const names = data.players.map((p: any) => p.name);
-
-    // Manecas must be LAST — order should be max(existing) + 1 = 10
     expect(names[names.length - 1]).toBe("Manecas");
 
-    // Verify the actual order value is 10 (9 + 1), not 4 (length of existing)
     const manecas = await prisma.player.findFirst({
       where: { eventId: event.id, name: "Manecas" },
     });
     expect(manecas!.order).toBe(10);
+  });
+});
+
+describe("Player ordering — count-based append must not collide with archived gaps", () => {
+  it("a rejoin after leave lands at max(order)+1, not at a colliding count()", async () => {
+    const event = await seedRecurringEvent();
+
+    // Player A leaves, leaving an archived GameParticipant at order 0.
+    // Live participants: B(order 1), C(order 2). count(live) = 2 → a
+    // count()-based append would assign the new player order 2, colliding
+    // with C.
+    await seedGameParticipant(event.id, event.currentGameId!, "A", 0, { archived: true });
+    await seedGameParticipant(event.id, event.currentGameId!, "B", 1);
+    await seedGameParticipant(event.id, event.currentGameId!, "C", 2);
+
+    await prisma.player.create({ data: { eventId: event.id, name: "B", order: 1 } });
+    await prisma.player.create({ data: { eventId: event.id, name: "C", order: 2 } });
+
+    const res = await addPlayer(ctx(event.id, { name: "D" }));
+    expect(res.status).toBe(200);
+
+    const eventRes = await getEvent({ params: { id: event.id }, request: new Request("http://localhost/") } as any);
+    const body = await eventRes.json();
+    const orders = body.players.map((p: any) => p.order);
+
+    // No collisions — every order unique
+    expect(new Set(orders).size).toBe(orders.length);
   });
 });

--- a/src/test/priority-api.test.ts
+++ b/src/test/priority-api.test.ts
@@ -121,6 +121,9 @@ function mockNoAuth() {
 
 beforeEach(async () => {
   mockGetSession.mockReset();
+  await testPrisma.gameParticipant.deleteMany();
+  await testPrisma.eventPlayer.deleteMany();
+  await testPrisma.game.deleteMany();
   await testPrisma.priorityConfirmation.deleteMany();
   await testPrisma.priorityEnrollment.deleteMany();
   await testPrisma.gameHistory.deleteMany();
@@ -383,6 +386,148 @@ describe("POST /api/events/:id/priority/confirm", () => {
 
     const res = await confirmPriority(ctx({ id: event.id }, {}));
     expect(res.status).toBe(404);
+  });
+
+  // ── Guaranteed spot (ADR 0020) ────────────────────────────────────────────
+
+  async function seedGame(event: { id: string }, maxPlayers = 8) {
+    const game = await testPrisma.game.create({
+      data: { eventId: event.id, dateTime: new Date(Date.now() + 7 * 86400_000), status: "upcoming" },
+    });
+    await testPrisma.event.update({ where: { id: event.id }, data: { currentGameId: game.id, maxPlayers } });
+    return game;
+  }
+
+  async function seedEnrollment(eventId: string, user: { id: string }) {
+    await testPrisma.priorityEnrollment.create({
+      data: { eventId, userId: user.id, source: "auto" },
+    });
+  }
+
+  async function seedPendingConfirmation(eventId: string, user: { id: string }, gameDate: Date) {
+    await testPrisma.priorityConfirmation.create({
+      data: {
+        eventId,
+        userId: user.id,
+        gameDate,
+        status: "pending",
+        notifiedAt: new Date(),
+        deadline: new Date(gameDate.getTime() - 48 * 3600_000),
+      },
+    });
+  }
+
+  async function seedParticipant(eventId: string, gameId: string, name: string, order: number, opts: { userId?: string } = {}) {
+    const ep = await testPrisma.eventPlayer.upsert({
+      where: { eventId_name: { eventId, name } },
+      create: { eventId, name, userId: opts.userId },
+      update: { ...(opts.userId ? { userId: opts.userId } : {}) },
+    });
+    return testPrisma.gameParticipant.create({ data: { gameId, eventPlayerId: ep.id, order } });
+  }
+
+  async function activeOrders(eventId: string, gameId: string, maxPlayers: number) {
+    const eps = await testPrisma.eventPlayer.findMany({ where: { eventId }, select: { id: true, name: true } });
+    const gps = await testPrisma.gameParticipant.findMany({
+      where: { gameId, archivedAt: null, order: { lt: maxPlayers } },
+      orderBy: { order: "asc" },
+    });
+    return gps.map((gp) => {
+      const ep = eps.find((e) => e.id === gp.eventPlayerId);
+      return { name: ep?.name, order: gp.order };
+    });
+  }
+
+  it("appends a confirmed priority player at the end of the queue when the game has room", async () => {
+    const owner = await seedUser();
+    const player = await seedUser({ name: "PriorityPlayer" });
+    const event = await seedEvent(owner.id, { priorityEnabled: true });
+    const game = await seedGame(event, 8);
+
+    // 3 regular players already in the game at orders 0,1,2
+    await seedParticipant(event.id, game.id, "Ana", 0);
+    await seedParticipant(event.id, game.id, "Bia", 1);
+    await seedParticipant(event.id, game.id, "Carlos", 2);
+
+    await seedEnrollment(event.id, player);
+    await seedPendingConfirmation(event.id, player, event.dateTime);
+    mockAuth(player.id);
+    mockGetSession.mockResolvedValue({ user: { id: player.id, name: "PriorityPlayer" }, session: { id: "s1" } });
+
+    const res = await confirmPriority(ctx({ id: event.id }, {}));
+    expect(res.status).toBe(200);
+
+    const list = await activeOrders(event.id, game.id, 8);
+    expect(list).toEqual([
+      { name: "Ana", order: 0 },
+      { name: "Bia", order: 1 },
+      { name: "Carlos", order: 2 },
+      { name: "PriorityPlayer", order: 3 },
+    ]);
+  });
+
+  it("gives a confirmed priority player an active spot by evicting the last non-priority player to the bench when full", async () => {
+    const owner = await seedUser();
+    const player = await seedUser({ name: "PriorityPlayer" });
+    const event = await seedEvent(owner.id, { priorityEnabled: true });
+    const game = await seedGame(event, 4); // 4 active spots
+
+    // Full game: orders 0-3 occupied. Player at order 3 is the last non-priority active.
+    await seedParticipant(event.id, game.id, "Ana", 0);
+    await seedParticipant(event.id, game.id, "Bia", 1);
+    await seedParticipant(event.id, game.id, "Carlos", 2);
+    await seedParticipant(event.id, game.id, "Duda", 3);
+
+    await seedEnrollment(event.id, player);
+    await seedPendingConfirmation(event.id, player, event.dateTime);
+    mockAuth(player.id);
+    mockGetSession.mockResolvedValue({ user: { id: player.id, name: "PriorityPlayer" }, session: { id: "s1" } });
+
+    const res = await confirmPriority(ctx({ id: event.id }, {}));
+    expect(res.status).toBe(200);
+
+    const list = await activeOrders(event.id, game.id, 4);
+    // Priority player takes the last active slot; the previous occupant (Duda) is evicted to the bench.
+    const names = list.map((p) => p.name);
+    expect(names).toContain("PriorityPlayer");
+    const priorityOrder = list.find((p) => p.name === "PriorityPlayer")!.order;
+    expect(priorityOrder).toBeLessThan(4);
+    expect(names).not.toContain("Duda");
+    const duda = await testPrisma.gameParticipant.findFirst({
+      where: { gameId: game.id, eventPlayer: { name: "Duda" } },
+    });
+    expect(duda!.archivedAt).toBeNull();
+    expect(duda!.order).toBeGreaterThanOrEqual(4);
+  });
+
+  it("does not evict another priority player to make room", async () => {
+    const owner = await seedUser();
+    const player = await seedUser({ name: "PriorityPlayer" });
+    const otherPriority = await seedUser({ name: "OtherPriority" });
+    const event = await seedEvent(owner.id, { priorityEnabled: true });
+    const game = await seedGame(event, 4);
+
+    await seedParticipant(event.id, game.id, "Ana", 0);
+    await seedParticipant(event.id, game.id, "Bia", 1);
+    await seedParticipant(event.id, game.id, "Carlos", 2);
+    await seedParticipant(event.id, game.id, "OtherPriority", 3, { userId: otherPriority.id });
+    await seedEnrollment(event.id, otherPriority);
+
+    await seedEnrollment(event.id, player);
+    await seedPendingConfirmation(event.id, player, event.dateTime);
+    mockAuth(player.id);
+    mockGetSession.mockResolvedValue({ user: { id: player.id, name: "PriorityPlayer" }, session: { id: "s1" } });
+
+    const res = await confirmPriority(ctx({ id: event.id }, {}));
+    expect(res.status).toBe(200);
+
+    const list = await activeOrders(event.id, game.id, 4);
+    // OtherPriority is priority too — must not be evicted. Instead Carlos
+    // (highest-order non-priority active) is displaced to the bench.
+    const names = list.map((p) => p.name);
+    expect(names).toContain("OtherPriority");
+    expect(names).toContain("PriorityPlayer");
+    expect(names).not.toContain("Carlos");
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes the player ordering bug reported in #657 (prod repro: event `cmmkfrx8b0000o2ixrix1yp2m` showed orders `0,1,2,3,14` — a 9-slot gap).

### Root cause

`GameParticipant.order` was assigned from three inconsistent sources depending on the join path:

| Path | Old source | Problem |
|---|---|---|
| Fresh join | `event.players.length` (event-wide) | Grows across games → new player lands at order 14 while regulars sit at 0-3 |
| Re-add / re-join | `gameParticipant.count()` | Collides with archived gaps from players who left |
| Priority confirm | `order: 0` + `update: {}` | Order collision; archived participant stays archived (#625) |

### Changes

- `nextGameParticipantOrder(gameId)` in `src/lib/game.server.ts` — single source of truth: `max(order)+1`, game-scoped, gap-safe. All 4 order-assignment sites in `players.ts` use it; fresh join no longer uses `event.players.length`.
- `grantActiveSpot(...)` — ADR 0020 guaranteed spot for priority-confirmed players: room → append; full → evict the last **non-priority** active player to bench; never evicts priority players. `confirm.ts` uses it and re-syncs teams.
- ADR 0020 documents the ordering + guaranteed-spot decisions.

### Tests (TDD, red→green)

- `src/test/player-order.test.ts` — reproduces prod gap `[0,1,2,3,14]` and the count-based collision (both failed before, pass after) + legacy no-game path.
- `src/test/priority-api.test.ts` — 3 new tests: append when room, evict last non-priority when full, never evict a priority player.

Full suite: 3057 pass. Typecheck clean. Lint 0 errors.