### PR TITLE
fix: pin docker base to node 22 (better-sqlite3 has no node>=24 musl prebuild)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,11 @@ updates:
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 3
+    ignore:
+      # better-sqlite3 ships no musl prebuilds for Node >=24 (build fails in
+      # alpine without python/make/g++); node 25 also drops bundled corepack.
+      - dependency-name: "node"
+        versions: [">=24"]
 
   - package-ecosystem: "gradle"
     directory: "/android-app"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24-alpine AS base
+FROM node:22-alpine AS base
 
 RUN apk add --no-cache openssl
 RUN corepack enable && corepack prepare pnpm@10 --activate

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,7 +1,7 @@
 # Base image: runtime dependencies that rarely change.
 # Rebuilt only when pnpm-lock.yaml or prisma/schema.prisma change.
 # Tagged as registry.fly.io/convocados:base
-FROM node:24-alpine
+FROM node:22-alpine
 
 RUN apk add --no-cache openssl
 RUN corepack enable && corepack prepare pnpm@10 --activate


### PR DESCRIPTION
Second layer of the node bump breakage.

**Symptom:** base image build fails at `pnpm install --frozen-lockfile --prod` with `gyp ERR! find Python`.

**Root cause:** `better-sqlite3` ships prebuilt binaries for Node 22 (musl), but not Node 24/25. On alpine without python/make/g++, node-gyp rebuild fails. The GitHub runner (Ubuntu/glibc) works because prebuilds exist there — only the alpine Docker base breaks.

**Fix:** revert to `node:22-alpine` (LTS until 2027, ships corepack, has the better-sqlite3 musl prebuild) and add a dependabot ignore for node >=24 so this can't silently re-break production.