### PR TITLE
fix: handle missing /data volume in release recovery

### DIFF
--- a/scripts/release-migrate.sh
+++ b/scripts/release-migrate.sh
@@ -16,8 +16,14 @@ export DATABASE_URL
 # exists in the image. These queries only touch raw SQL, so better-sqlite3 is
 # the right tool and is already a production dependency.
 echo "[release] Checking for failed migrations and recovering in one shot..."
+mkdir -p /data
 node -e '
+  const fs = require("fs");
   const Database = require("/app/node_modules/better-sqlite3");
+  if (!fs.existsSync("/data/db.sqlite")) {
+    console.log("[release] No database present yet — skipping failed-migration recovery.");
+    process.exit(0);
+  }
   const db = new Database("/data/db.sqlite", { readonly: false });
   const cutoff = new Date(Date.now() - 300000).toISOString();
   try {


### PR DESCRIPTION
## Summary
Follow-up to #669. Fly's `release_command` runs in a temporary machine **without the persistent volume attached** (documented Fly behavior), so `/data/db.sqlite` does not exist there.

My better-sqlite3 rewrite in #669 opened the DB unconditionally → `Cannot open database because the directory does not exist` → release_command failed → deploy aborted.

## Fix
- `mkdir -p /data` (safe: app machine volume already provides it)
- Skip failed-migration recovery when `/data/db.sqlite` is absent (temp release machine has no volume), log clearly
- `prisma migrate deploy` then creates the DB + applies migrations as before

Real recovery still runs in `start.sh` on the app machine (which has the volume).

## Verified
Sandboxed against copy of `test.db`:
- Existing DB → "No failed migrations detected", migrate deploy exit 0
- Missing DB → "No database present yet — skipping", migrate deploy creates DB + applies all 81 migrations, exit 0