### PR TITLE
feat: coverage-aware pre-push feedback

### DIFF
--- a/scripts/coverage-report.sh
+++ b/scripts/coverage-report.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+# Print per-file coverage report when the coverage threshold fails.
+# Reads coverage/coverage-summary.json (produced by vitest --coverage).
+# Surfaces the specific files below threshold and their line ranges so the
+# developer knows exactly what to cover before pushing.
+
+SUMMARY="coverage/coverage-summary.json"
+THRESH_LINES="${1:-94}"
+
+if [ ! -f "$SUMMARY" ]; then
+  echo "  (no coverage-summary.json found — re-run vitest run --coverage)"
+  exit 1
+fi
+
+echo ""
+echo "Files below ${THRESH_LINES}% line coverage:"
+python3 - "$SUMMARY" "$THRESH_LINES" <<'EOF'
+import json
+import sys
+
+summary_path, thresh = sys.argv[1], float(sys.argv[2])
+data = json.load(open(summary_path))
+files = [(name, f["lines"]["pct"]) for name, f in data.items() if name != "total"]
+below = sorted([f for f in files if f[1] < thresh], key=lambda f: f[1])
+if not below:
+    print("  none — all files at or above threshold.")
+    sys.exit(0)
+
+for name, pct in below:
+    print(f"  {pct:5.1f}%  {name}")
+
+# Show uncovered line ranges for the worst offender
+if below:
+    worst = below[0][0]
+    cov = json.load(open("coverage/coverage-final.json"))
+    for path, info in cov.items():
+        if path == worst:
+            uncovered = {}
+            for idx, count in info["s"].items():
+                if count == 0:
+                    uncovered[info["statementMap"][idx]["start"]["line"]] = 1
+            ranges = []
+            lines = sorted(uncovered)
+            if lines:
+                start = prev = lines[0]
+                for ln in lines[1:]:
+                    if ln == prev + 1:
+                        prev = ln
+                    else:
+                        ranges.append(f"{start}-{prev}" if start != prev else str(start))
+                        start = prev = ln
+                ranges.append(f"{start}-{prev}" if start != prev else str(start))
+            print(f"\n  Uncovered line ranges in {worst}: {', '.join(ranges)}")
+            break
+sys.exit(1)
+EOF

--- a/scripts/pre-push.sh
+++ b/scripts/pre-push.sh
@@ -26,6 +26,9 @@ echo "→ Running tests with coverage..."
 npx vitest run --coverage
 if [ $? -ne 0 ]; then
   echo "✗ Tests failed. Push aborted."
+  echo ""
+  echo "Coverage detail (files below 94% line threshold):"
+  sh "$(dirname "$0")/coverage-report.sh" 94
   exit 1
 fi
 

--- a/src/test/merge-player.test.ts
+++ b/src/test/merge-player.test.ts
@@ -234,4 +234,66 @@ describe("POST /api/events/[id]/merge-player", () => {
     });
     expect(targetEp).not.toBeNull();
   });
