### PR TITLE
fix: bump prod Docker base to node:24 (Prisma 7 rejects node:23)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:23-alpine AS base
+FROM node:24-alpine AS base
 
 RUN apk add --no-cache openssl python3 make g++
 RUN corepack enable && corepack prepare pnpm@10 --activate

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,7 +1,7 @@
 # Base image: runtime dependencies that rarely change.
 # Rebuilt only when pnpm-lock.yaml or prisma/schema.prisma change.
 # Tagged as registry.fly.io/convocados:base
-FROM node:23-alpine
+FROM node:24-alpine
 
 RUN apk add --no-cache openssl python3 make g++
 RUN corepack enable && corepack prepare pnpm@10 --activate


### PR DESCRIPTION
## Summary

The Release deploy job is failing: the Docker base image (`node:23-alpine`) can no longer run `pnpm install --frozen-lockfile --prod` because Prisma 7 requires Node 20.19+/22.12+/24.0+:

```
Prisma only supports Node.js versions 20.19+, 22.12+, 24.0+.
Please upgrade your Node.js version.
```

The stale base layer was reused from the GHA cache until a cache miss forced a full rebuild, which is why this only surfaced now. This blocked shipping #680.

## Changes

- `Dockerfile.base`: `node:23-alpine` → `node:24-alpine`
- `Dockerfile`: same bump for consistency

Node 24 matches local dev (`node -v` = 24.18.0) and every CI `setup-node` step. After merge, the Release workflow bumps to 3.122.2 and the base image rebuilds on Node 24, letting the Fly deploy go through.