### PR TITLE
fix: restrict RSVP confirm ping to game participants

### DIFF
--- a/src/lib/rsvp.server.ts
+++ b/src/lib/rsvp.server.ts
@@ -241,20 +241,24 @@ export interface RsvpSummary {
   pendingUserIds: string[];
 }
 
-/** User-recipient set: EventFollow ∪ active Player.userId ∪ Owner. Unlinked guests excluded (they have their own Rsvp keyed on playerId). Archived linked players excluded — see #XXX off-by-one fix. */
+/**
+ * User-recipient set: active linked Player.userId ∪ Owner. Unlinked guests
+ * excluded (they have their own Rsvp keyed on playerId). Archived linked
+ * players excluded. Followers are NOT included — the "Are you coming" confirm
+ * ping (#656) and its summary are for game participants only, not spectators
+ * (ADR 0017: game reminders are players-only).
+ */
 export async function getRsvpRecipients(eventId: string): Promise<string[]> {
   const event = await prisma.event.findUnique({
     where: { id: eventId },
     select: {
       ownerId: true,
-      followers: { select: { userId: true } },
       players: { where: { archivedAt: null }, select: { userId: true } },
     },
   });
   if (!event) return [];
   const set = new Set<string>();
   if (event.ownerId) set.add(event.ownerId);
-  for (const f of event.followers) if (f.userId) set.add(f.userId);
   for (const p of event.players) if (p.userId) set.add(p.userId);
   return [...set];
 }

