### PR TITLE
fix: scheduler heartbeat staleness must not fail health check

### DIFF
--- a/src/pages/api/health.ts
+++ b/src/pages/api/health.ts
@@ -36,7 +36,11 @@ export const GET: APIRoute = async () => {
       }
       response.litestream = { running };
 
-      // Check the scheduler heartbeat — a stale one means reminders are stuck
+      // Check the scheduler heartbeat — a stale one means reminders are stuck.
+      // Report it as degraded but DON'T fail the check: the scheduler polls the
+      // app via its public URL, so a 503 here removes the instance from the load
+      // balancer, which the scheduler can then never reach to refresh the
+      // heartbeat — the app stays down until manual DB intervention (deadlock).
       const heartbeat = await prisma.schedulerHeartbeat.findUnique({
         where: { id: SCHEDULER_HEARTBEAT_ID },
       });
@@ -44,8 +48,7 @@ export const GET: APIRoute = async () => {
         !!heartbeat && Date.now() - heartbeat.lastSeenAt.getTime() < SCHEDULER_STALE_MS;
       response.scheduler = { running: schedulerRunning };
       if (!schedulerRunning) {
-        response.status = "error";
-        return Response.json(response, { status: 503 });
+        response.degraded = true;
       }
     }
 

--- a/src/test/health.test.ts
+++ b/src/test/health.test.ts
@@ -113,7 +113,7 @@ describe("GET /api/health", () => {
     }
   });
 
-  it("returns 503 when scheduler heartbeat is stale in production", async () => {
+  it("reports scheduler running=false but stays healthy when heartbeat is stale (deadlock prevention)", async () => {
     const oldNodeEnv = process.env.NODE_ENV;
     process.env.NODE_ENV = "production";
     try {
@@ -123,23 +123,29 @@ describe("GET /api/health", () => {
         update: { lastSeenAt: new Date(Date.now() - 10 * 60 * 1000) },
       });
       const res = await GET(ctx());
-      expect(res.status).toBe(503);
+      // 200 (not 503): a 503 would remove the instance from the load balancer,
+      // and the scheduler — which polls via the public URL — could never reach
+      // it again to refresh the heartbeat, deadlocking the app.
+      expect(res.status).toBe(200);
       const body = await res.json();
+      expect(body.status).toBe("ok");
       expect(body.scheduler).toEqual({ running: false });
+      expect(body.degraded).toBe(true);
     } finally {
       process.env.NODE_ENV = oldNodeEnv;
     }
   });
 
-  it("returns 503 when no scheduler heartbeat exists in production", async () => {
+  it("reports scheduler running=false but stays healthy when no heartbeat exists", async () => {
     const oldNodeEnv = process.env.NODE_ENV;
     process.env.NODE_ENV = "production";
     try {
       await prisma.schedulerHeartbeat.deleteMany();
       const res = await GET(ctx());
-      expect(res.status).toBe(503);
+      expect(res.status).toBe(200);
       const body = await res.json();
       expect(body.scheduler).toEqual({ running: false });
+      expect(body.degraded).toBe(true);
     } finally {
       process.env.NODE_ENV = oldNodeEnv;
     }


### PR DESCRIPTION
## Problem

The scheduler-heartbeat health check (from #712) creates a deadlock that bricks the app:

1. `/api/health` returns **503** whenever `SchedulerHeartbeat.lastSeenAt` is stale (> 3min) or missing.
2. Fly's health check then marks the instance unhealthy and removes it from the load balancer — **all** public traffic 503s.
3. The scheduler polls the app via that same **public URL**, so it can never reach the app to refresh the heartbeat.
4. Result: the app stays down permanently until a human edits the DB. This is exactly what happened after the 3.128.1 deploy (empty heartbeat table at startup → 503 → deadlock → manual heartbeat insert to recover).

## Fix

`src/pages/api/health.ts` — a stale/missing scheduler heartbeat now reports the app as **degraded** instead of **down**:

```json
{ "status": "ok", "scheduler": { "running": false }, "degraded": true }
```

- HTTP stays **200**, so the instance is never removed from the load balancer.
- The app's liveness now depends only on the app itself (DB + litestream), never on an external component that must traverse the health-gated LB.
- Scheduler downtime remains observable via `scheduler.running:false` / `degraded:true` (for a future external monitor).
- If the scheduler is genuinely down, it recovers automatically when it comes back — no deadlock, no manual intervention.

## Tests

- Updated `src/test/health.test.ts`: stale/missing heartbeat now asserts 200 + `scheduler.running:false` + `degraded:true` (was 503), plus a comment documenting the deadlock rationale.
- Full suite green locally (pre-push hook: lint, typecheck, vitest coverage) — pending CI.
