### PR TITLE
feat: profile avatars for account-linked players

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,12 @@ Every change must include tests that prove the functionality works:
 - Bug fixes → Regression tests
 - Refactoring → Ensure existing tests still pass
 
+### 4. Platform Parity
+Web and the Android apps (`:app`, `:wear`) stay in sync for user-facing features. A feature
+that ships on one platform ships on the others in the **same PR** or an explicitly linked
+follow-up ticket (Wear included where the affordance exists). No "web-only" or "app-only"
+UI drift.
+
 ## Development Workflow
 
 ### First-time setup
@@ -396,6 +402,7 @@ Before submitting a PR:
 - [ ] All tests pass (`npm run test`)
 - [ ] Type checking passes (`npm run typecheck`)
 - [ ] i18n strings added to all 6 locales
+- [ ] Platform parity considered (web ↔ Android apps)
 - [ ] Database migrations included (if schema changed)
 - [ ] Documentation updated (if API changed)
 - [ ] No console errors in browser

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -43,6 +43,14 @@ EventPlayer.name is mutable (owner/admin can rename for typo fixes or disambigua
 
 _Avoid_: PlayerRating (absorbed into EventPlayer), series player
 
+## Account-linked Player
+An **EventPlayer** whose `userId` is set — the person has a Convocados **User** account. Represented in the player list by that user's profile identity (avatar, or first-initial placeholder when no image) rather than a badge: having an account is an *identity* statement, not a *protection* statement.
+
+Its complement is the **Anonymous** EventPlayer — an unlinked, name-keyed guest, shown with an anonymous glyph.
+
+Distinct from the **account-link protection rule** (a behavior, not a display): an Account-linked Player can only be removed from the list by themselves or the Event Owner/Admin.
+_Avoid_: protected player (implies a security status rather than an identity)
+
 ## Owner
 The User who created the Game or to whom ownership was transferred. Has full management control. A Game has exactly zero or one Owner.
 

--- a/android-app/app/build.gradle.kts
+++ b/android-app/app/build.gradle.kts
@@ -184,6 +184,9 @@ dependencies {
     // Accompanist (Permissions)
     implementation(libs.accompanist.permissions)
 
+    // Image loading (profile avatars)
+    implementation(libs.coil.compose)
+
     // OSM Maps
     implementation(libs.osmdroid)
 
@@ -206,5 +209,6 @@ dependencies {
     testImplementation(libs.roborazzi.compose)
     testImplementation(libs.roborazzi.junit.rule)
     testImplementation(libs.androidx.compose.ui.test.junit4)
+    testImplementation(libs.coil.test)
     debugImplementation(libs.androidx.compose.ui.test.manifest)
 }

--- a/android-app/app/src/main/java/dev/convocados/data/api/Models.kt
+++ b/android-app/app/src/main/java/dev/convocados/data/api/Models.kt
@@ -36,6 +36,7 @@ data class Player(
     val name: String,
     val order: Int,
     val userId: String? = null,
+    val image: String? = null,
     val createdAt: String = "",
 )
 

--- a/android-app/app/src/main/java/dev/convocados/data/local/entity/EventDetailEntities.kt
+++ b/android-app/app/src/main/java/dev/convocados/data/local/entity/EventDetailEntities.kt
@@ -47,7 +47,8 @@ data class PlayerEntity(
     val eventId: String,
     val name: String,
     val order: Int,
-    val userId: String?
+    val userId: String?,
+    val image: String?,
 )
 
 @Entity(
@@ -92,7 +93,8 @@ fun Player.toEntity(eventId: String) = PlayerEntity(
     eventId = eventId,
     name = name,
     order = order,
-    userId = userId
+    userId = userId,
+    image = image,
 )
 
 fun GameHistory.toEntity(eventId: String) = GameHistoryEntity(

--- a/android-app/app/src/main/java/dev/convocados/data/repository/EventRepository.kt
+++ b/android-app/app/src/main/java/dev/convocados/data/repository/EventRepository.kt
@@ -139,7 +139,7 @@ class EventRepository @Inject constructor(
     )
 
     private fun PlayerEntity.toDomain() = Player(
-        id = id, name = name, order = order, userId = userId
+        id = id, name = name, order = order, userId = userId, image = image
     )
 
     private fun GameHistoryEntity.toDomain() = GameHistory(

--- a/android-app/app/src/main/java/dev/convocados/ui/screen/event/EventDetailScreen.kt
+++ b/android-app/app/src/main/java/dev/convocados/ui/screen/event/EventDetailScreen.kt
@@ -7,13 +7,16 @@ import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.background
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.*
+import androidx.compose.material.icons.outlined.Person
 import androidx.compose.material3.*
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.*
@@ -30,8 +33,10 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import coil3.compose.SubcomposeAsyncImage
 import androidx.hilt.navigation.compose.hiltViewModel
 import dev.convocados.R
 import androidx.lifecycle.ViewModel
@@ -973,6 +978,7 @@ fun EventDetailScreen(
                             currentUserId = user?.id,
                             isOwner = isOwner,
                             onRemove = { viewModel.removePlayer(eventId, it) },
+                            onUserClick = onUserClick,
                         )
 
                         if (benchPlayers.isNotEmpty()) {
@@ -983,6 +989,7 @@ fun EventDetailScreen(
                                 isOwner = isOwner,
                                 isBench = true,
                                 onRemove = { viewModel.removePlayer(eventId, it) },
+                                onUserClick = onUserClick,
                             )
                         }
 
@@ -1300,6 +1307,7 @@ fun PlayerListCard(
     currentUserId: String?,
     isOwner: Boolean,
     onRemove: (playerId: String) -> Unit,
+    onUserClick: (userId: String) -> Unit = {},
     modifier: Modifier = Modifier,
     isBench: Boolean = false,
 ) {
@@ -1311,6 +1319,7 @@ fun PlayerListCard(
                     isMe = p.userId == currentUserId,
                     isBench = isBench,
                     onRemove = { onRemove(p.id) },
+                    onUserClick = p.userId?.let { { onUserClick(it) } } ?: {},
                     canRemove = isOwner || p.userId == currentUserId || p.userId == null,
                 )
                 if (i < players.lastIndex) HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
@@ -1335,12 +1344,59 @@ private fun EventHeaderPreview() {
     }
 }
 
+/** Round profile avatar for an account-linked player: profile image when set, else first-initial
+ *  placeholder. The image is best-effort — on load failure (or while loading) the initial
+ *  placeholder shows, so avatars never block the roster. Clickable → the user's profile screen. */
+@Composable
+fun PlayerAvatar(
+    name: String,
+    image: String?,
+    isMe: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val bg = if (isMe) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surfaceVariant
+    val fg = if (isMe) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurfaceVariant
+
+    Box(
+        modifier = modifier
+            .size(24.dp)
+            .clip(CircleShape)
+            .background(bg)
+            .clickable(onClick = onClick),
+        contentAlignment = Alignment.Center,
+    ) {
+        if (image != null) {
+            SubcomposeAsyncImage(
+                model = image,
+                contentDescription = name,
+                modifier = Modifier.fillMaxSize(),
+                loading = { PlayerInitial(name, fg) },
+                error = { PlayerInitial(name, fg) },
+            )
+        } else {
+            PlayerInitial(name, fg)
+        }
+    }
+}
+
+@Composable
+private fun PlayerInitial(name: String, color: Color) {
+    Text(
+        name.trim().take(1).uppercase(),
+        color = color,
+        style = MaterialTheme.typography.labelSmall,
+        fontWeight = FontWeight.SemiBold,
+    )
+}
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PlayerRow(
     player: Player, isMe: Boolean = false, isBench: Boolean = false,
     canRemove: Boolean = false,
     onRemove: () -> Unit = {},
+    onUserClick: () -> Unit = {},
 ) {
     ListItem(
         headlineContent = {
@@ -1354,9 +1410,19 @@ fun PlayerRow(
         },
         leadingContent = {
             if (player.userId != null) {
-                Icon(Icons.Default.Person, stringResource(R.string.linked), tint = if (isMe) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant, modifier = Modifier.size(20.dp))
+                PlayerAvatar(
+                    name = player.name,
+                    image = player.image,
+                    isMe = isMe,
+                    onClick = onUserClick,
+                )
             } else {
-                Spacer(Modifier.size(20.dp))
+                Icon(
+                    Icons.Outlined.Person,
+                    contentDescription = stringResource(R.string.anonymous_player),
+                    tint = MaterialTheme.colorScheme.outline,
+                    modifier = Modifier.size(20.dp),
+                )
             }
         },
         trailingContent = if (canRemove) {{ IconButton(onClick = onRemove, modifier = Modifier.size(32.dp)) { Icon(Icons.Default.Close, stringResource(R.string.remove), tint = MaterialTheme.colorScheme.outline, modifier = Modifier.size(16.dp)) } }} else null,

--- a/android-app/app/src/main/res/values-de/strings.xml
+++ b/android-app/app/src/main/res/values-de/strings.xml
@@ -152,6 +152,7 @@
     <string name="removed_tap_undo">%1$s entfernt — tippen zum Rückgängigmachen</string>
     <string name="vs">VS</string>
     <string name="linked">Verknüpft</string>
+    <string name="anonymous_player">Anonymer Spieler</string>
     <string name="player_moved">%1$s verschoben</string>
     <string name="undo">Rückgängig</string>
     <string name="add_score">+ Ergebnis</string>

--- a/android-app/app/src/main/res/values-es/strings.xml
+++ b/android-app/app/src/main/res/values-es/strings.xml
@@ -152,6 +152,7 @@
     <string name="removed_tap_undo">%1$s eliminado — toca para deshacer</string>
     <string name="vs">VS</string>
     <string name="linked">Vinculado</string>
+    <string name="anonymous_player">Jugador anónimo</string>
     <string name="player_moved">%1$s movido</string>
     <string name="undo">Deshacer</string>
     <string name="add_score">+ Resultado</string>

--- a/android-app/app/src/main/res/values-fr/strings.xml
+++ b/android-app/app/src/main/res/values-fr/strings.xml
@@ -152,6 +152,7 @@
     <string name="removed_tap_undo">%1$s retiré — touchez pour annuler</string>
     <string name="vs">VS</string>
     <string name="linked">Lié</string>
+    <string name="anonymous_player">Joueur anonyme</string>
     <string name="player_moved">%1$s déplacé</string>
     <string name="undo">Annuler</string>
     <string name="add_score">+ Score</string>

--- a/android-app/app/src/main/res/values-it/strings.xml
+++ b/android-app/app/src/main/res/values-it/strings.xml
@@ -152,6 +152,7 @@
     <string name="removed_tap_undo">%1$s rimosso — tocca per annullare</string>
     <string name="vs">VS</string>
     <string name="linked">Collegato</string>
+    <string name="anonymous_player">Giocatore anonimo</string>
     <string name="player_moved">%1$s spostato</string>
     <string name="undo">Annulla</string>
     <string name="add_score">+ Punteggio</string>

--- a/android-app/app/src/main/res/values-pt/strings.xml
+++ b/android-app/app/src/main/res/values-pt/strings.xml
@@ -152,6 +152,7 @@
     <string name="removed_tap_undo">%1$s removido — toca para anular</string>
     <string name="vs">VS</string>
     <string name="linked">Associado</string>
+    <string name="anonymous_player">Jogador anónimo</string>
     <string name="player_moved">%1$s movido</string>
     <string name="undo">Anular</string>
     <string name="add_score">+ Resultado</string>

--- a/android-app/app/src/main/res/values/strings.xml
+++ b/android-app/app/src/main/res/values/strings.xml
@@ -166,6 +166,7 @@
     <string name="removed_tap_undo">%1$s removed — tap to undo</string>
     <string name="vs">VS</string>
     <string name="linked">Linked</string>
+    <string name="anonymous_player">Anonymous player</string>
     <string name="player_moved">%1$s moved</string>
     <string name="added_player_confirm">Added %1$s ✓</string>
     <string name="undo">Undo</string>

--- a/android-app/app/src/test/java/dev/convocados/data/api/ModelsTest.kt
+++ b/android-app/app/src/test/java/dev/convocados/data/api/ModelsTest.kt
@@ -1,0 +1,27 @@
+package dev.convocados.data.api
+
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ModelsTest {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun `decodes profile image on a linked player`() {
+        val player = json.decodeFromString<Player>(
+            """{"id":"p1","name":"Alice","order":0,"userId":"u1","image":"https://example.com/alice.jpg","createdAt":""}"""
+        )
+        assertEquals("https://example.com/alice.jpg", player.image)
+    }
+
+    @Test
+    fun `defaults image to null when absent`() {
+        val player = json.decodeFromString<Player>(
+            """{"id":"p1","name":"Alice","order":0,"userId":"u1","createdAt":""}"""
+        )
+        assertNull(player.image)
+    }
+}

--- a/android-app/app/src/test/java/dev/convocados/i18n/StringsParityTest.kt
+++ b/android-app/app/src/test/java/dev/convocados/i18n/StringsParityTest.kt
@@ -16,6 +16,7 @@ class StringsParityTest {
         "add_player_confirm_desc_bench",
         "add_player_confirm_desc_both",
         "add_player_in_flight",
+        "anonymous_player",
     )
 
     @Test

--- a/android-app/app/src/test/java/dev/convocados/ui/screen/event/PlayerRowTest.kt
+++ b/android-app/app/src/test/java/dev/convocados/ui/screen/event/PlayerRowTest.kt
@@ -1,0 +1,87 @@
+package dev.convocados.ui.screen.event
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import coil3.ImageLoader
+import coil3.SingletonImageLoader
+import coil3.test.FakeImage
+import coil3.test.FakeImageLoaderEngine
+import dev.convocados.data.api.Player
+import dev.convocados.ui.theme.ConvocadosTheme
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.GraphicsMode
+
+@RunWith(RobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class PlayerRowTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Before
+    @Suppress("DEPRECATION") // FakeImage is deprecated in favor of coil-core ColorImage
+    fun setUpImageLoader() {
+        // Deterministic image loading for AsyncImage — never hits the network.
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        SingletonImageLoader.setUnsafe(
+            ImageLoader.Builder(context)
+                .components { add(FakeImageLoaderEngine.Builder().default(FakeImage()).build()) }
+                .build()
+        )
+    }
+
+    @Test
+    fun `linked player without image shows first-initial avatar`() {
+        composeRule.setContent {
+            ConvocadosTheme {
+                PlayerRow(player = Player("p1", "Alice", 0, userId = "u1", image = null), onUserClick = {})
+            }
+        }
+        composeRule.onNodeWithText("A").assertIsDisplayed()
+    }
+
+    @Test
+    fun `linked player with image renders an avatar image`() {
+        composeRule.setContent {
+            ConvocadosTheme {
+                PlayerRow(player = Player("p1", "Alice", 0, userId = "u1", image = "https://example.com/alice.jpg"), onUserClick = {})
+            }
+        }
+        composeRule.onNodeWithContentDescription("Alice").assertIsDisplayed()
+    }
+
+    @Test
+    fun `anonymous player shows anonymous icon`() {
+        composeRule.setContent {
+            ConvocadosTheme {
+                PlayerRow(player = Player("p1", "Carol", 0, userId = null, image = null))
+            }
+        }
+        composeRule.onNodeWithContentDescription("Anonymous player").assertIsDisplayed()
+    }
+
+    @Test
+    fun `avatar click invokes onUserClick for a linked player`() {
+        var clicked = false
+        composeRule.setContent {
+            ConvocadosTheme {
+                PlayerRow(
+                    player = Player("p1", "Alice", 0, userId = "u1", image = null),
+                    onUserClick = { clicked = true },
+                )
+            }
+        }
+        composeRule.onNodeWithText("A").performClick()
+        assertTrue(clicked)
+    }
+}

--- a/android-app/gradle/libs.versions.toml
+++ b/android-app/gradle/libs.versions.toml
@@ -38,6 +38,7 @@ roborazzi = "1.70.0"
 robolectric = "4.16.1"
 osmdroid = "6.1.20"
 kotlinxCoroutinesTest = "1.11.0"
+coil = "3.2.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "androidxCore" }
@@ -110,6 +111,8 @@ roborazzi-junit-rule = { group = "io.github.takahirom.roborazzi", name = "robora
 robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
 androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
+coil-compose = { group = "io.coil-kt.coil3", name = "coil-compose", version.ref = "coil" }
+coil-test = { group = "io.coil-kt.coil3", name = "coil-test", version.ref = "coil" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/src/components/EventPage.tsx
+++ b/src/components/EventPage.tsx
@@ -212,6 +212,7 @@ export default function EventPage({ eventId }: { eventId: string }) {
         name: p.name,
         gamesPlayed: p.gamesPlayed ?? 1,
         userId: p.userId ?? null,
+        image: p.image ?? null,
       }))
       .sort((a, b) => {
         if (qjName && a.name.toLowerCase() === qjName.toLowerCase()) return -1;

--- a/src/components/HistoryPage.tsx
+++ b/src/components/HistoryPage.tsx
@@ -30,7 +30,7 @@ interface AddHistoricalGameDialogProps {
   eventId: string;
   defaultTeamOneName: string;
   defaultTeamTwoName: string;
-  knownPlayers: { name: string; gamesPlayed: number; userId?: string | null }[];
+  knownPlayers: { name: string; gamesPlayed: number; userId?: string | null; image?: string | null }[];
   playerRatings: { name: string; rating: number; gamesPlayed: number }[];
   onSuccess: (entry: HistoryEntry) => void;
 }
@@ -327,7 +327,7 @@ export default function HistoryPage({ eventId }: { eventId: string }) {
   const [nextCursor, setNextCursor] = useState<string | null>(null);
   const [hasMore, setHasMore] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
-  const [knownPlayers, setKnownPlayers] = useState<{ name: string; gamesPlayed: number; userId?: string | null }[]>([]);
+  const [knownPlayers, setKnownPlayers] = useState<{ name: string; gamesPlayed: number; userId?: string | null; image?: string | null }[]>([]);
   const [playerRatings, setPlayerRatings] = useState<{ name: string; rating: number; gamesPlayed: number }[]>([]);
   const [ownerId, setOwnerId] = useState<string | null>(null);
   const [isAdmin, setIsAdmin] = useState(false);
@@ -370,19 +370,19 @@ export default function HistoryPage({ eventId }: { eventId: string }) {
 
     // Fetch known players (historical) and ratings in parallel (non-blocking)
     // Combine current event players with historical players for suggestions
-    const currentPlayers = (ev.players ?? []).map((p: { name: string }) => ({ name: p.name, gamesPlayed: -1, userId: null })); // -1 indicates current player
+    const currentPlayers = (ev.players ?? []).map((p: { name: string; image?: string | null }) => ({ name: p.name, gamesPlayed: -1, userId: null, image: p.image ?? null })); // -1 indicates current player
     Promise.all([
       fetch(`/api/events/${eventId}/known-players`).then((r) => r.json()).catch(() => ({ players: [] })),
       fetch(`/api/events/${eventId}/ratings`).then((r) => r.json()).catch(() => ({ data: [] })),
     ]).then(([kp, ratings]) => {
       // Combine current players with historical players, deduping by name
-      const allPlayersMap = new Map<string, { name: string; gamesPlayed: number; userId: string | null }>();
+      const allPlayersMap = new Map<string, { name: string; gamesPlayed: number; userId: string | null; image: string | null }>();
       // Current players first (they get priority)
-      currentPlayers.forEach((p: { name: string; gamesPlayed: number; userId: string | null }) => allPlayersMap.set(p.name.toLowerCase(), p));
+      currentPlayers.forEach((p: { name: string; gamesPlayed: number; userId: string | null; image: string | null }) => allPlayersMap.set(p.name.toLowerCase(), p));
       // Historical players (only if not already in current)
-      (kp.players ?? []).forEach((p: { name: string; gamesPlayed: number; userId?: string | null }) => {
+      (kp.players ?? []).forEach((p: { name: string; gamesPlayed: number; userId?: string | null; image?: string | null }) => {
         if (!allPlayersMap.has(p.name.toLowerCase())) {
-          allPlayersMap.set(p.name.toLowerCase(), { name: p.name, gamesPlayed: p.gamesPlayed, userId: p.userId ?? null });
+          allPlayersMap.set(p.name.toLowerCase(), { name: p.name, gamesPlayed: p.gamesPlayed, userId: p.userId ?? null, image: p.image ?? null });
         }
       });
       setKnownPlayers(Array.from(allPlayersMap.values()));

--- a/src/components/event/PlayerAutocomplete.tsx
+++ b/src/components/event/PlayerAutocomplete.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import { TextField, Autocomplete, InputAdornment, IconButton, Tooltip, Box } from "@mui/material";
 import PersonAddIcon from "@mui/icons-material/PersonAdd";
-import ShieldIcon from "@mui/icons-material/Shield";
 import { useT } from "~/lib/useT";
 import { matchesWithName } from "~/lib/stringMatch";
+import { PlayerAvatar, AnonymousPlayerIcon } from "./PlayerIdentity";
 import type { PlayerOption } from "./types";
 import type { AddPlayerIntent } from "./AddPlayerConfirmDialog";
 
@@ -14,7 +14,7 @@ interface Props {
   onAdd: (name: string) => void;
   /** Confirm-required add (dropdown row tap). Optional — falls back to onAdd. */
   onRequestAdd?: (intent: AddPlayerIntent) => void;
-  suggestions: { name: string; gamesPlayed: number; userId?: string | null }[];
+  suggestions: { name: string; gamesPlayed: number; userId?: string | null; image?: string | null }[];
   disabled?: boolean;
   label?: string;
 }
@@ -39,6 +39,7 @@ export function PlayerAutocomplete({ value, onChange, onAdd, onRequestAdd, sugge
             name: s.name,
             gamesPlayed: s.gamesPlayed,
             userId: s.userId ?? null,
+            image: s.image ?? null,
           }));
         if (trimmed && !filtered.some((o) => o.name.toLowerCase() === trimmed.toLowerCase())) {
           filtered.push({ type: "create" as const, name: trimmed });
@@ -116,9 +117,13 @@ export function PlayerAutocomplete({ value, onChange, onAdd, onRequestAdd, sugge
             <Box sx={{ display: "flex", alignItems: "center", gap: 0.5, minWidth: 0, overflow: "hidden" }}>
               {option.userId ? (
                 <Tooltip title={t("protectedPlayer")}>
-                  <ShieldIcon fontSize="small" sx={{ color: "primary.main", flexShrink: 0 }} />
+                  <span><PlayerAvatar userId={option.userId} name={option.name} image={option.image} size={20} clickable={false} /></span>
                 </Tooltip>
-              ) : null}
+              ) : (
+                <Tooltip title={t("anonymousPlayer")}>
+                  <span><AnonymousPlayerIcon /></span>
+                </Tooltip>
+              )}
               <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{option.name}</span>
             </Box>
             {option.gamesPlayed > 0 && (

--- a/src/components/event/PlayerIdentity.tsx
+++ b/src/components/event/PlayerIdentity.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { Avatar, Link } from "@mui/material";
+import Person2OutlinedIcon from "@mui/icons-material/Person2Outlined";
+
+/** Round profile avatar for an account-linked player: image when set, else first-initial
+ *  placeholder. Clickable (default) → the user's profile page. Anonymous players get a
+ *  muted silhouette instead (AnonymousPlayerIcon). */
+export function PlayerAvatar({
+  userId, name, image, size = 22, clickable = true,
+}: { userId?: string | null; name: string; image?: string | null; size?: number; clickable?: boolean }) {
+  const avatar = (
+    <Avatar
+      alt={name}
+      src={image ?? undefined}
+      slotProps={{ img: { loading: "lazy" } }}
+      sx={{
+        width: size,
+        height: size,
+        fontSize: Math.max(10, Math.round(size * 0.5)),
+        bgcolor: "primary.main",
+        color: "primary.contrastText",
+        flexShrink: 0,
+      }}
+    >
+      {name[0]?.toUpperCase()}
+    </Avatar>
+  );
+  if (!userId || !clickable) return avatar;
+  return (
+    <Link href={`/users/${userId}`} sx={{ display: "inline-flex", textDecoration: "none", alignItems: "center" }} aria-label={name}>
+      {avatar}
+    </Link>
+  );
+}
+
+/** Muted silhouette marking a player with no linked account. */
+export function AnonymousPlayerIcon({ size = 20 }: { size?: number }) {
+  return (
+    <Person2OutlinedIcon sx={{ color: "text.disabled", width: size, height: size, flexShrink: 0 }} />
+  );
+}

--- a/src/components/event/PlayerList.tsx
+++ b/src/components/event/PlayerList.tsx
@@ -10,7 +10,6 @@ import ShuffleIcon from "@mui/icons-material/Shuffle";
 import CloseIcon from "@mui/icons-material/Close";
 import AirlineSeatReclineNormalIcon from "@mui/icons-material/AirlineSeatReclineNormal";
 import DragIndicatorIcon from "@mui/icons-material/DragIndicator";
-import ShieldIcon from "@mui/icons-material/Shield";
 import ContactsIcon from "@mui/icons-material/Contacts";
 import HowToRegIcon from "@mui/icons-material/HowToReg";
 import CancelIcon from "@mui/icons-material/Cancel";
@@ -19,6 +18,7 @@ import BackspaceIcon from "@mui/icons-material/Backspace";
 import RestartAltIcon from "@mui/icons-material/RestartAlt";
 import { useT } from "~/lib/useT";
 import { matchesWithName } from "~/lib/stringMatch";
+import { PlayerAvatar, AnonymousPlayerIcon } from "./PlayerIdentity";
 import type { Player, PlayerOption } from "./types";
 import type { AddPlayerIntent } from "./AddPlayerConfirmDialog";
 import { ConfirmLeaveDialog, type LeaveContext } from "./ConfirmLeaveDialog";
@@ -52,6 +52,7 @@ interface PlayerSuggestion {
   name: string;
   gamesPlayed: number;
   userId?: string | null;
+  image?: string | null;
 }
 
 interface Props {
@@ -328,6 +329,7 @@ export function PlayerList({
                   name: s.name,
                   gamesPlayed: s.gamesPlayed,
                   userId: s.userId ?? null,
+                  image: s.image ?? null,
                 }));
               // Add "Create new player" option when input doesn't exactly match an existing suggestion
               if (trimmed && !filtered.some((o) => o.name.toLowerCase() === trimmed.toLowerCase())) {
@@ -445,9 +447,13 @@ export function PlayerList({
                   <Box sx={{ display: "flex", alignItems: "center", gap: 0.5, minWidth: 0, overflow: "hidden" }}>
                     {option.userId ? (
                       <Tooltip title={t("protectedPlayer")}>
-                        <ShieldIcon fontSize="small" sx={{ color: "primary.main", flexShrink: 0 }} />
+                        <span><PlayerAvatar userId={option.userId} name={option.name} image={option.image} size={20} clickable={false} /></span>
                       </Tooltip>
-                    ) : null}
+                    ) : (
+                      <Tooltip title={t("anonymousPlayer")}>
+                        <span><AnonymousPlayerIcon /></span>
+                      </Tooltip>
+                    )}
                     <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{option.name}</span>
                   </Box>
                   {option.gamesPlayed > 0 && (
@@ -502,7 +508,9 @@ export function PlayerList({
               {availableSuggestions.slice(0, 12).map((s) => (
                 <Chip
                   key={s.name}
-                  icon={s.userId ? <ShieldIcon sx={{ color: "primary.main !important" }} /> : undefined}
+                  icon={s.userId
+                    ? <PlayerAvatar userId={s.userId} name={s.name} image={s.image} size={18} clickable={false} />
+                    : <AnonymousPlayerIcon size={18} />}
                   label={s.name}
                   variant="outlined"
                   size="small"
@@ -513,7 +521,7 @@ export function PlayerList({
                       onAddPlayer(s.name);
                     }
                   }}
-                  title={s.userId ? t("protectedPlayer") : undefined}
+                  title={s.userId ? t("protectedPlayer") : t("anonymousPlayer")}
                   sx={{
                     cursor: "pointer",
                     "&:hover": { backgroundColor: alpha(theme.palette.primary.main, 0.1) },
@@ -577,10 +585,18 @@ export function PlayerList({
                     <DragIndicatorIcon fontSize="small" sx={{ color: "text.disabled", mr: 0.5, flexShrink: 0 }} />
                   )}
                   {player.userId ? (
-                     <Tooltip title={t("protectedPlayer")}>
-                       <ShieldIcon fontSize="small" sx={{ color: "primary.main", mr: 0.5, flexShrink: 0 }} />
-                     </Tooltip>
-                   ) : null}
+                    <Tooltip title={t("protectedPlayer")}>
+                      <span style={{ display: "inline-flex", alignItems: "center", marginRight: 4 }}>
+                        <PlayerAvatar userId={player.userId} name={player.name} image={player.image} />
+                      </span>
+                    </Tooltip>
+                  ) : (
+                    <Tooltip title={t("anonymousPlayer")}>
+                      <span style={{ display: "inline-flex", alignItems: "center", marginRight: 4 }}>
+                        <AnonymousPlayerIcon />
+                      </span>
+                    </Tooltip>
+                  )}
                    <ListItemText
                      primary={player.userId ? (
                        <a href={`/users/${player.userId}`} style={{ textDecoration: "none", color: "inherit", fontWeight: 500 }}>
@@ -643,9 +659,17 @@ export function PlayerList({
                       )}
                       {player.userId ? (
                         <Tooltip title={t("protectedPlayer")}>
-                          <ShieldIcon fontSize="small" sx={{ color: "warning.main", mr: 0.5, flexShrink: 0 }} />
+                          <span style={{ display: "inline-flex", alignItems: "center", marginRight: 4 }}>
+                            <PlayerAvatar userId={player.userId} name={player.name} image={player.image} />
+                          </span>
                         </Tooltip>
-                      ) : null}
+                      ) : (
+                        <Tooltip title={t("anonymousPlayer")}>
+                          <span style={{ display: "inline-flex", alignItems: "center", marginRight: 4 }}>
+                            <AnonymousPlayerIcon />
+                          </span>
+                        </Tooltip>
+                      )}
                       <ListItemText
                         primary={player.userId ? (
                           <a href={`/users/${player.userId}`} style={{ textDecoration: "none", color: "inherit", fontWeight: 500 }}>

--- a/src/components/event/types.ts
+++ b/src/components/event/types.ts
@@ -2,6 +2,7 @@ export interface Player {
   id: string;
   name: string;
   userId?: string | null;
+  image?: string | null;
 }
 
 export interface TeamMember {
@@ -56,9 +57,11 @@ export interface KnownPlayer {
   gamesPlayed?: number;
   /** When non-null, the suggestion matches a registered user account by name. */
   userId?: string | null;
+  /** Profile image of the linked user account, if any. */
+  image?: string | null;
 }
 
 /** Option type for the player Autocomplete: either an existing player or a "create new" action. */
 export type PlayerOption =
-  | { type: "existing"; name: string; gamesPlayed: number; userId: string | null }
+  | { type: "existing"; name: string; gamesPlayed: number; userId: string | null; image?: string | null }
   | { type: "create"; name: string };

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -371,6 +371,7 @@ const de: TranslationKeys = {
   undoRemoveDesc: "{name} entfernt",
   undoExpired: "Rückgängig-Zeitfenster abgelaufen.",
   protectedPlayer: "Kontogebundener Spieler",
+  anonymousPlayer: "Anonymer Spieler",
   ownerOnly: "Nur der Event-Eigentümer kann dies tun.",
   relinquishOwnership: "Als Eigentümer zurücktreten",
   relinquishOwnershipDesc: "Das Event wird eigentümerlos und jeder kann es beanspruchen.",

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -406,6 +406,7 @@ const en = {
   undoRemoveDesc: "{name} removed",
   undoExpired: "Undo window expired.",
   protectedPlayer: "Account-linked player",
+  anonymousPlayer: "Anonymous player",
   ownerOnly: "Only the event owner can do this.",
   relinquishOwnership: "Leave as owner",
   relinquishOwnershipDesc: "The event will become ownerless and anyone can claim it.",

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -371,6 +371,7 @@ const es: TranslationKeys = {
   undoRemoveDesc: "{name} eliminado",
   undoExpired: "Tiempo para deshacer expirado.",
   protectedPlayer: "Jugador con cuenta",
+  anonymousPlayer: "Jugador anónimo",
   ownerOnly: "Solo el dueño del evento puede hacer esto.",
   relinquishOwnership: "Dejar de ser dueño",
   relinquishOwnershipDesc: "El evento quedará sin dueño y cualquiera podrá reclamarlo.",

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -371,6 +371,7 @@ const fr: TranslationKeys = {
   undoRemoveDesc: "{name} supprimé",
   undoExpired: "Délai d'annulation expiré.",
   protectedPlayer: "Joueur avec compte",
+  anonymousPlayer: "Joueur anonyme",
   ownerOnly: "Seul le propriétaire de l'événement peut faire cela.",
   relinquishOwnership: "Quitter en tant que propriétaire",
   relinquishOwnershipDesc: "L'événement n'aura plus de propriétaire et n'importe qui pourra le revendiquer.",

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -371,6 +371,7 @@ const it: TranslationKeys = {
   undoRemoveDesc: "{name} rimosso",
   undoExpired: "Tempo per annullare scaduto.",
   protectedPlayer: "Giocatore con account",
+  anonymousPlayer: "Giocatore anonimo",
   ownerOnly: "Solo il proprietario dell'evento può farlo.",
   relinquishOwnership: "Lascia come proprietario",
   relinquishOwnershipDesc: "L'evento rimarrà senza proprietario e chiunque potrà rivendicarlo.",

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -408,6 +408,7 @@ const pt: TranslationKeys = {
   undoRemoveDesc: "{name} removido",
   undoExpired: "Tempo para desfazer expirou.",
   protectedPlayer: "Jogador com conta",
+  anonymousPlayer: "Jogador anónimo",
   ownerOnly: "Apenas o dono do evento pode fazer isto.",
   relinquishOwnership: "Deixar de ser dono",
   relinquishOwnershipDesc: "O evento ficará sem dono e qualquer pessoa pode reclamá-lo.",

--- a/src/pages/api/events/[id]/index.ts
+++ b/src/pages/api/events/[id]/index.ts
@@ -11,7 +11,7 @@ export const GET: APIRoute = async ({ params, request }) => {
   const event = await prisma.event.findUnique({
     where: { id: params.id },
     include: {
-      players: { where: { archivedAt: null }, orderBy: { order: "asc" } },
+      players: { where: { archivedAt: null }, orderBy: { order: "asc" }, include: { user: { select: { image: true } } } },
       teamResults: { include: { members: { orderBy: { order: "asc" } } } },
       owner: { select: { id: true, name: true } },
     },
@@ -203,16 +203,33 @@ export const GET: APIRoute = async ({ params, request }) => {
         .map((p) => [p.name, p.userId]),
     );
 
-    playersPayload = participants.map((gp) => ({
-      id: gp.eventPlayer.id,
-      name: gp.eventPlayer.name,
-      order: gp.order,
-      eventId: gp.eventPlayer.eventId,
-      userId: gp.eventPlayer.userId ?? playersByName.get(gp.eventPlayer.name) ?? null,
-      createdAt: gp.createdAt.toISOString(),
-    }));
+    // EventPlayer has no Prisma relation to User, so resolve profile images in
+    // one batch query keyed by the resolved userId (account-linked identity).
+    const linkedUserIds = [...new Set(participants.map((gp) => gp.eventPlayer.userId ?? playersByName.get(gp.eventPlayer.name)))].filter((u): u is string => !!u);
+    const linkedUsers = linkedUserIds.length
+      ? await prisma.user.findMany({ where: { id: { in: linkedUserIds } }, select: { id: true, image: true } })
+      : [];
+    const imageByUserId = new Map(linkedUsers.map((u) => [u.id, u.image]));
+
+    playersPayload = participants.map((gp) => {
+      const userId = gp.eventPlayer.userId ?? playersByName.get(gp.eventPlayer.name) ?? null;
+      return {
+        id: gp.eventPlayer.id,
+        name: gp.eventPlayer.name,
+        order: gp.order,
+        eventId: gp.eventPlayer.eventId,
+        userId,
+        image: userId ? (imageByUserId.get(userId) ?? null) : null,
+        createdAt: gp.createdAt.toISOString(),
+      };
+    });
   } else {
-    playersPayload = event.players.map((p) => ({ ...p, userId: p.userId ?? null, createdAt: p.createdAt.toISOString() }));
+    playersPayload = event.players.map(({ user, ...p }) => ({
+      ...p,
+      userId: p.userId ?? null,
+      image: user?.image ?? null,
+      createdAt: p.createdAt.toISOString(),
+    }));
   }
 
   // ADR 0016: include current game status for the UI

--- a/src/pages/api/events/[id]/known-players.ts
+++ b/src/pages/api/events/[id]/known-players.ts
@@ -71,5 +71,18 @@ export const GET: APIRoute = async ({ params, request }) => {
     .sort((a, b) => b.gamesPlayed - a.gamesPlayed)
     .slice(0, 30);
 
-  return Response.json({ players });
+  // Resolve profile images for account-linked suggestions in one batch query
+  // (EventPlayer has no Prisma relation to User).
+  const linkedIds = [...new Set(players.map((p) => p.userId).filter((u): u is string => !!u))];
+  const users = linkedIds.length
+    ? await prisma.user.findMany({ where: { id: { in: linkedIds } }, select: { id: true, image: true } })
+    : [];
+  const imageByUserId = new Map(users.map((u) => [u.id, u.image]));
+
+  const payload = players.map((p) => ({
+    ...p,
+    image: p.userId ? (imageByUserId.get(p.userId) ?? null) : null,
+  }));
+
+  return Response.json({ players: payload });
 };

--- a/src/test/api.test.ts
+++ b/src/test/api.test.ts
@@ -262,6 +262,41 @@ describe("GET /api/events/[id]", () => {
     expect(editableUntil).toBeLessThanOrEqual(sevenDaysFromNow + 5000);
     expect(editableUntil > Date.now()).toBe(true);
   });
+
+  it("includes user image on linked players and null for guests (legacy branch)", async () => {
+    const id = await seedEvent();
+    await prisma.user.create({
+      data: { id: "u-img", name: "Alice", email: "alice-img@t.com", emailVerified: true, image: "https://example.com/alice.jpg" },
+    });
+    await prisma.player.createMany({
+      data: [
+        { name: "Alice", eventId: id, userId: "u-img", order: 0 },
+        { name: "Guest", eventId: id, userId: null, order: 1 },
+      ],
+    });
+    const res = await getEvent(ctx({ id }));
+    const body = await res.json();
+    const byName = Object.fromEntries(body.players.map((p: any) => [p.name, p]));
+    expect(byName["Alice"].image).toBe("https://example.com/alice.jpg");
+    expect(byName["Guest"].image).toBeNull();
+  });
+
+  it("includes user image on players in the currentGameId (GameParticipant) branch", async () => {
+    const id = await seedEvent();
+    await prisma.user.create({
+      data: { id: "u-gp", name: "Carol", email: "carol-gp@t.com", emailVerified: true, image: "https://example.com/carol.jpg" },
+    });
+    const game = await prisma.game.create({
+      data: { eventId: id, dateTime: new Date(Date.now() + 86400_000), status: "upcoming" },
+    });
+    await prisma.event.update({ where: { id }, data: { currentGameId: game.id } });
+    const ep = await prisma.eventPlayer.create({ data: { eventId: id, name: "Carol", userId: "u-gp" } });
+    await prisma.gameParticipant.create({ data: { gameId: game.id, eventPlayerId: ep.id, order: 0 } });
+    const res = await getEvent(ctx({ id }));
+    const body = await res.json();
+    const byName = Object.fromEntries(body.players.map((p: any) => [p.name, p]));
+    expect(byName["Carol"].image).toBe("https://example.com/carol.jpg");
+  });
 });
 
 // ─── POST /api/events/[id]/players ──────────────────────────────────────────
@@ -861,6 +896,38 @@ describe("GET /api/events/[id]/known-players", () => {
     const res = await getKnownPlayers(ctx({ id }));
     const body = await res.json();
     expect(body.players[0].userId).toBeNull();
+  });
+
+  it("annotates suggestions with profile image for linked EventPlayers", async () => {
+    const id = await seedEvent();
+    await prisma.user.create({
+      data: { id: "u-kp", name: "Gonçalo", email: "kp-img@t.com", emailVerified: true, image: "https://example.com/goncalo.jpg" },
+    });
+    await seedEventPlayer(id, "Gonçalo", 1, "u-kp");
+    const res = await getKnownPlayers(ctx({ id }));
+    const body = await res.json();
+    expect(body.players[0].image).toBe("https://example.com/goncalo.jpg");
+  });
+
+  it("leaves image null for anonymous suggestions", async () => {
+    const id = await seedEvent();
+    await seedEventPlayer(id, "Bob");
+    const res = await getKnownPlayers(ctx({ id }));
+    const body = await res.json();
+    expect(body.players[0].userId).toBeNull();
+    expect(body.players[0].image).toBeNull();
+  });
+
+  it("annotates suggestions with profile image for follower-derived names", async () => {
+    const id = await seedEvent();
+    await prisma.user.create({
+      data: { id: "u-fol", name: "Follower", email: "fol-img@t.com", emailVerified: true, image: "https://example.com/follower.jpg" },
+    });
+    await prisma.eventFollow.create({ data: { eventId: id, userId: "u-fol" } });
+    const res = await getKnownPlayers(ctx({ id }));
+    const body = await res.json();
+    const byName = Object.fromEntries(body.players.map((p: any) => [p.name, p]));
+    expect(byName["Follower"].image).toBe("https://example.com/follower.jpg");
   });
 });
 

--- a/src/test/components/PlayerAutocomplete.test.tsx
+++ b/src/test/components/PlayerAutocomplete.test.tsx
@@ -93,3 +93,33 @@ describe("PlayerAutocomplete — confirmation dialog trigger", () => {
     expect(onAdd).toHaveBeenCalledWith("Alice");
   });
 });
+
+describe("PlayerAutocomplete — player identity (avatar / anonymous icon)", () => {
+  interface IdentityHarnessProps {
+    onAdd: (name: string) => void;
+    suggestions: { name: string; gamesPlayed: number; userId?: string | null; image?: string | null }[];
+  }
+  function IdentityHarness({ onAdd, suggestions }: IdentityHarnessProps) {
+    const [value, setValue] = useState("");
+    return <PlayerAutocomplete value={value} onChange={setValue} onAdd={onAdd} suggestions={suggestions} />;
+  }
+
+  it("renders the profile avatar for a linked suggestion and the anonymous icon for a guest", async () => {
+    const user = userEvent.setup();
+    const onAdd = vi.fn();
+    const suggestions = [
+      { name: "Linked", gamesPlayed: 2, userId: "u-x", image: "https://example.com/linked.jpg" },
+      { name: "Anon", gamesPlayed: 1, userId: null, image: null },
+    ];
+    renderWithTheme(<IdentityHarness onAdd={onAdd} suggestions={suggestions} />);
+    const input = screen.getByPlaceholderText(/add player name/i);
+    await user.click(input);
+    await user.type(input, "Lin");
+    const option = await screen.findByRole("option", { name: /Linked/ });
+    expect(option.querySelector("img")).toHaveAttribute("src", "https://example.com/linked.jpg");
+    await user.clear(input);
+    await user.type(input, "Anon");
+    const anonOption = await screen.findByRole("option", { name: /Anon/ });
+    expect(anonOption.querySelector('[data-testid="Person2OutlinedIcon"]')).not.toBeNull();
+  });
+});

--- a/src/test/components/PlayerList.test.tsx
+++ b/src/test/components/PlayerList.test.tsx
@@ -105,6 +105,79 @@ describe("PlayerList — confirmation dialog trigger", () => {
   });
 });
 
+describe("PlayerList — player identity (avatar / anonymous icon)", () => {
+  const linkedWithImage: Player = { id: "p-img", name: "Alice", userId: "u-1", image: "https://example.com/alice.jpg" };
+  const linkedNoImage: Player = { id: "p-nimg", name: "Bob", userId: "u-2", image: null };
+  const guest: Player = { id: "p-guest", name: "Carol", userId: null };
+
+  it("renders the profile avatar with image for a linked player", () => {
+    renderWithTheme(<PlayerList {...baseProps} players={[linkedWithImage]} availableSuggestions={[]} />);
+    const img = screen.getByRole("img", { name: "Alice" });
+    expect(img).toHaveAttribute("src", "https://example.com/alice.jpg");
+    expect(screen.queryByTestId("Person2OutlinedIcon")).toBeNull();
+  });
+
+  it("links the avatar to the user's profile page", () => {
+    renderWithTheme(<PlayerList {...baseProps} players={[linkedWithImage]} availableSuggestions={[]} />);
+    const img = screen.getByRole("img", { name: "Alice" });
+    expect(img.closest("a")).toHaveAttribute("href", "/users/u-1");
+  });
+
+  it("renders an initial-letter avatar for a linked player without image", () => {
+    renderWithTheme(<PlayerList {...baseProps} players={[linkedNoImage]} availableSuggestions={[]} />);
+    expect(screen.getByText("B")).toBeInTheDocument();
+    expect(screen.queryByRole("img")).toBeNull();
+  });
+
+  it("renders the anonymous icon for a guest player", () => {
+    renderWithTheme(<PlayerList {...baseProps} players={[guest]} availableSuggestions={[]} />);
+    expect(screen.getByTestId("Person2OutlinedIcon")).toBeInTheDocument();
+  });
+
+  it("renders identity markers in the bench list", () => {
+    const players: Player[] = [];
+    for (let i = 0; i < 11; i++) {
+      players.push({
+        id: `p${i}`,
+        name: `P${i}`,
+        userId: i === 10 ? "u-10" : null,
+        image: i === 10 ? "https://example.com/p10.jpg" : null,
+      });
+    }
+    renderWithTheme(<PlayerList {...baseProps} players={players} />);
+    expect(screen.getByRole("img", { name: "P10" })).toBeInTheDocument();
+    expect(screen.getAllByTestId("Person2OutlinedIcon").length).toBeGreaterThan(0);
+  });
+
+  it("renders avatar/anonymous markers in the recent-players chips", () => {
+    const suggestions = [
+      { name: "Linked", gamesPlayed: 2, userId: "u-x", image: "https://example.com/linked.jpg" },
+      { name: "Anon", gamesPlayed: 1, userId: null, image: null },
+    ];
+    renderWithTheme(<PlayerList {...baseProps} players={[]} availableSuggestions={suggestions} />);
+    expect(screen.getByRole("img", { name: "Linked" })).toBeInTheDocument();
+    expect(screen.getByTestId("Person2OutlinedIcon")).toBeInTheDocument();
+  });
+
+  it("renders avatar/anonymous markers in the add-player dropdown options", async () => {
+    const user = userEvent.setup();
+    const suggestions = [
+      { name: "Linked", gamesPlayed: 2, userId: "u-x", image: "https://example.com/linked.jpg" },
+      { name: "Anon", gamesPlayed: 1, userId: null, image: null },
+    ];
+    renderWithTheme(<PlayerList {...baseProps} players={[]} availableSuggestions={suggestions} />);
+    const input = screen.getByPlaceholderText(/add player/i);
+    await user.click(input);
+    await user.type(input, "Lin");
+    const option = await screen.findByRole("option", { name: /Linked/ });
+    expect(option.querySelector("img")).toHaveAttribute("src", "https://example.com/linked.jpg");
+    await user.clear(input);
+    await user.type(input, "Anon");
+    const anonOption = await screen.findByRole("option", { name: /Anon/ });
+    expect(anonOption.querySelector('[data-testid="Person2OutlinedIcon"]')).not.toBeNull();
+  });
+});
+
 describe.skip("PlayerList — attendance UI (You row + guest pill)", () => {
   const linkedPlayer: Player = { id: "p-linked", name: "LinkedAlice", userId: "u-1" };
   const guestPlayer: Player = { id: "p-guest", name: "GuestBob", userId: null };


### PR DESCRIPTION
## Summary

Replace the ShieldIcon "Account-linked player" badge with the player's **profile identity**:
a round avatar (profile image, or first-initial placeholder) for account-linked players, and a
muted anonymous silhouette for guests. Matches web + Android `:app` (platform parity).

## Changes

- **API**: `GET /api/events/[id]` (both players-payload branches) and `GET /api/events/[id]/known-players`
  now return `image` from `User.image` for linked players, `null` for anonymous. No migration.
- **Web** `PlayerList` (active rows, bench, add-player dropdown, recent chips) + `PlayerAutocomplete`
  (HistoryPage): avatar/anonymous icon in all surfaces; avatar links to `/users/:id` (non-clickable in
  dropdown/chips so it can't swallow the add action). Images lazy-loaded, initial fallback on error.
- **Android `:app`**: `PlayerRow` renders avatar via Coil `SubcomposeAsyncImage` with initial fallback
  on loading/error (images best-effort, never block the roster); avatar click opens the user profile.
  `Player`/`PlayerEntity` carry `image` through the Room cache. `Icons.Outlined.Person` for anonymous.
- **i18n**: `anonymousPlayer` tooltip in all 6 web locales + Android `anonymous_player` × 6 locales.
- **Docs**: AGENTS.md "Platform Parity" principle + checklist item; CONTEXT.md "Account-linked Player"
  glossary entry.

## Not in scope

- **Wear**: no account-linked affordance exists there (name-only chips). Follow-up ticket if desired.
- Profile-image upload (only OAuth `User.image` used).

## Tests

- Web: API `image` assertions (both payload branches + known-players), PlayerList + PlayerAutocomplete
  identity rendering (7 + 1 tests). Full web suite 3119 passed; typecheck + lint clean.
- Android: `Player` serialization (2), `PlayerRow` avatar/anonymous/click (4). Android `:app` unit tests
  pass except two pre-existing environment-broken classes (StringsParityTest, DateFormatterTest) that
  fail identically on `main`; `:wear` has a pre-existing test-compile failure on `main` (untouched).