+
+  it("reassigns source children to target and drops overlapping game rows", async () => {
+    const user = await prisma.user.create({ data: { id: "u1", name: "Gonçalo Silva", email: "g@t.com", emailVerified: true } });
+    const event = await seedEvent();
+    await prisma.event.update({ where: { id: event.id }, data: { ownerId: null } });
+    await prisma.playerRating.create({ data: { eventId: event.id, name: "Gonçalo", rating: 1000 } });
+    await prisma.playerRating.create({ data: { eventId: event.id, name: "Gonçalo Silva", userId: user.id, rating: 1000 } });
+
+    const game = await prisma.game.create({ data: { eventId: event.id, dateTime: new Date() } });
+    const otherGame = await prisma.game.create({ data: { eventId: event.id, dateTime: new Date(Date.now() + 86400_000) } });
+    await prisma.event.update({ where: { id: event.id }, data: { currentGameId: game.id } });
+
+    const sourceEp = await prisma.eventPlayer.create({ data: { eventId: event.id, name: "Gonçalo" } });
+    const targetEp = await prisma.eventPlayer.create({ data: { eventId: event.id, name: "Gonçalo Silva", userId: user.id } });
+
+    // Source participates in both games; target already in `game` → overlap
+    await prisma.gameParticipant.create({ data: { gameId: game.id, eventPlayerId: sourceEp.id, order: 0 } });
+    await prisma.gameParticipant.create({ data: { gameId: otherGame.id, eventPlayerId: sourceEp.id, order: 0 } });
+    await prisma.gameParticipant.create({ data: { gameId: game.id, eventPlayerId: targetEp.id, order: 1 } });
+    // Source has an RSVP answer to move + a payment to move + an overlapping RSVP to drop
+    await prisma.rsvp.create({ data: { eventPlayerId: sourceEp.id, gameId: otherGame.id, status: "yes" } });
+    await prisma.rsvp.create({ data: { eventPlayerId: sourceEp.id, gameId: game.id, status: "no" } });
+    // Target already answered on `game` → source's overlapping rsvp is dropped
+    await prisma.rsvp.create({ data: { eventPlayerId: targetEp.id, gameId: game.id, status: "yes" } });
+    await prisma.gamePayment.create({
+      data: { gameId: game.id, eventPlayerId: sourceEp.id, playerName: "Gonçalo", amount: 5, status: "paid" },
+    });
+
+    const res = await POST(ctx(event.id, { sourceName: "Gonçalo", targetName: "Gonçalo Silva" }, { isOwner: true, isAdmin: false }));
+    expect(res.status).toBe(200);
+
+    // Overlapping game: source row dropped, target's row kept
+    const gameParticipants = await prisma.gameParticipant.findMany({
+      where: { gameId: game.id },
+      include: { eventPlayer: { select: { name: true } } },
+    });
+    expect(gameParticipants).toHaveLength(1);
+    expect(gameParticipants[0].eventPlayer.name).toBe("Gonçalo Silva");
+
+    // Non-overlapping game: source participant moved to target
+    const otherParticipants = await prisma.gameParticipant.findMany({
+      where: { gameId: otherGame.id },
+      include: { eventPlayer: { select: { name: true } } },
+    });
+    expect(otherParticipants).toHaveLength(1);
+    expect(otherParticipants[0].eventPlayer.name).toBe("Gonçalo Silva");
+
+    // RSVP moved to target
+    const rsvp = await prisma.rsvp.findFirst({ where: { gameId: otherGame.id } });
+    expect(rsvp?.eventPlayerId).toBe(targetEp.id);
+    expect(rsvp?.status).toBe("yes");
+
+    // Payment moved to target
+    const payment = await prisma.gamePayment.findFirst({ where: { gameId: game.id } });
+    expect(payment?.eventPlayerId).toBe(targetEp.id);
+
+    // Ghost EventPlayer removed
+    const ghost = await prisma.eventPlayer.findUnique({
+      where: { eventId_name: { eventId: event.id, name: "Gonçalo" } },
+    });
+    expect(ghost).toBeNull();
+  });
 });


### PR DESCRIPTION
Fixes #617

## Changes
- **`scripts/coverage-report.sh`** (new): parses `coverage/coverage-summary.json` on push failure and prints:
  - every file below the 94% line threshold (sorted worst-first)
  - uncovered line ranges for the worst offender
- **`scripts/pre-push.sh`**: on coverage threshold failure, invokes the report so the developer sees exactly which files/lines need tests instead of just a bare percentage.

## Also
- Added a merge-player test covering the overlapping game-scoped merge path (participant drop, RSVP move/drop, payment reassignment). This restores the global functions threshold (89%) that the #674 merge-event-player helper had nudged below, so the pre-push hook stays green.

## Notes
- Shell script only; no runtime behavior change. CI-verified via the standard test/lint/typecheck jobs.
