### PR TITLE
fix: hide empty teams section until randomization or roster full

### DIFF
--- a/src/pages/api/events/[id]/index.ts
+++ b/src/pages/api/events/[id]/index.ts
@@ -273,11 +273,15 @@ export const GET: APIRoute = async ({ params, request }) => {
   // ADR 0016: filter teamResults to only include members in the current game's player list.
   // After a recurrence reset, old team members linger in TeamResult but the player list
   // is now game-scoped via GameParticipant. Only show team members who are active players.
+  // Teams that end up with no active members are dropped entirely: a Teams section with
+  // empty rosters is never meaningful, and UIs use this array to decide whether teams exist.
   const activePlayerNames = new Set(playersPayload.map((p: { name: string }) => p.name));
-  const filteredTeamResults = event.teamResults.map((tr) => ({
-    ...tr,
-    members: tr.members.filter((m) => activePlayerNames.has(m.name)),
-  }));
+  const filteredTeamResults = event.teamResults
+    .map((tr) => ({
+      ...tr,
+      members: tr.members.filter((m) => activePlayerNames.has(m.name)),
+    }))
+    .filter((tr) => tr.members.length > 0);
 
   return Response.json({
     wasReset,

--- a/src/test/game-occurrence.test.ts
+++ b/src/test/game-occurrence.test.ts
@@ -656,6 +656,60 @@ describe("Recurrence advancement preserves legacy data (no destructive reset)", 
   });
 });
 
+describe("Event GET hides empty teams (Teams section hidden until randomized/full)", () => {
+  it("drops teamResults with no active members after a recurrence reset", async () => {
+    const pastDate = new Date(Date.now() - 2 * 86400_000);
+    const event = await prisma.event.create({
+      data: {
+        title: "Weekly", location: "Pitch", dateTime: pastDate,
+        isRecurring: true,
+        recurrenceRule: JSON.stringify({ freq: "weekly", interval: 1, byDay: "FR" }),
+        nextResetAt: new Date(pastDate.getTime() + 60 * 60 * 1000),
+        durationMinutes: 60,
+        teamOneName: "A", teamTwoName: "B",
+      },
+    });
+    const game1 = await prisma.game.create({ data: { eventId: event.id, dateTime: pastDate } });
+    await prisma.event.update({ where: { id: event.id }, data: { currentGameId: game1.id } });
+
+    // Teams were generated for the previous occurrence, then the reset cleared their members.
+    await prisma.teamResult.create({
+      data: { eventId: event.id, name: "A", members: { create: [{ name: "Old Player", order: 0 }] } },
+    });
+    await prisma.teamResult.create({ data: { eventId: event.id, name: "B" } });
+
+    const res = await getEvent(ctx({ id: event.id }));
+    const body = await res.json();
+    expect(body.wasReset).toBe(true);
+
+    // teamResult rows still exist in the DB (non-destructive reset)…
+    const dbTeams = await prisma.teamResult.findMany({ where: { eventId: event.id } });
+    expect(dbTeams).toHaveLength(2);
+    // …but the API response omits empty teams so no UI shows a blank Teams section.
+    expect(body.teamResults).toEqual([]);
+  });
+
+  it("returns teams with members once they have active players", async () => {
+    const future = new Date(Date.now() + 86400_000);
+    const event = await prisma.event.create({
+      data: { title: "Footy", location: "Pitch", dateTime: future, teamOneName: "A", teamTwoName: "B" },
+    });
+    await prisma.teamResult.create({
+      data: { eventId: event.id, name: "A", members: { create: [{ name: "Alice", order: 0 }] } },
+    });
+    await prisma.teamResult.create({
+      data: { eventId: event.id, name: "B", members: { create: [{ name: "Bob", order: 0 }] } },
+    });
+    await prisma.player.create({ data: { eventId: event.id, name: "Alice", order: 0 } });
+    await prisma.player.create({ data: { eventId: event.id, name: "Bob", order: 1 } });
+
+    const res = await getEvent(ctx({ id: event.id }));
+    const body = await res.json();
+    expect(body.teamResults.map((tr: any) => tr.name)).toEqual(["A", "B"]);
+    expect(body.teamResults[0].members).toHaveLength(1);
+  });
+});
+
 
 // ─── Phase 2 Slice 4: History endpoint reads from Game rows ──────────────────
 


### PR DESCRIPTION
## Problem

The Teams section renders whenever the event has `teamResults`, even when every team has zero members. This happens after a recurrence reset (which clears `teamMember` rows but keeps the empty `TeamResult` shells) — so recurring games show a blank "Teams" section on every occurrence, before anyone randomized and regardless of roster size.

## Root cause

`GET /api/events/[id]` returned `teamResults` entries with empty `members` arrays after a reset. All three UIs (web, Android, iOS) render the Teams section based on this array's presence, so an empty shell meant "teams exist" and the section always showed.

## Fix

Server-side, in the event GET: after filtering team members down to active players (ADR 0016), drop any team that ends up with zero members. All platforms read `teamResults` from this one endpoint, so a single change hides the Teams section everywhere until either:
- someone clicks **Randomize** (teams generated → members present → section appears), or
- the roster fills to `maxPlayers` (existing `autoRandomizeIfFull` generates teams → section appears).

The non-destructive reset contract (teamResult rows persist in the DB) is untouched — only the API response omits the empty shells.

## Tests

- Regression: after a recurrence reset, the event GET returns `teamResults: []` while the DB rows remain.
- Guard: events with populated teams still return them.

Note: the local test suite could not be executed here (broken `better-sqlite3` native binding on this arm64 box — pre-existing, affects all tests). Typecheck and lint pass; CI runs the full suite.