### PR TITLE
fix: revert docker to node 24 alpine (corepack removed in node 25)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:25-alpine AS base
+FROM node:24-alpine AS base
 
 RUN apk add --no-cache openssl
 RUN corepack enable && corepack prepare pnpm@10 --activate

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,7 +1,7 @@
 # Base image: runtime dependencies that rarely change.
 # Rebuilt only when pnpm-lock.yaml or prisma/schema.prisma change.
 # Tagged as registry.fly.io/convocados:base
-FROM node:25-alpine
+FROM node:24-alpine
 
 RUN apk add --no-cache openssl
 RUN corepack enable && corepack prepare pnpm@10 --activate


### PR DESCRIPTION
Dependabot bump #655 moved Dockerfiles to node:25-alpine, which removed bundled corepack. `corepack enable` now exits 127, failing the base image build and blocking deploys.

Root cause: Node 25 no longer ships corepack. The deploy workflow's setup-node already uses node 24 (which has corepack) — aligning Dockerfiles to node:24-alpine is the consistent LTS fix.