--- a/src/test/rsvp-cron.test.ts
+++ b/src/test/rsvp-cron.test.ts
@@ -31,7 +31,7 @@ async function seedEvent(dateTime: Date, ownerId: string | null) {
 }
 
 describe("RSVP 48h tick windowing", () => {
-  it("fanout resolves exactly the expected recipients", async () => {
+  it("fanout resolves exactly the expected recipients (players only)", async () => {
     const owner = await seedUser("Owner");
     const follower = await seedUser("Follower");
     const linked = await seedUser("Linked");
@@ -42,12 +42,14 @@ describe("RSVP 48h tick windowing", () => {
     await prisma.player.create({ data: { eventId: ev.id, name: "Guest", order: 1 } });
 
     const recipients = await getRsvpRecipients(ev.id);
-    expect(recipients.sort()).toEqual([owner.id, follower.id, linked.id].sort());
+    // #656: follower is not a player → excluded from the "Are you coming" ping
+    expect(recipients.sort()).toEqual([owner.id, linked.id].sort());
     // ghost has no follow + no player link
     expect(recipients).not.toContain(ghost.id);
+    expect(recipients).not.toContain(follower.id);
   });
 
-  it("summary counts yes/no/pending across recipients", async () => {
+  it("summary counts yes/no/pending across game participants only", async () => {
     const owner = await seedUser("Owner");
     const follower = await seedUser("Follower");
     const linked = await seedUser("Linked");
@@ -59,10 +61,10 @@ describe("RSVP 48h tick windowing", () => {
     await upsertRsvp(ev.id, linked.id, "no");
 
     const summary = await getRsvpSummary(ev.id);
-    expect(summary.yes).toBe(1);
+    // #656: follower is not a game participant → their RSVP is ignored
+    expect(summary.yes).toBe(0);
     expect(summary.no).toBe(1);
     expect(summary.pending).toBe(1);
-    expect(summary.yesUserIds).toEqual([follower.id]);
     expect(summary.noUserIds).toEqual([linked.id]);
     expect(summary.pendingUserIds).toEqual([owner.id]);
   });

--- a/src/test/rsvp.test.ts
+++ b/src/test/rsvp.test.ts
@@ -121,7 +121,7 @@ describe("getRsvpForUser", () => {
 });
 
 describe("getRsvpSummary", () => {
-  it("counts yes/no/pending correctly across followers + players + owner", async () => {
+  it("counts yes/no/pending across players + owner, excluding followers", async () => {
     const owner = await seedUser({ name: "Owner" });
     const follower = await seedUser({ name: "Follower" });
     const playerUser = await seedUser({ name: "PlayerUser" });
@@ -129,23 +129,21 @@ describe("getRsvpSummary", () => {
 
     const event = await seedEvent(owner.id);
 
-    // follower follows
+    // follower + stranger follow the event but are not players
     await prisma.eventFollow.create({ data: { eventId: event.id, userId: follower.id } });
+    await prisma.eventFollow.create({ data: { eventId: event.id, userId: stranger.id } });
     // player linked to event
     await prisma.player.create({ data: { eventId: event.id, name: playerUser.name, userId: playerUser.id, order: 0 } });
-    // stranger is a "linked" user via implicit follow? No — they need an EventFollow or Player link.
-    // Add a stranger who follows
-    await prisma.eventFollow.create({ data: { eventId: event.id, userId: stranger.id } });
 
     await upsertRsvp(event.id, follower.id, "yes");
     await upsertRsvp(event.id, playerUser.id, "no");
-    // owner and stranger are pending (no row)
+    // owner is pending (no row)
 
     const summary = await getRsvpSummary(event.id);
-    expect(summary.yes).toBe(1);
+    // #656: followers are excluded — only player + owner are counted
+    expect(summary.yes).toBe(0);
     expect(summary.no).toBe(1);
-    // pending = 2 (owner + stranger)
-    expect(summary.pending).toBe(2);
+    expect(summary.pending).toBe(1);
   });
 });
 
@@ -183,7 +181,7 @@ describe("getUserRsvpMap", () => {
 });
 
 describe("getRsvpRecipients", () => {
-  it("resolves followers + linked players + owner, skipping unlinked guests", async () => {
+  it("resolves owner + linked players, excluding followers and unlinked guests", async () => {
     const owner = await seedUser({ name: "Owner" });
     const follower = await seedUser({ name: "Follower" });
     const playerUser = await seedUser({ name: "PlayerUser" });
@@ -198,7 +196,10 @@ describe("getRsvpRecipients", () => {
     await ghost;
 
     const recipients = await getRsvpRecipients(event.id);
-    expect(recipients.sort()).toEqual([owner.id, follower.id, playerUser.id].sort());
+    // #656: "Are you coming" confirm ping is for players only — followers are excluded
+    expect(recipients.sort()).toEqual([owner.id, playerUser.id].sort());
+    expect(recipients).not.toContain(follower.id);
+    expect(recipients).not.toContain(ghost.id);
   });
 
   it("excludes soft-archived players from the recipient set (#XXX off-by-one fix)", async () => {
@@ -385,14 +386,14 @@ describe("getRsvpSummary (with guests)", () => {
     const guest1 = await prisma.player.create({ data: { eventId: event.id, name: "G1", order: 0 } });
     const guest2 = await prisma.player.create({ data: { eventId: event.id, name: "G2", order: 1 } });
 
-    // User RSVPs: 1 yes, 1 pending (owner)
+    // User RSVPs: 0 (follower not a player, excluded per #656), 1 pending (owner)
     await upsertRsvp(event.id, follower.id, "yes");
     // Guest RSVPs: 1 yes, 1 no, owner pending
     await upsertGuestRsvp(event.id, guest1.id, "yes", owner.id);
     await upsertGuestRsvp(event.id, guest2.id, "no", owner.id);
 
     const summary = await getRsvpSummary(event.id);
-    expect(summary.yes).toBe(2);          // follower + guest1
+    expect(summary.yes).toBe(1);          // guest1 (follower excluded)
     expect(summary.no).toBe(1);           // guest2
     expect(summary.pending).toBe(1);      // owner (no userId-guests not in recipient set)
   });


### PR DESCRIPTION
Fixes #656

## Problem
The 48h "Are you coming to X?" confirm ping and its organizer summary targeted `EventFollow ∪ active players ∪ owner`. Spectators (followers who aren't playing) received the game-reminder-style notification — noise per ADR 0017 (game reminders are players-only).

## Fix
`getRsvpRecipients` now returns owner + active linked players only; followers dropped.

## Tests
- recipient fanout test: follower excluded
- summary tests: follower RSVP no longer counted (67 RSVP tests pass)
