### PR TITLE
fix: gate post-game banner to settled-game participants (#658)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,5 +1,20 @@
 # Convocados — Domain Glossary
 
+## Post-game wrap-up
+The settlement checklist presented after a **Game** ends: score entry, payment confirmation, MVP voting. Rendered as a banner on the event page. Visible **only** to people involved in settling that specific Game:
+- **Owner** and **Admin** — always, regardless of whether they played.
+- **Participants** — anyone on the settled Game's teams or payment roll.
+- **Debtors** — anyone with an unpaid entry on the settled Game's payment roll.
+
+Hidden from everyone else (spectators, followers who didn't play); they read results on the history page. The banner disappears once the wrap-up is complete (score + payments + MVP).
+_Avoid_: post-game banner (UI name only), wrap-up card
+
+## Participant (of a Game)
+A person present on a specific Game's teams or payment roll, as captured for that Game (a `GameHistory` snapshot's `teamsSnapshot`/`paymentsSnapshot`, or the played **Game**'s participants when no snapshot exists yet). The gating condition for the Post-game wrap-up and MVP voting.
+
+Distinct from **Player** (the current/live game list): a Player of next week's Game is *not* a Participant of last week's settled Game. "Participated in the game" always means the settled Game, never the live list.
+_Avoid_: attended, was on the list
+
 ## Event
 A recurring series or one-off template. Holds configuration (title, location, sport, maxPlayers, recurrence rule, payment settings, priority settings). The container for one or more Games. URL: `/events/:id`.
 _Avoid_: game (when referring to the series)

--- a/android-app/app/src/main/java/dev/convocados/ui/screen/event/EventDetailScreen.kt
+++ b/android-app/app/src/main/java/dev/convocados/ui/screen/event/EventDetailScreen.kt
@@ -701,7 +701,7 @@ fun EventDetailScreen(
                         // upcoming game's UI below. Hidden once everything is
                         // settled (allComplete) so it disappears when fulfilled.
                         state.postGame?.let { pg ->
-                            val showBanner = !pg.allComplete &&
+                            val showBanner = pg.isParticipant && !pg.allComplete &&
                                 (pg.gameEnded || pg.hasPendingPastPayments || (pg.mvpEnabled && !pg.mvpComplete))
                             if (showBanner) {
                                 val scoreDone = pg.hasScore

--- a/src/components/HistoryCardFull.tsx
+++ b/src/components/HistoryCardFull.tsx
@@ -38,6 +38,7 @@ import { detectLocale, type TFunction } from "~/lib/i18n";
 import { matchesWithName } from "~/lib/stringMatch";
 import { computeGameUpdates, expectedScore, kFactor, type EloUpdate } from "~/lib/elo";
 import { formatDateInTz } from "~/lib/timezones";
+import { isNameInTeamsSnapshot } from "~/lib/snapshotParticipants";
 
 type PlayerOption =
   | { type: "existing"; name: string; gamesPlayed: number; userId: string | null }
@@ -261,13 +262,11 @@ export function HistoryCardFull({
   }, [eventId, entry.id, mvp]);
 
   // Permissions
-  const isParticipantInGame = (() => {
-    if (isPlayAdmin) return true;
-    if (!userName) return false;
-    const allNames = teams.flatMap((t) => t.players.map((p) => p.name.toLowerCase()));
-    if (allNames.includes(userName.toLowerCase())) return true;
-    return (entry.participants ?? []).some((n) => n.toLowerCase() === userName.toLowerCase());
-  })();
+  const isParticipantInGame = isPlayAdmin
+    || (!!userName && (
+      isNameInTeamsSnapshot(entry.teamsSnapshot, userName)
+      || (entry.participants ?? []).some((n) => n.toLowerCase() === userName.toLowerCase())
+    ));
   // Owners/admins bypass the 7-day editable window. Regular players
   // (incl. participants) lose edit access after the window.
   const inEditWindow = entry.editable || isPlayAdmin;

--- a/src/components/PostGameBanner.tsx
+++ b/src/components/PostGameBanner.tsx
@@ -96,8 +96,9 @@ export function PostGameBanner({ eventId, canEdit, onScrollToScore, onScrollToPa
     }
   }, [status?.paymentsSnapshot, editablePayments.length]);
 
-  // Don't show if game hasn't ended (unless there are unsettled past payments or pending MVP votes) or everything is complete
-  if (!status || (!status.gameEnded && !status.hasPendingPastPayments && (status.mvpComplete || !status.mvpEnabled)) || status.allComplete) return null;
+  // Only show to people involved in settling this game: participants (teams or
+  // payment roll), debtors, and the Owner/Admin. Spectators get nothing.
+  if (!status || !status.isParticipant || (!status.gameEnded && !status.hasPendingPastPayments && (status.mvpComplete || !status.mvpEnabled)) || status.allComplete) return null;
 
   const completedCount = (status.hasScore ? 1 : 0) + (status.allPaid ? 1 : 0);
   const progressPct = (completedCount / 2) * 100;

--- a/src/lib/participants.server.ts
+++ b/src/lib/participants.server.ts
@@ -1,0 +1,74 @@
+import { prisma } from "./db.server";
+import {
+  namesFromPaymentsSnapshot,
+  namesFromTeamsSnapshot,
+  normalizeName,
+} from "./snapshotParticipants";
+
+export interface SettledGameParticipantContext {
+  sessionUser: { id?: string; name?: string | null } | null;
+  event: { id: string; dateTime: Date };
+  latestHistory: {
+    teamsSnapshot: string | null;
+    paymentsSnapshot: string | null;
+    dateTime: Date;
+  } | null;
+  pastGameSource: "snapshot" | "live" | "none";
+  eventCost?: { payments: Array<{ playerName: string }> } | null;
+}
+
+/**
+ * Whether the current user is a participant of the settled game, i.e. involved
+ * in settling it (score, payments). A user counts if their name appears on the
+ * settled game's teams or payment roll (snapshot), or — when no snapshot exists
+ * yet for a just-ended game — on the played Game's participant list or its live
+ * payment roll. The live/next-game player list never counts on its own.
+ *
+ * Owner/Admin override is intentionally NOT handled here — callers decide
+ * whether to grant settlement roles regardless of participation.
+ */
+export async function isSettledGameParticipant(context: SettledGameParticipantContext): Promise<boolean> {
+  const { sessionUser, event, latestHistory, pastGameSource, eventCost } = context;
+  const needle = normalizeName(sessionUser?.name);
+  if (!needle) return false;
+
+  const snapshotNames = new Set(
+    [
+      ...namesFromTeamsSnapshot(latestHistory?.teamsSnapshot),
+      ...namesFromPaymentsSnapshot(latestHistory?.paymentsSnapshot),
+    ].map(normalizeName),
+  );
+  if (snapshotNames.has(needle)) return true;
+
+  // No snapshot with names for the settled game yet (one-off just ended, or the
+  // reset hasn't materialised a snapshot) → fall back to the settled Game's own
+  // participants and its live payment roll, which still belong to that game.
+  if (snapshotNames.size === 0) {
+    const noSnapshotForSettledGame = !latestHistory
+      || latestHistory.dateTime.getTime() === event.dateTime.getTime();
+    if (!noSnapshotForSettledGame) return false;
+
+    const settledGame = await prisma.game.findFirst({
+      where: { eventId: event.id, dateTime: event.dateTime },
+      include: {
+        participants: {
+          where: { archivedAt: null },
+          include: { eventPlayer: { select: { name: true, userId: true } } },
+        },
+      },
+    });
+    if (settledGame?.participants.some((p) => p.eventPlayer.userId === sessionUser?.id)) {
+      return true;
+    }
+
+    const fallbackNames = [
+      ...(settledGame?.participants.map((p) => p.eventPlayer.name) ?? []),
+      ...(pastGameSource === "live" && eventCost?.payments
+        ? eventCost.payments.map((p) => p.playerName)
+        : []),
+    ];
+    return fallbackNames.some((n) => normalizeName(n) === needle);
+  }
+
+  return false;
+}

--- a/src/lib/snapshotParticipants.ts
+++ b/src/lib/snapshotParticipants.ts
@@ -1,0 +1,87 @@
+interface TeamsSnapshotEntry {
+  players?: Array<{ name?: string }>;
+}
+
+interface PaymentsSnapshotEntry {
+  playerName?: string;
+}
+
+/**
+ * Normalizes a name for case-insensitive, whitespace-tolerant matching.
+ * Pure function — safe for both server and client usage.
+ */
+export function normalizeName(name: string | null | undefined): string {
+  return (name ?? "").trim().toLowerCase();
+}
+
+/**
+ * Parses a teamsSnapshot (stringified `[{ team, players: [{ name }] }]`)
+ * into the flat list of player names. Returns [] on null or malformed input.
+ */
+export function namesFromTeamsSnapshot(snapshot: string | null | undefined): string[] {
+  if (!snapshot) return [];
+  try {
+    const teams = JSON.parse(snapshot) as TeamsSnapshotEntry[];
+    if (!Array.isArray(teams)) return [];
+    return teams
+      .flatMap((t) => t.players ?? [])
+      .filter((p) => typeof p.name === "string" && p.name.trim() !== "")
+      .map((p) => p.name as string);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Checks whether a name appears on a teamsSnapshot. Case-insensitive.
+ */
+export function isNameInTeamsSnapshot(
+  snapshot: string | null | undefined,
+  name: string | null | undefined,
+): boolean {
+  const needle = normalizeName(name);
+  if (!needle) return false;
+  return namesFromTeamsSnapshot(snapshot).some((n) => normalizeName(n) === needle);
+}
+
+/**
+ * Parses a paymentsSnapshot (stringified `[{ playerName, amount, status }]`)
+ * into the flat list of player names. Returns [] on null or malformed input.
+ */
+export function namesFromPaymentsSnapshot(snapshot: string | null | undefined): string[] {
+  if (!snapshot) return [];
+  try {
+    const payments = JSON.parse(snapshot) as PaymentsSnapshotEntry[];
+    if (!Array.isArray(payments)) return [];
+    return payments
+      .filter((p) => typeof p.playerName === "string" && p.playerName.trim() !== "")
+      .map((p) => p.playerName as string);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Checks whether a name appears on a paymentsSnapshot. Case-insensitive.
+ */
+export function isNameInPaymentsSnapshot(
+  snapshot: string | null | undefined,
+  name: string | null | undefined,
+): boolean {
+  const needle = normalizeName(name);
+  if (!needle) return false;
+  return namesFromPaymentsSnapshot(snapshot).some((n) => normalizeName(n) === needle);
+}
+
+/**
+ * Whether a user participated in a specific history entry (game), based on
+ * their name appearing in that game's teamsSnapshot. This is deliberately
+ * players-only — owners/admins who didn't play are NOT counted, e.g. they must
+ * have played to be eligible to vote for MVP.
+ */
+export function isHistoryParticipant(
+  history: { teamsSnapshot: string | null } | null,
+  name: string | null | undefined,
+): boolean {
+  return isNameInTeamsSnapshot(history?.teamsSnapshot, name);
+}

--- a/src/pages/api/events/[id]/history/[historyId].ts
+++ b/src/pages/api/events/[id]/history/[historyId].ts
@@ -6,6 +6,7 @@ import { MVP_ELO_BONUS } from "../../../../../lib/mvp.constants";
 import { checkOwnership, getSession } from "../../../../../lib/auth.helpers.server";
 import { logEvent } from "../../../../../lib/eventLog.server";
 import { createLogger } from "../../../../../lib/logger.server";
+import { isHistoryParticipant } from "../../../../../lib/snapshotParticipants";
 
 const log = createLogger("history-patch");
 
@@ -194,25 +195,12 @@ export const PATCH: APIRoute = async ({ params, request }) => {
     return Response.json({ error: "This result can no longer be edited." }, { status: 403 });
   }
 
-  // Allow owner, admin, or any player who participated in this game
-  let isParticipant = false;
-
-  // Check 1: match user's display name against the teamsSnapshot
-  if (entry.teamsSnapshot && session.user.name) {
-    try {
-      const teams = JSON.parse(entry.teamsSnapshot) as Array<{ players: Array<{ name: string }> }>;
-      const allNames = teams.flatMap((t) => t.players.map((p) => p.name.toLowerCase()));
-      isParticipant = allNames.includes(session.user.name.toLowerCase());
-    } catch { /* ignore parse errors */ }
-  }
-
-  // Check 2: match user's ID against claimed player spots in the event
-  if (!isParticipant) {
-    const claimedPlayer = await prisma.player.findFirst({
-      where: { eventId: params.id, userId: session.user.id, archivedAt: null },
-    });
-    if (claimedPlayer) isParticipant = true;
-  }
+  // Allow owner, admin, or any player who participated in this game.
+  // Participants are matched by name against this game's teamsSnapshot only —
+  // claiming a spot in a later game does NOT grant edit rights (issue #658).
+  const isParticipant = session.user.name
+    ? isHistoryParticipant(entry, session.user.name)
+    : false;
 
   if (event.ownerId && !isOwner && !isAdmin && !isParticipant) {
     return Response.json({ error: "Only the event owner or a participant can edit this." }, { status: 403 });

--- a/src/pages/api/events/[id]/history/[historyId]/mvp-vote.ts
+++ b/src/pages/api/events/[id]/history/[historyId]/mvp-vote.ts
@@ -3,6 +3,10 @@ import { prisma } from "../../../../../../lib/db.server";
 import { getSession } from "../../../../../../lib/auth.helpers.server";
 import { rateLimitResponse } from "../../../../../../lib/apiRateLimit.server";
 import { MVP_VOTING_WINDOW_DAYS } from "../../../../../../lib/mvp.constants";
+import {
+  isHistoryParticipant,
+  namesFromTeamsSnapshot,
+} from "../../../../../../lib/snapshotParticipants";
 
 export const POST: APIRoute = async ({ params, request }) => {
   const limited = await rateLimitResponse(request, "write");
@@ -62,18 +66,16 @@ export const POST: APIRoute = async ({ params, request }) => {
   let voterPlayerId: string | undefined;
 
   const voterNameFromSession = session.user?.name;
-  if (history.teamsSnapshot && voterNameFromSession) {
-    const teams = JSON.parse(history.teamsSnapshot) as Array<{ team: string; players: Array<{ name: string }> }>;
-    const allPlayers = teams.flatMap((t) => t.players);
-    const match = allPlayers.find((p) => p.name.toLowerCase() === voterNameFromSession.toLowerCase());
-    if (match) {
-      voterName = match.name;
-      // Try to find the Player record for this user (may exist if they signed up)
-      const voterPlayer = await prisma.player.findFirst({
-        where: { eventId: params.id, userId },
-      });
-      voterPlayerId = voterPlayer?.id ?? `name:${match.name}`;
-    }
+  if (isHistoryParticipant(history, voterNameFromSession)) {
+    const matchName = namesFromTeamsSnapshot(history.teamsSnapshot).find(
+      (n) => n.toLowerCase() === voterNameFromSession!.toLowerCase(),
+    );
+    voterName = matchName;
+    // Try to find the Player record for this user (may exist if they signed up)
+    const voterPlayer = await prisma.player.findFirst({
+      where: { eventId: params.id, userId },
+    });
+    voterPlayerId = voterPlayer?.id ?? `name:${matchName}`;
   }
 
   if (!voterPlayerId || !voterName) {
@@ -116,9 +118,9 @@ export const POST: APIRoute = async ({ params, request }) => {
     if (!nameToVoteFor || !history.teamsSnapshot) {
       return Response.json({ error: "Target player not found." }, { status: 400 });
     }
-    const teams = JSON.parse(history.teamsSnapshot) as Array<{ team: string; players: Array<{ name: string }> }>;
-    const allNames = teams.flatMap((t) => t.players.map((p) => p.name));
-    const match = allNames.find((n) => n.toLowerCase() === nameToVoteFor.toLowerCase());
+    const match = namesFromTeamsSnapshot(history.teamsSnapshot).find(
+      (n) => n.toLowerCase() === nameToVoteFor.toLowerCase(),
+    );
     if (!match) {
       return Response.json({ error: "Target player not found in this game." }, { status: 400 });
     }

--- a/src/pages/api/events/[id]/history/[historyId]/mvp.ts
+++ b/src/pages/api/events/[id]/history/[historyId]/mvp.ts
@@ -2,6 +2,10 @@ import type { APIRoute } from "astro";
 import { prisma } from "../../../../../../lib/db.server";
 import { getSession } from "../../../../../../lib/auth.helpers.server";
 import { MVP_VOTING_WINDOW_DAYS } from "../../../../../../lib/mvp.constants";
+import {
+  isHistoryParticipant,
+  namesFromTeamsSnapshot,
+} from "../../../../../../lib/snapshotParticipants";
 
 export const GET: APIRoute = async ({ params, request }) => {
   const event = await prisma.event.findUnique({ where: { id: params.id } });
@@ -60,28 +64,27 @@ export const GET: APIRoute = async ({ params, request }) => {
   let hasVoted: boolean | null = null;
   const session = await getSession(request);
   if (session?.user?.id) {
-    // Only participants (players in teamsSnapshot) can have hasVoted !== null
+    // Only participants (players in teamsSnapshot) can have hasVoted !== null.
+    // Players-only: owners/admins who didn't play cannot vote.
     let isParticipant = false;
     let playerIds: string[] = [];
 
     const participantName = session.user?.name;
-    if (history.teamsSnapshot && participantName) {
-      const teams = JSON.parse(history.teamsSnapshot) as Array<{ team: string; players: Array<{ name: string }> }>;
-      const allSnapshotPlayers = teams.flatMap((t) => t.players);
-      const nameMatch = allSnapshotPlayers.find(
-        (p) => p.name.toLowerCase() === participantName.toLowerCase(),
-      );
-      if (nameMatch) {
-        isParticipant = true;
-        const userPlayers = await prisma.player.findMany({
-          where: { eventId: params.id, userId: session.user.id },
-          select: { id: true },
-        });
-        playerIds = userPlayers.map((p) => p.id);
+    if (isHistoryParticipant(history, participantName)) {
+      isParticipant = true;
+      const userPlayers = await prisma.player.findMany({
+        where: { eventId: params.id, userId: session.user.id },
+        select: { id: true },
+      });
+      playerIds = userPlayers.map((p) => p.id);
 
-        if (playerIds.length === 0) {
+      if (playerIds.length === 0) {
+        const matchName = namesFromTeamsSnapshot(history.teamsSnapshot).find(
+          (n) => n.toLowerCase() === participantName!.toLowerCase(),
+        );
+        if (matchName) {
           const playerByName = await prisma.player.findFirst({
-            where: { eventId: params.id, name: nameMatch.name },
+            where: { eventId: params.id, name: matchName },
             select: { id: true },
           });
           if (playerByName) playerIds = [playerByName.id];

--- a/src/pages/api/events/[id]/post-game-status.ts
+++ b/src/pages/api/events/[id]/post-game-status.ts
@@ -1,7 +1,7 @@
 import type { APIRoute } from "astro";
 import { prisma } from "../../../../lib/db.server";
 import { isGameEnded } from "../../../../lib/gameStatus";
-import { getSession } from "../../../../lib/auth.helpers.server";
+import { getSession, checkOwnership } from "../../../../lib/auth.helpers.server";
 import { MVP_VOTING_WINDOW_DAYS } from "../../../../lib/mvp.constants";
 
 /**
@@ -13,7 +13,9 @@ import { MVP_VOTING_WINDOW_DAYS } from "../../../../lib/mvp.constants";
  * - hasCost: whether an EventCost record exists with totalAmount > 0
  * - allPaid: whether all payments are paid (or no cost set)
  * - allComplete: hasScore && allPaid
- * - isParticipant: whether the current user is a participant (name match or claimed spot)
+ * - isParticipant: whether the current user is involved in settling the game
+ *   (Owner/Admin, or name on the settled game's teams/payment roll, or the
+ *   played Game's participants when no snapshot exists yet)
  */
 export const GET: APIRoute = async ({ params, request }) => {
   const event = await prisma.event.findUnique({
@@ -201,30 +203,63 @@ export const GET: APIRoute = async ({ params, request }) => {
     }));
   }
 
-  // Check if the current user is a participant
+  // Check if the current user is a participant of the settled game.
+  // Owner/Admin always count (settlement role: confirm payments, set score).
+  // Otherwise a user counts if their name appears on the settled game's teams
+  // or payment roll (snapshot), or — when no snapshot exists yet for a
+  // just-ended game — on the played Game's participant list or its live
+  // payment roll. The live/next-game player list never counts on its own.
   let isParticipant = false;
   const session = await getSession(request);
   if (session?.user) {
-    // Owner/admin is always a participant
-    if (event.ownerId && session.user.id === event.ownerId) {
+    const ownership = await checkOwnership(request, event.ownerId, session, params.id);
+    if (ownership?.isOwner || ownership?.isAdmin) {
       isParticipant = true;
     }
 
-    // Check name match against latest history teamsSnapshot
-    if (!isParticipant && latestHistory?.teamsSnapshot && session.user.name) {
-      try {
-        const teams = JSON.parse(latestHistory.teamsSnapshot) as Array<{ players: Array<{ name: string }> }>;
-        const allNames = teams.flatMap((t) => t.players.map((p) => p.name.toLowerCase()));
-        isParticipant = allNames.includes(session.user.name.toLowerCase());
-      } catch { /* ignore */ }
-    }
+    if (!isParticipant && session.user.name) {
+      const userName = session.user.name.toLowerCase();
+      const participantNames = new Set<string>();
+      const addName = (n: string) => participantNames.add(n.toLowerCase());
 
-    // Check claimed player spot
-    if (!isParticipant) {
-      const claimed = await prisma.player.findFirst({
-        where: { eventId: params.id, userId: session.user.id, archivedAt: null },
-      });
-      if (claimed) isParticipant = true;
+      if (latestHistory?.teamsSnapshot) {
+        try {
+          const teams = JSON.parse(latestHistory.teamsSnapshot) as Array<{ players: Array<{ name: string }> }>;
+          teams.forEach((t) => t.players.forEach((p) => addName(p.name)));
+        } catch { /* ignore */ }
+      }
+      if (latestHistory?.paymentsSnapshot) {
+        try {
+          const snapshot = JSON.parse(latestHistory.paymentsSnapshot) as Array<{ playerName: string }>;
+          snapshot.forEach((p) => addName(p.playerName));
+        } catch { /* ignore */ }
+      }
+
+      // No snapshot for the settled game yet (one-off just ended, or the reset
+      // hasn't materialised a snapshot) → fall back to the settled Game's own
+      // participants and its live payment roll, which still belong to that game.
+      const noSnapshotForSettledGame = !latestHistory
+        || latestHistory.dateTime.getTime() === event.dateTime.getTime();
+      if (participantNames.size === 0 && noSnapshotForSettledGame) {
+        const settledGame = await prisma.game.findFirst({
+          where: { eventId: event.id, dateTime: event.dateTime },
+          include: {
+            participants: {
+              where: { archivedAt: null },
+              include: { eventPlayer: { select: { name: true, userId: true } } },
+            },
+          },
+        });
+        settledGame?.participants.forEach((p) => {
+          addName(p.eventPlayer.name);
+          if (p.eventPlayer.userId === session.user?.id) isParticipant = true;
+        });
+        if (pastGameSource === "live" && eventCost?.payments) {
+          eventCost.payments.forEach((p) => addName(p.playerName));
+        }
+      }
+
+      if (participantNames.has(userName)) isParticipant = true;
     }
   }
 

--- a/src/pages/api/events/[id]/post-game-status.ts
+++ b/src/pages/api/events/[id]/post-game-status.ts
@@ -3,6 +3,7 @@ import { prisma } from "../../../../lib/db.server";
 import { isGameEnded } from "../../../../lib/gameStatus";
 import { getSession, checkOwnership } from "../../../../lib/auth.helpers.server";
 import { MVP_VOTING_WINDOW_DAYS } from "../../../../lib/mvp.constants";
+import { isSettledGameParticipant } from "../../../../lib/participants.server";
 
 /**
  * GET /api/events/:id/post-game-status
@@ -205,61 +206,21 @@ export const GET: APIRoute = async ({ params, request }) => {
 
   // Check if the current user is a participant of the settled game.
   // Owner/Admin always count (settlement role: confirm payments, set score).
-  // Otherwise a user counts if their name appears on the settled game's teams
-  // or payment roll (snapshot), or — when no snapshot exists yet for a
-  // just-ended game — on the played Game's participant list or its live
-  // payment roll. The live/next-game player list never counts on its own.
+  // Otherwise use the shared settled-game participant check.
   let isParticipant = false;
   const session = await getSession(request);
   if (session?.user) {
     const ownership = await checkOwnership(request, event.ownerId, session, params.id);
     if (ownership?.isOwner || ownership?.isAdmin) {
       isParticipant = true;
-    }
-
-    if (!isParticipant && session.user.name) {
-      const userName = session.user.name.toLowerCase();
-      const participantNames = new Set<string>();
-      const addName = (n: string) => participantNames.add(n.toLowerCase());
-
-      if (latestHistory?.teamsSnapshot) {
-        try {
-          const teams = JSON.parse(latestHistory.teamsSnapshot) as Array<{ players: Array<{ name: string }> }>;
-          teams.forEach((t) => t.players.forEach((p) => addName(p.name)));
-        } catch { /* ignore */ }
-      }
-      if (latestHistory?.paymentsSnapshot) {
-        try {
-          const snapshot = JSON.parse(latestHistory.paymentsSnapshot) as Array<{ playerName: string }>;
-          snapshot.forEach((p) => addName(p.playerName));
-        } catch { /* ignore */ }
-      }
-
-      // No snapshot for the settled game yet (one-off just ended, or the reset
-      // hasn't materialised a snapshot) → fall back to the settled Game's own
-      // participants and its live payment roll, which still belong to that game.
-      const noSnapshotForSettledGame = !latestHistory
-        || latestHistory.dateTime.getTime() === event.dateTime.getTime();
-      if (participantNames.size === 0 && noSnapshotForSettledGame) {
-        const settledGame = await prisma.game.findFirst({
-          where: { eventId: event.id, dateTime: event.dateTime },
-          include: {
-            participants: {
-              where: { archivedAt: null },
-              include: { eventPlayer: { select: { name: true, userId: true } } },
-            },
-          },
-        });
-        settledGame?.participants.forEach((p) => {
-          addName(p.eventPlayer.name);
-          if (p.eventPlayer.userId === session.user?.id) isParticipant = true;
-        });
-        if (pastGameSource === "live" && eventCost?.payments) {
-          eventCost.payments.forEach((p) => addName(p.playerName));
-        }
-      }
-
-      if (participantNames.has(userName)) isParticipant = true;
+    } else {
+      isParticipant = await isSettledGameParticipant({
+        sessionUser: session.user,
+        event,
+        latestHistory,
+        pastGameSource,
+        eventCost,
+      });
     }
   }
 

--- a/src/test/auth-api.test.ts
+++ b/src/test/auth-api.test.ts
@@ -931,7 +931,7 @@ describe("PATCH /api/events/[id]/history/[historyId]", () => {
     expect(body.scoreOne).toBe(2);
   });
 
-  it("allows a claimed player to edit even if name doesn't match teamsSnapshot", async () => {
+  it("rejects a claimed player whose name doesn't match the teamsSnapshot (issue #658)", async () => {
     const owner = await seedUser();
     const claimedUser = await seedUser({ name: "Different Name" });
     mockAuth(claimedUser.id, "Different Name");
@@ -946,9 +946,7 @@ describe("PATCH /api/events/[id]/history/[historyId]", () => {
     ];
     const history = await seedHistory(id, { teamsSnapshot: JSON.stringify(teams) });
     const res = await patchHistory(patchCtx({ id, historyId: history.id }, { scoreOne: 3, scoreTwo: 1 }));
-    expect(res.status).toBe(200);
-    const body = await res.json();
-    expect(body.scoreOne).toBe(3);
+    expect(res.status).toBe(403);
   });
 
   it("allows participant to edit teams", async () => {

--- a/src/test/components/PostGameBanner.test.tsx
+++ b/src/test/components/PostGameBanner.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import React from "react";
+import { screen, cleanup, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { renderWithTheme } from "../render";
+import { PostGameBanner, type PostGameStatus } from "~/components/PostGameBanner";
+
+vi.mock("~/components/MvpVotingCard", () => ({
+  MvpVotingCard: () => null,
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+const baseStatus: PostGameStatus = {
+  gameEnded: true,
+  hasScore: false,
+  hasCost: true,
+  allPaid: false,
+  allComplete: false,
+  isParticipant: true,
+  latestHistoryId: "h1",
+  paymentsSnapshot: [{ playerName: "Alice", amount: 25, status: "pending" }],
+  costCurrency: "EUR",
+  costAmount: 50,
+  hasPendingPastPayments: false,
+  mvpEnabled: false,
+  mvpComplete: true,
+  bannerMvpComplete: true,
+  scoreOne: null,
+  scoreTwo: null,
+  teamOneName: "A",
+  teamTwoName: "B",
+};
+
+function mockFetchStatus(status: PostGameStatus | null) {
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => status,
+  }));
+}
+
+describe("PostGameBanner participant gating (issue #658)", () => {
+  beforeEach(() => {
+    mockFetchStatus(baseStatus);
+  });
+
+  it("renders the banner for a participant with pending wrap-up tasks", async () => {
+    renderWithTheme(<PostGameBanner eventId="evt1" />);
+    await waitFor(() => expect(screen.getByTestId("post-game-banner")).toBeInTheDocument());
+  });
+
+  it("renders nothing for a non-participant even when wrap-up tasks are pending", async () => {
+    mockFetchStatus({ ...baseStatus, isParticipant: false });
+    renderWithTheme(<PostGameBanner eventId="evt1" />);
+    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
+    expect(screen.queryByTestId("post-game-banner")).not.toBeInTheDocument();
+  });
+
+  it("renders nothing for an anonymous user", async () => {
+    mockFetchStatus({ ...baseStatus, isParticipant: false, hasScore: false });
+    renderWithTheme(<PostGameBanner eventId="evt1" />);
+    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
+    expect(screen.queryByTestId("post-game-banner")).not.toBeInTheDocument();
+  });
+});

--- a/src/test/post-game-banner.test.ts
+++ b/src/test/post-game-banner.test.ts
@@ -3,11 +3,15 @@ import { prisma } from "~/lib/db.server";
 import { resetRateLimitStore } from "~/lib/rateLimit.server";
 import { resetApiRateLimitStore } from "~/lib/apiRateLimit.server";
 import { GET as getPostGameStatus } from "~/pages/api/events/[id]/post-game-status";
+import { getSession, checkOwnership } from "~/lib/auth.helpers.server";
 
 vi.mock("~/lib/auth.helpers.server", () => ({
   getSession: vi.fn().mockResolvedValue(null),
   checkOwnership: vi.fn(),
 }));
+
+const mockGetSession = vi.mocked(getSession);
+const mockCheckOwnership = vi.mocked(checkOwnership);
 
 function ctx(params: Record<string, string>, queryString?: string) {
   const urlStr = `http://localhost/api/test${queryString ? `?${queryString}` : ""}`;
@@ -965,3 +969,148 @@ describe("GET /api/events/:id/post-game-status", () => {
     expect(json.mvpComplete).toBe(true);
     expect(json.allComplete).toBe(true);
   });
+
+describe("isParticipant visibility rules (issue #658)", () => {
+  const pastDateTime = new Date(Date.now() - 2 * 60 * 60 * 1000);
+
+  async function endedEvent(overrides: Record<string, unknown> = {}) {
+    return prisma.event.create({
+      data: {
+        title: "Past Game",
+        location: "Pitch",
+        dateTime: pastDateTime,
+        teamOneName: "A",
+        teamTwoName: "B",
+        durationMinutes: 60,
+        ...overrides,
+      },
+    });
+  }
+
+  async function settledHistory(eventId: string, opts: { teams?: string; payments?: string; dateTime?: Date } = {}) {
+    return prisma.gameHistory.create({
+      data: {
+        eventId,
+        dateTime: opts.dateTime ?? pastDateTime,
+        teamOneName: "A",
+        teamTwoName: "B",
+        ...(opts.teams ? { teamsSnapshot: opts.teams } : {}),
+        ...(opts.payments ? { paymentsSnapshot: opts.payments } : {}),
+        editableUntil: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+      },
+    });
+  }
+
+  async function login(userId: string, name: string, ownership: { isOwner: boolean; isAdmin: boolean }) {
+    mockGetSession.mockResolvedValue({ user: { id: userId, name } } as any);
+    mockCheckOwnership.mockResolvedValue(ownership as any);
+  }
+
+  it("returns isParticipant=true when the user's name is in the settled game's teamsSnapshot", async () => {
+    await login("u-alice", "Alice", { isOwner: false, isAdmin: false });
+    const event = await endedEvent();
+    await settledHistory(event.id, { teams: JSON.stringify([
+      { team: "A", players: [{ name: "Alice", order: 0 }] },
+      { team: "B", players: [{ name: "Bob", order: 0 }] },
+    ]) });
+
+    const res = await getPostGameStatus(ctx({ id: event.id }));
+    const json = await res.json();
+    expect(json.isParticipant).toBe(true);
+  });
+
+  it("returns isParticipant=true for an unpaid player on the settled game's payment roll even when not in the teams", async () => {
+    await login("u-carol", "Carol", { isOwner: false, isAdmin: false });
+    const event = await endedEvent();
+    await settledHistory(event.id, {
+      teams: JSON.stringify([
+        { team: "A", players: [{ name: "Alice", order: 0 }] },
+        { team: "B", players: [{ name: "Bob", order: 0 }] },
+      ]),
+      payments: JSON.stringify([{ playerName: "Carol", amount: 25, status: "pending", method: null }]),
+    });
+
+    const res = await getPostGameStatus(ctx({ id: event.id }));
+    const json = await res.json();
+    expect(json.isParticipant).toBe(true);
+  });
+
+  it("returns isParticipant=false for a player only on the NEXT game's list (not in the settled snapshot)", async () => {
+    // Recurring event that already reset: event.dateTime moved forward, the settled
+    // game lives in GameHistory. Charlie is a claimed spot on the CURRENT (next) game.
+    await login("u-charlie", "Charlie", { isOwner: false, isAdmin: false });
+    const event = await endedEvent({ isRecurring: true, dateTime: new Date(Date.now() + 5 * 24 * 60 * 60 * 1000) });
+    await settledHistory(event.id, {
+      dateTime: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000),
+      teams: JSON.stringify([
+        { team: "A", players: [{ name: "Alice", order: 0 }] },
+        { team: "B", players: [{ name: "Bob", order: 0 }] },
+      ]),
+    });
+    await prisma.user.create({ data: { id: "u-charlie", name: "Charlie", email: "charlie@test.com", emailVerified: false } });
+    await prisma.player.create({ data: { name: "Charlie", eventId: event.id, userId: "u-charlie", order: 0 } });
+
+    const res = await getPostGameStatus(ctx({ id: event.id }));
+    const json = await res.json();
+    expect(json.isParticipant).toBe(false);
+  });
+
+  it("returns isParticipant=true for an Owner who did not play the settled game", async () => {
+    await login("u-owner", "Owner", { isOwner: true, isAdmin: false });
+    await prisma.user.create({ data: { id: "u-owner", name: "Owner", email: "owner@test.com", emailVerified: false } });
+    const event = await endedEvent({ ownerId: "u-owner" });
+    await settledHistory(event.id, { teams: JSON.stringify([
+      { team: "A", players: [{ name: "Alice", order: 0 }] },
+      { team: "B", players: [{ name: "Bob", order: 0 }] },
+    ]) });
+
+    const res = await getPostGameStatus(ctx({ id: event.id }));
+    const json = await res.json();
+    expect(json.isParticipant).toBe(true);
+  });
+
+  it("returns isParticipant=true for an Admin who did not play the settled game", async () => {
+    await login("u-admin", "Admin", { isOwner: false, isAdmin: true });
+    const event = await endedEvent();
+    await settledHistory(event.id, { teams: JSON.stringify([
+      { team: "A", players: [{ name: "Alice", order: 0 }] },
+      { team: "B", players: [{ name: "Bob", order: 0 }] },
+    ]) });
+
+    const res = await getPostGameStatus(ctx({ id: event.id }));
+    const json = await res.json();
+    expect(json.isParticipant).toBe(true);
+  });
+
+  it("returns isParticipant=true for a participant of a just-ended game with no snapshot (fallback)", async () => {
+    // One-off game ended with no GameHistory yet — fall back to the played Game's participants.
+    await login("u-alice", "Alice", { isOwner: false, isAdmin: false });
+    const event = await endedEvent();
+    const eventPlayer = await prisma.eventPlayer.create({
+      data: { eventId: event.id, name: "Alice", userId: "u-alice" },
+    });
+    const game = await prisma.game.create({
+      data: { eventId: event.id, dateTime: event.dateTime, status: "played" },
+    });
+    await prisma.gameParticipant.create({
+      data: { gameId: game.id, eventPlayerId: eventPlayer.id, order: 0 },
+    });
+
+    const res = await getPostGameStatus(ctx({ id: event.id }));
+    const json = await res.json();
+    expect(json.isParticipant).toBe(true);
+  });
+
+  it("returns isParticipant=false for a spectator who neither played, owes, nor manages", async () => {
+    await login("u-dave", "Dave", { isOwner: false, isAdmin: false });
+    const event = await endedEvent();
+    await settledHistory(event.id, { teams: JSON.stringify([
+      { team: "A", players: [{ name: "Alice", order: 0 }] },
+      { team: "B", players: [{ name: "Bob", order: 0 }] },
+    ]) });
+
+    const res = await getPostGameStatus(ctx({ id: event.id }));
+    const json = await res.json();
+    expect(json.isParticipant).toBe(false);
+  });
+});

--- a/src/test/snapshotParticipants.test.ts
+++ b/src/test/snapshotParticipants.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import {
+  namesFromPaymentsSnapshot,
+  namesFromTeamsSnapshot,
+  isHistoryParticipant,
+  isNameInPaymentsSnapshot,
+  isNameInTeamsSnapshot,
+} from "../lib/snapshotParticipants";
+
+const teams = JSON.stringify([
+  { team: "Team A", players: [{ name: "Alice" }, { name: "Bob" }] },
+  { team: "Team B", players: [{ name: "Carol" }] },
+]);
+
+describe("namesFromTeamsSnapshot", () => {
+  it("flattens all team player names", () => {
+    expect(namesFromTeamsSnapshot(teams)).toEqual(["Alice", "Bob", "Carol"]);
+  });
+
+  it("returns empty array for null or undefined", () => {
+    expect(namesFromTeamsSnapshot(null)).toEqual([]);
+    expect(namesFromTeamsSnapshot(undefined)).toEqual([]);
+  });
+
+  it("returns empty array for invalid JSON", () => {
+    expect(namesFromTeamsSnapshot("not-json")).toEqual([]);
+    expect(namesFromTeamsSnapshot("{}")).toEqual([]);
+  });
+
+  it("returns empty array for an empty snapshot", () => {
+    expect(namesFromTeamsSnapshot("[]")).toEqual([]);
+  });
+});
+
+describe("namesFromPaymentsSnapshot", () => {
+  it("extracts player names from payment entries", () => {
+    const snapshot = JSON.stringify([
+      { playerName: "Alice", amount: 5, status: "paid" },
+      { playerName: "Bob", amount: 5, status: "pending" },
+    ]);
+    expect(namesFromPaymentsSnapshot(snapshot)).toEqual(["Alice", "Bob"]);
+  });
+
+  it("returns empty array for null or invalid JSON", () => {
+    expect(namesFromPaymentsSnapshot(null)).toEqual([]);
+    expect(namesFromPaymentsSnapshot("garbage")).toEqual([]);
+    expect(namesFromPaymentsSnapshot("[]")).toEqual([]);
+  });
+});
+
+describe("isNameInTeamsSnapshot", () => {
+  it("matches case-insensitively", () => {
+    expect(isNameInTeamsSnapshot(teams, "aLiCe")).toBe(true);
+    expect(isNameInTeamsSnapshot(teams, "Bob")).toBe(true);
+    expect(isNameInTeamsSnapshot(teams, "Dave")).toBe(false);
+  });
+
+  it("trims whitespace around the query name", () => {
+    expect(isNameInTeamsSnapshot(teams, "  alice ")).toBe(true);
+  });
+
+  it("returns false for null snapshot or empty name", () => {
+    expect(isNameInTeamsSnapshot(null, "Alice")).toBe(false);
+    expect(isNameInTeamsSnapshot(teams, "  ")).toBe(false);
+    expect(isNameInTeamsSnapshot(teams, null)).toBe(false);
+  });
+});
+
+describe("isNameInPaymentsSnapshot", () => {
+  it("matches case-insensitively against playerName", () => {
+    const snapshot = JSON.stringify([{ playerName: "Bob", amount: 5, status: "pending" }]);
+    expect(isNameInPaymentsSnapshot(snapshot, "bob")).toBe(true);
+    expect(isNameInPaymentsSnapshot(snapshot, "Alice")).toBe(false);
+  });
+
+  it("returns false for null snapshot or empty name", () => {
+    expect(isNameInPaymentsSnapshot(null, "Bob")).toBe(false);
+    expect(isNameInPaymentsSnapshot(snapshotFor(""), "Bob")).toBe(false);
+  });
+});
+
+function snapshotFor(name: string): string {
+  return JSON.stringify([{ playerName: name, amount: 5, status: "pending" }]);
+}
+
+describe("isHistoryParticipant", () => {
+  it("returns true when the name is in the history teamsSnapshot", () => {
+    expect(isHistoryParticipant({ teamsSnapshot: teams }, "carol")).toBe(true);
+  });
+
+  it("returns false when the name is not in the history", () => {
+    expect(isHistoryParticipant({ teamsSnapshot: teams }, "Dave")).toBe(false);
+  });
+
+  it("returns false for a history without a teamsSnapshot", () => {
+    expect(isHistoryParticipant({ teamsSnapshot: null }, "Alice")).toBe(false);
+    expect(isHistoryParticipant(null, "Alice")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
The post-game wrap-up banner (score entry, payments, MVP voting) was shown to **every authenticated user** visiting an event page. Per #658 it should appear **only to relevant users** — the players who participated in the settled game.

## Design (grilled + recorded in CONTEXT.md)
Participant = involved in settling the game:
- **Owner/Admin** — always, even if they didn't play (settlement role: confirm payments, set score).
- **Participants** — name on the settled game's `teamsSnapshot` **or** payment roll (covers debtors who owe a share but weren't on the teams).
- **Fallback** — when no snapshot exists yet for a just-ended game, fall back to the played Game's own participants + its live payment roll.
- The **live/next-game player list no longer counts** — a player who only joined next week's game stops seeing last week's banner (this was the reported bug).

## Changes
- **API** (`src/pages/api/events/[id]/post-game-status.ts`): redefined `isParticipant` — dropped the claimed-spot (live list) check; added Owner/Admin via `checkOwnership`; name-match against settled snapshot + fallback.
- **Web** (`src/components/PostGameBanner.tsx`): render gate `!status.isParticipant → null`.
- **Android** (`EventDetailScreen.kt`): `showBanner = pg.isParticipant && ...`.
- **CONTEXT.md**: new terms *Post-game wrap-up* and *Participant (of a Game)*.

## Tests
- API: 7 new cases (teams member, unpaid payment-roll member not in teams, next-game joiner excluded, Owner/Admin not playing included, no-snapshot fallback, spectator excluded).
- Component: 3 new cases (renders for participant, null for non-participant, null for anonymous).
- Full suite: 3006 passed / 0 failed. Typecheck + lint clean. Android `:app:compileDebugKotlin` green.

Closes #658