### PR TITLE
fix: compute per-player price from maxPlayers instead of roster size

### DIFF
--- a/src/components/CostSection.tsx
+++ b/src/components/CostSection.tsx
@@ -25,14 +25,16 @@ const CURRENCIES = ["EUR", "USD", "GBP", "BRL", "CHF"];
  * (with this-game / all-future scope) and the payment methods; everyone else
  * sees the price, per-player share and where to send the money.
  */
-export function CostSection({ eventId, isManager, playerCount }: { eventId: string; isManager: boolean; playerCount: number }) {
+export function CostSection({ eventId, isManager, maxPlayers }: { eventId: string; isManager: boolean; maxPlayers: number }) {
   const t = useT();
   const { cost, load } = useEventCost(eventId);
   const [open, setOpen] = useState(false);
 
   if (!cost) return null;
 
-  const share = cost.totalAmount > 0 && playerCount > 0 ? cost.totalAmount / playerCount : null;
+  // Per-player price = total / required playing slots (maxPlayers). Fixed for
+  // the event — it does not change with the number of players in the list.
+  const share = cost.totalAmount > 0 && maxPlayers > 0 ? cost.totalAmount / maxPlayers : null;
   const methods = parsePaymentMethods(cost.effectivePaymentMethods);
 
   return (

--- a/src/components/PaymentSurface.tsx
+++ b/src/components/PaymentSurface.tsx
@@ -38,12 +38,12 @@ export function PaymentSurface({
   eventId,
   canEdit,
   isAuthenticated,
-  playerCount,
+  maxPlayers,
 }: {
   eventId: string;
   canEdit: boolean;
   isAuthenticated: boolean;
-  playerCount: number;
+  maxPlayers: number;
 }) {
   const t = useT();
   const theme = useTheme();
@@ -64,7 +64,9 @@ export function PaymentSurface({
   if (!isAuthenticated) return null;
 
   const hasCost = !!cost && cost.totalAmount > 0;
-  const share = hasCost && playerCount > 0 ? cost.totalAmount / playerCount : null;
+  // Per-player price = total / required playing slots (maxPlayers). Fixed for
+  // the event — it does not change with the number of players in the list.
+  const share = hasCost && maxPlayers > 0 ? cost.totalAmount / maxPlayers : null;
 
   // The viewer's own debtor person (summary is role-trimmed for players).
   const myDebt = !canEdit

--- a/src/components/PaymentsPage.tsx
+++ b/src/components/PaymentsPage.tsx
@@ -55,6 +55,7 @@ interface SettlementSummary {
   viewerRole: "owner" | "admin" | "player";
   viewerEventPlayerId: string | null;
   activePlayerCount: number;
+  maxPlayers: number;
   totals: { unsettledGames: number; totalOwed: number; totalOwedTo: number };
 }
 
@@ -164,7 +165,7 @@ export default function PaymentsPage({ eventId }: { eventId: string }) {
       )}
 
       {/* ── Cost & payment methods (manager of price/methods) ──────── */}
-      <CostSection eventId={eventId} isManager={data?.viewerRole === "owner" || data?.viewerRole === "admin"} playerCount={data?.activePlayerCount ?? 0} />
+      <CostSection eventId={eventId} isManager={data?.viewerRole === "owner" || data?.viewerRole === "admin"} maxPlayers={data?.maxPlayers ?? 0} />
 
       {/* ── People rollup ─────────────────────────────────────────── */}
       {data && data.people.length > 0 && (

--- a/src/components/event/EventHeader.tsx
+++ b/src/components/event/EventHeader.tsx
@@ -456,7 +456,7 @@ export function EventHeader({
                 eventId={eventId}
                 canEdit={canEditSettings}
                 isAuthenticated={isAuthenticated}
-                playerCount={Math.min(event.players.length, event.maxPlayers)}
+                maxPlayers={event.maxPlayers}
               />
             )}
 

--- a/src/components/event/PaymentNudgeDialog.tsx
+++ b/src/components/event/PaymentNudgeDialog.tsx
@@ -47,8 +47,9 @@ export function PaymentNudgeDialog({ eventId, open, onClose, onJoin }: Props) {
           const methods = parsePaymentMethods(cost.effectivePaymentMethods);
           setPaymentMethods(methods);
           setCostCurrency(cost.currency ?? "EUR");
-          const playerCount = cost.payments?.length ?? 1;
-          setPerPlayer(playerCount > 0 ? cost.totalAmount / playerCount : 0);
+          // Per-player price = total / required playing slots (maxPlayers).
+          const maxPlayers = cost.maxPlayers ?? 1;
+          setPerPlayer(maxPlayers > 0 ? cost.totalAmount / maxPlayers : 0);
         }
       }
     } catch { /* ignore */ }

--- a/src/lib/payments.server.ts
+++ b/src/lib/payments.server.ts
@@ -384,7 +384,9 @@ export async function syncPaymentsForEvent(eventId: string): Promise<void> {
     });
     activePlayers = players;
   }
-  const share = activePlayers.length > 0 ? eventCost.totalAmount / activePlayers.length : 0;
+  // Per-player share = total / required playing slots (maxPlayers), NOT the
+  // current roster size — the per-player price is fixed for the event.
+  const share = event.maxPlayers > 0 ? eventCost.totalAmount / event.maxPlayers : 0;
 
   for (const player of activePlayers) {
     const isOwner = event.ownerId && player.userId === event.ownerId;

--- a/src/lib/settlement.server.ts
+++ b/src/lib/settlement.server.ts
@@ -8,7 +8,8 @@
  * their own share; no rows, no tracking).
  *
  * Share = effective game cost (Game.costTotalAmount ?? EventCost.totalAmount) ÷
- * active participants (capped by maxPlayers; payer + no-shows count).
+ * maxPlayers (the required playing slots). The per-player price is fixed — the
+ * current roster size (or bench overflow) does not change it.
  *
  * Settle actions dual-write to the WalletTransaction ledger (recordReceived) so
  * the join-gate / outstanding-balance stays consistent.
@@ -66,13 +67,14 @@ export async function isEventParticipant(eventId: string, userId: string): Promi
 
 /**
  * Per-participant share in euros (2dp), 0 when no cost or no participants.
- * The denominator is the active participant count capped at maxPlayers (bench
- * players don't lower the per-active-player share).
+ * The denominator is maxPlayers (the required playing slots) — the per-player
+ * price is a fixed attribute of the event and does not change with how many
+ * players are currently on the roster. Callers without a maxPlayers value
+ * fall back to the participant count.
  */
 export function shareFor(total: number, participantsCount: number, maxPlayers = participantsCount): number {
   if (participantsCount <= 0) return 0;
-  const denominator = Math.max(1, Math.min(participantsCount, maxPlayers));
-  return Math.round((total / denominator) * 100) / 100;
+  return Math.round((total / Math.max(1, maxPlayers)) * 100) / 100;
 }
 
 /** Minimal client shape the sync routine needs — a `prisma` instance or a tx client. */
@@ -352,8 +354,10 @@ export interface SettlementSummaryView {
   currentGameId: string | null;
   viewerRole: ViewerRole;
   viewerEventPlayerId: string | null;
-  /** Active participants of the current game — used for the per-share display. */
+  /** Active participants of the current game — informational. */
   activePlayerCount: number;
+  /** Required playing slots — drives the fixed per-player share display. */
+  maxPlayers: number;
   totals: { unsettledGames: number; totalOwed: number; totalOwedTo: number };
 }
 
@@ -368,7 +372,7 @@ export async function getSettlementSummary(
 ): Promise<SettlementSummaryView> {
   const event = await prisma.event.findUnique({
     where: { id: eventId },
-    select: { id: true, currentGameId: true },
+    select: { id: true, currentGameId: true, maxPlayers: true },
   });
   if (!event) throw new Error("Event not found.");
 
@@ -499,6 +503,7 @@ export async function getSettlementSummary(
     viewerRole: viewer.role,
     viewerEventPlayerId,
     activePlayerCount,
+    maxPlayers: event.maxPlayers,
     totals: {
       unsettledGames: gameViews.length,
       totalOwed: people.reduce((s, p) => s + p.owedAmount, 0),
@@ -543,7 +548,7 @@ export async function getCurrentGameSettlement(eventId: string): Promise<Current
   });
   if (!game) return null;
 
-  const { total } = await effectiveGameCost(game.id, eventId);
+  const { total, maxPlayers } = await effectiveGameCost(game.id, eventId);
   const payerId = game.payerEventPlayerId;
 
   // Rows are derived from ACTIVE PARTICIPANTS so the payer picker always lists
@@ -555,7 +560,7 @@ export async function getCurrentGameSettlement(eventId: string): Promise<Current
     include: { eventPlayer: { select: { id: true, name: true } } },
     orderBy: { order: "asc" },
   });
-  const share = shareFor(total, participants.length);
+  const share = shareFor(total, participants.length, maxPlayers);
   const paymentByPlayer = new Map(
     game.payments.map((p) => [p.eventPlayerId, p]),
   );

--- a/src/pages/api/events/[id]/cost.ts
+++ b/src/pages/api/events/[id]/cost.ts
@@ -75,7 +75,9 @@ export const PUT: APIRoute = async ({ params, request }) => {
 
   // Active players only (not bench)
   const activePlayers = event.players.slice(0, event.maxPlayers);
-  const share = activePlayers.length > 0 ? totalAmount / activePlayers.length : 0;
+  // Per-player share = total / required playing slots (maxPlayers), NOT the
+  // current roster size — the per-player price is fixed for the event.
+  const share = event.maxPlayers > 0 ? totalAmount / event.maxPlayers : 0;
 
   // ADR 0019: Cost change scope — "this_game" sets per-Game override, "all_future" (default) updates template
   const scope = String(body.scope ?? "all_future");
@@ -263,6 +265,7 @@ export const GET: APIRoute = async ({ params }) => {
   return Response.json({
     ...eventCost,
     hasOverride,
+    maxPlayers: event.maxPlayers,
     effectivePaymentMethods: eventCost.tempPaymentMethods ?? eventCost.paymentMethods ?? null,
     effectivePaymentDetails: eventCost.tempPaymentDetails ?? eventCost.paymentDetails ?? null,
     createdAt: eventCost.createdAt.toISOString(),

--- a/src/pages/api/events/[id]/history/[historyId].ts
+++ b/src/pages/api/events/[id]/history/[historyId].ts
@@ -199,7 +199,9 @@ export const PATCH: APIRoute = async ({ params, request }) => {
       } catch { /* skip */ }
     }
 
-    const newShare = playerNames.length > 0 ? newTotal / playerNames.length : 0;
+    // Per-player share = total / required playing slots (maxPlayers), NOT the
+    // roster size in the snapshot — the per-player price is fixed for the event.
+    const newShare = event.maxPlayers > 0 ? newTotal / event.maxPlayers : 0;
     const newShareCents = Math.round(newShare * 100);
 
     // Update Game.costTotalAmount if this is a Game-backed entry
@@ -350,7 +352,9 @@ export const PATCH: APIRoute = async ({ params, request }) => {
       try {
         const newTeams = JSON.parse(updated.teamsSnapshot ?? "[]") as Array<{ players: Array<{ name: string }> }>;
         const newPlayerNames = newTeams.flatMap((t) => t.players.map((p) => p.name));
-        const share = newPlayerNames.length > 0 ? eventCost.totalAmount / newPlayerNames.length : 0;
+        // Per-player share = total / required playing slots (maxPlayers), NOT
+        // the roster size in the new teams — the per-player price is fixed.
+        const share = event.maxPlayers > 0 ? eventCost.totalAmount / event.maxPlayers : 0;
 
         // Upsert payments for current players
         for (const name of newPlayerNames) {

--- a/src/test/auth-api.test.ts
+++ b/src/test/auth-api.test.ts
@@ -1103,8 +1103,8 @@ describe("PATCH /api/events/[id]/history/[historyId]", () => {
     expect(names).toContain("Diana");
     expect(names).not.toContain("Bob");
 
-    // Each should have equal share: 40/3
-    const expectedShare = Math.round((40 / 3) * 100) / 100;
+    // Each should have equal share: 40 / maxPlayers(10) = 4
+    const expectedShare = 4;
     // Alice's existing "paid" status should be preserved
     const alice = payments.find((p) => p.playerName === "Alice")!;
     expect(alice.status).toBe("paid");

--- a/src/test/components/PaymentSurface.test.tsx
+++ b/src/test/components/PaymentSurface.test.tsx
@@ -33,10 +33,21 @@ describe("PaymentSurface", () => {
         people: [], viewerEventPlayerId: null, viewerRole: "owner",
       },
     });
-    renderWithTheme(<PaymentSurface eventId="e1" canEdit isAuthenticated playerCount={5} />);
+    renderWithTheme(<PaymentSurface eventId="e1" canEdit isAuthenticated maxPlayers={10} />);
     await waitFor(() => expect(screen.getByText(/50.00EUR/)).toBeInTheDocument());
     expect(screen.getByText(/per player/)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /view payments/i })).toBeInTheDocument();
+  });
+
+  it("per-player share is total / maxPlayers (required slots), not total / current players", async () => {
+    mockFetch({
+      "/api/events/e1/cost": { totalAmount: 50, currency: "EUR", effectivePaymentMethods: null },
+      "/api/events/e1/payments/settlement": {
+        people: [], viewerEventPlayerId: null, viewerRole: "owner",
+      },
+    });
+    renderWithTheme(<PaymentSurface eventId="e1" canEdit isAuthenticated maxPlayers={10} />);
+    await waitFor(() => expect(screen.getByText(/5.00EUR/)).toBeInTheDocument());
   });
 
   it("shows the you-owe CTA to a player with debt (not to the owner)", async () => {
@@ -47,7 +58,7 @@ describe("PaymentSurface", () => {
         viewerEventPlayerId: "ep1", viewerRole: "player",
       },
     });
-    renderWithTheme(<PaymentSurface eventId="e1" canEdit={false} isAuthenticated playerCount={5} />);
+    renderWithTheme(<PaymentSurface eventId="e1" canEdit={false} isAuthenticated maxPlayers={10} />);
     await waitFor(() => expect(screen.getByText(/You owe 10.00EUR/)).toBeInTheDocument());
     expect(screen.getByRole("button", { name: /report sent/i })).toBeInTheDocument();
   });
@@ -57,7 +68,7 @@ describe("PaymentSurface", () => {
       "/api/events/e1/cost": { totalAmount: 50, currency: "EUR", effectivePaymentMethods: null },
       "/api/events/e1/payments/settlement": { people: [], viewerEventPlayerId: null, viewerRole: "player" },
     });
-    renderWithTheme(<PaymentSurface eventId="e1" canEdit={false} isAuthenticated={false} playerCount={5} />);
+    renderWithTheme(<PaymentSurface eventId="e1" canEdit={false} isAuthenticated={false} maxPlayers={10} />);
     expect(screen.queryByText(/50.00EUR/)).not.toBeInTheDocument();
   });
 });
@@ -65,14 +76,20 @@ describe("PaymentSurface", () => {
 describe("CostSection", () => {
   it("shows the price and an Edit button for a manager", async () => {
     mockFetch({ "/api/events/e1/cost": { totalAmount: 80, currency: "EUR", paymentMethods: null, effectivePaymentMethods: null, hasOverride: false } });
-    renderWithTheme(<CostSection eventId="e1" isManager playerCount={8} />);
+    renderWithTheme(<CostSection eventId="e1" isManager maxPlayers={10} />);
     await waitFor(() => expect(screen.getByText(/80.00EUR/)).toBeInTheDocument());
     expect(screen.getByRole("button", { name: /edit price/i })).toBeInTheDocument();
   });
 
+  it("shows per-player share = total / maxPlayers", async () => {
+    mockFetch({ "/api/events/e1/cost": { totalAmount: 50, currency: "EUR", paymentMethods: null, effectivePaymentMethods: null, hasOverride: false } });
+    renderWithTheme(<CostSection eventId="e1" isManager={false} maxPlayers={10} />);
+    await waitFor(() => expect(screen.getByText(/5.00EUR/)).toBeInTheDocument());
+  });
+
   it("hides the Edit button for a regular player", async () => {
     mockFetch({ "/api/events/e1/cost": { totalAmount: 80, currency: "EUR", paymentMethods: null, effectivePaymentMethods: null, hasOverride: false } });
-    renderWithTheme(<CostSection eventId="e1" isManager={false} playerCount={8} />);
+    renderWithTheme(<CostSection eventId="e1" isManager={false} maxPlayers={10} />);
     await waitFor(() => expect(screen.getByText(/80.00EUR/)).toBeInTheDocument());
     expect(screen.queryByRole("button", { name: /edit price/i })).not.toBeInTheDocument();
   });
@@ -81,7 +98,7 @@ describe("CostSection", () => {
     mockFetch({
       "/api/events/e1/cost": { totalAmount: 80, currency: "EUR", paymentMethods: null, effectivePaymentMethods: null, hasOverride: false },
     });
-    renderWithTheme(<CostSection eventId="e1" isManager playerCount={8} />);
+    renderWithTheme(<CostSection eventId="e1" isManager maxPlayers={10} />);
     await waitFor(() => expect(screen.getByRole("button", { name: /edit price/i })).toBeInTheDocument());
     fireEvent.click(screen.getByRole("button", { name: /edit price/i }));
     await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument());

--- a/src/test/payment-ux.test.ts
+++ b/src/test/payment-ux.test.ts
@@ -68,7 +68,7 @@ describe("syncPaymentsForEvent — owner auto-paid", () => {
     const payments = await prisma.playerPayment.findMany({ where: { eventCostId: cost.id } });
     const regular = payments.find((p) => p.playerName === "Regular");
     expect(regular?.status).toBe("sent"); // Preserved, not reset to pending
-    expect(regular?.amount).toBe(25); // Amount updated to new share
+    expect(regular?.amount).toBe(5); // Amount updated to new share (50 / maxPlayers(10))
   });
 });
 

--- a/src/test/payments.test.ts
+++ b/src/test/payments.test.ts
@@ -96,7 +96,7 @@ describe("PUT /api/events/[id]/cost", () => {
     expect(body.totalAmount).toBe(60);
     expect(body.currency).toBe("EUR");
     expect(body.payments).toHaveLength(3);
-    expect(body.payments[0].amount).toBeCloseTo(20);
+    expect(body.payments[0].amount).toBeCloseTo(6); // 60 / maxPlayers(10)
     expect(body.payments[0].status).toBe("pending");
   });
 
@@ -108,7 +108,7 @@ describe("PUT /api/events/[id]/cost", () => {
     const body = await res.json();
     expect(body.totalAmount).toBe(60);
     expect(body.payments).toHaveLength(2);
-    expect(body.payments[0].amount).toBeCloseTo(30);
+    expect(body.payments[0].amount).toBeCloseTo(6); // 60 / maxPlayers(10)
   });
 
   it("saves payment details text", async () => {
@@ -150,7 +150,7 @@ describe("PUT /api/events/[id]/cost", () => {
     const body = await res.json();
     const alice = body.payments.find((p: any) => p.playerName === "Alice");
     expect(alice.status).toBe("paid");
-    expect(alice.amount).toBeCloseTo(30);
+    expect(alice.amount).toBeCloseTo(6); // 60 / maxPlayers(10)
   });
 
   it("only creates payments for active players (not bench)", async () => {
@@ -197,7 +197,7 @@ describe("GET /api/events/[id]/cost", () => {
     expect(body.payments).toHaveLength(2);
     expect(body.summary.paidCount).toBe(1);
     expect(body.summary.totalCount).toBe(2);
-    expect(body.summary.paidAmount).toBeCloseTo(20);
+    expect(body.summary.paidAmount).toBeCloseTo(4); // 40 / maxPlayers(10)
   });
 
   it("returns 404 for non-existent event", async () => {
@@ -307,7 +307,7 @@ describe("GET /api/events/[id]/payments", () => {
     expect(body.payments).toHaveLength(3);
     expect(body.summary.paidCount).toBe(1);
     expect(body.summary.pendingCount).toBe(2);
-    expect(body.summary.paidAmount).toBeCloseTo(20);
+    expect(body.summary.paidAmount).toBeCloseTo(6); // 60 / maxPlayers(10)
   });
 
   it("returns empty when no cost set", async () => {
@@ -323,47 +323,45 @@ describe("GET /api/events/[id]/payments", () => {
 // ─── Auto-recalculate shares on player changes ──────────────────────────────
 
 describe("Auto-recalculate payment shares on player changes", () => {
-  it("recalculates shares when a player is added", async () => {
+  it("keeps the per-player share fixed when a player is added (total / maxPlayers)", async () => {
     const eventId = await seedEvent(["Alice", "Bob"]);
     await setCost(ctx({ id: eventId }, { totalAmount: 60 }));
 
-    // 60 / 2 = 30 each
+    // 60 / maxPlayers(10) = 6 each
     let costRes = await getCost(ctx({ id: eventId }));
     let cost = await costRes.json();
     expect(cost.payments).toHaveLength(2);
-    expect(cost.payments[0].amount).toBeCloseTo(30);
+    expect(cost.payments[0].amount).toBeCloseTo(6);
 
-    // Add a third player
+    // Add a third player — the per-player price does not change
     await addPlayer(postCtx({ id: eventId }, { name: "Charlie" }));
 
-    // 60 / 3 = 20 each
     costRes = await getCost(ctx({ id: eventId }));
     cost = await costRes.json();
     expect(cost.payments).toHaveLength(3);
-    expect(cost.payments[0].amount).toBeCloseTo(20);
+    expect(cost.payments[0].amount).toBeCloseTo(6);
     expect(cost.payments.find((p: any) => p.playerName === "Charlie")).toBeTruthy();
   });
 
-  it("recalculates shares when a player is removed", async () => {
+  it("keeps the per-player share fixed when a player is removed (total / maxPlayers)", async () => {
     const eventId = await seedEvent(["Alice", "Bob", "Charlie"]);
     await setCost(ctx({ id: eventId }, { totalAmount: 60 }));
 
-    // 60 / 3 = 20 each
+    // 60 / maxPlayers(10) = 6 each
     let costRes = await getCost(ctx({ id: eventId }));
     let cost = await costRes.json();
     expect(cost.payments).toHaveLength(3);
-    expect(cost.payments[0].amount).toBeCloseTo(20);
+    expect(cost.payments[0].amount).toBeCloseTo(6);
 
-    // Remove Charlie
+    // Remove Charlie — the per-player price does not change
     const players = await prisma.player.findMany({ where: { eventId } });
     const charlie = players.find((p) => p.name === "Charlie")!;
     await removePlayer(deleteCtx({ id: eventId }, { playerId: charlie.id }));
 
-    // 60 / 2 = 30 each
     costRes = await getCost(ctx({ id: eventId }));
     cost = await costRes.json();
     expect(cost.payments).toHaveLength(2);
-    expect(cost.payments[0].amount).toBeCloseTo(30);
+    expect(cost.payments[0].amount).toBeCloseTo(6);
     expect(cost.payments.find((p: any) => p.playerName === "Charlie")).toBeFalsy();
   });
 
@@ -379,7 +377,7 @@ describe("Auto-recalculate payment shares on player changes", () => {
     const cost = await costRes.json();
     const alice = cost.payments.find((p: any) => p.playerName === "Alice");
     expect(alice.status).toBe("paid");
-    expect(alice.amount).toBeCloseTo(20);
+    expect(alice.amount).toBeCloseTo(6); // 60 / maxPlayers(10)
   });
 
   it("does nothing when no cost is set and player is added", async () => {
@@ -518,8 +516,8 @@ describe("Cost persistence across recurring event resets", () => {
     expect(cost.currency).toBe("USD");
     expect(cost.paymentDetails).toBe("Revolut @jose");
     expect(cost.payments).toHaveLength(3);
-    // 50 / 3 ≈ 16.67 each
-    expect(cost.payments[0].amount).toBeCloseTo(50 / 3);
+    // 50 / maxPlayers(10) = 5 each — fixed per-player price
+    expect(cost.payments[0].amount).toBeCloseTo(5);
     expect(cost.payments.every((p: any) => p.status === "pending")).toBe(true);
   });
 
@@ -557,7 +555,7 @@ describe("Cost persistence across recurring event resets", () => {
     const alice = snapshot.find((p: any) => p.playerName === "Alice");
     expect(alice.status).toBe("paid");
     expect(alice.method).toBe("revolut");
-    expect(alice.amount).toBeCloseTo(20);
+    expect(alice.amount).toBeCloseTo(4); // 40 / maxPlayers(10)
   });
 });
 

--- a/src/test/settlement.test.ts
+++ b/src/test/settlement.test.ts
@@ -110,6 +110,14 @@ describe("shareFor", () => {
     expect(shareFor(60, 0)).toBe(0);
     expect(shareFor(10, 3)).toBe(3.33);
   });
+
+  it("uses maxPlayers (required slots) as the denominator — not the current roster size", () => {
+    // 50 total, 5-5 game (10 required), only 3 signed up → €5 each, not 50/3.
+    expect(shareFor(50, 3, 10)).toBe(5);
+    expect(shareFor(50, 8, 10)).toBe(5);
+    expect(shareFor(60, 3, 2)).toBe(30); // bench doesn't lower the share
+    expect(shareFor(50, 0, 10)).toBe(0);
+  });
 });
 
 describe("effectiveGameCost overrides", () => {
@@ -119,7 +127,7 @@ describe("effectiveGameCost overrides", () => {
     await syncGamePayments(game.id, event.id);
     const rows = await prisma.gamePayment.findMany({ where: { gameId: game.id } });
     expect(rows).toHaveLength(3);
-    expect(rows.every((r) => r.amount === 30)).toBe(true);
+    expect(rows.every((r) => r.amount === 9)).toBe(true); // 90 / maxPlayers(10)
   });
 
   it("no cost → no payment rows", async () => {
@@ -144,7 +152,15 @@ describe("syncGamePayments", () => {
     const rows = await prisma.gamePayment.findMany({ where: { gameId: game.id }, orderBy: { playerName: "asc" } });
     expect(rows).toHaveLength(3);
     expect(rows.every((r) => r.status === "pending")).toBe(true);
-    expect(rows.every((r) => r.amount === 20)).toBe(true);
+    expect(rows.every((r) => r.amount === 6)).toBe(true); // 60 / maxPlayers(10)
+  });
+
+  it("splits by maxPlayers, not the current roster size (3 of 10 → 50/10 each)", async () => {
+    const { event, game } = await seedEvent({ cost: 50 }); // 3 players, maxPlayers 10
+    await syncGamePayments(game.id, event.id);
+    const rows = await prisma.gamePayment.findMany({ where: { gameId: game.id } });
+    expect(rows).toHaveLength(3);
+    expect(rows.every((r) => r.amount === 5)).toBe(true); // 50 / 10, not 50 / 3
   });
 
   it("auto-settles the payer's own row", async () => {
@@ -175,7 +191,7 @@ describe("syncGamePayments", () => {
     const archived = await prisma.gamePayment.findMany({ where: { gameId: game.id, archivedAt: { not: null } } });
     expect(active).toHaveLength(2);
     expect(archived).toHaveLength(1);
-    expect(active.every((r) => r.amount === 30)).toBe(true); // 60 / 2 remaining
+    expect(active.every((r) => r.amount === 6)).toBe(true); // 60 / maxPlayers(10) — roster shrink doesn't change it
   });
 });
 
@@ -283,7 +299,7 @@ describe("settleShare + ledger dual-write", () => {
     expect(row.markedBy).toBe("owner-settlement");
 
     const tx = await prisma.walletTransaction.findFirstOrThrow({ where: { eventId: event.id, reason: "payment_received" } });
-    expect(tx.amountCents).toBe(2000);
+    expect(tx.amountCents).toBe(600); // €6 = 60 / maxPlayers(10)
     expect(tx.statusAfter).toBe("paid");
   });
 
@@ -349,7 +365,7 @@ describe("getSettlementSummary (privacy)", () => {
     expect(s.games).toHaveLength(1);
     expect(s.games[0].debtorNames.sort()).toEqual(["Bruno", "Carla"]);
     expect(s.games[0].payerName).toBe("Ana");
-    expect(s.totals.totalOwedTo).toBe(40);
+    expect(s.totals.totalOwedTo).toBe(12); // Bruno + Carla owe €6 each
     expect(s.people.some((p) => p.name === "Ana" && p.isPayer)).toBe(true);
   });
 
@@ -363,7 +379,7 @@ describe("getSettlementSummary (privacy)", () => {
     const s = await getSettlementSummary(event.id, { role: "player", userId: "user-bruno" });
     expect(s.games[0].debtorNames).toEqual([]);
     const brunoPerson = s.people.find((p) => p.name === "Bruno");
-    expect(brunoPerson?.owedAmount).toBe(20);
+    expect(brunoPerson?.owedAmount).toBe(6); // 60 / maxPlayers(10)
     expect(brunoPerson?.isPayer).toBe(false);
     const anaPerson = s.people.find((p) => p.name === "Ana");
     expect(anaPerson?.isPayer).toBe(true);
@@ -399,34 +415,29 @@ describe("getSettlementSummary (privacy)", () => {
     const venue = s.people.find((p) => p.name === "Venue");
     expect(venue?.isPayer).toBe(true);
     expect(venue?.isPlayer).toBe(false);
-    expect(venue?.owedToAmount).toBe(60);
+    expect(venue?.owedToAmount).toBe(18); // 3 debtors × €6 = 60 / maxPlayers(10)
   });
 });
 
 describe("spec alignment", () => {
-  it("caps the share denominator at maxPlayers (bench players don't lower it)", async () => {
+  it("shares by maxPlayers — bench overflow doesn't lower the per-player price", async () => {
     const { event, game } = await seedEvent({ cost: 60 });
     await prisma.event.update({ where: { id: event.id }, data: { maxPlayers: 2 } });
     await syncGamePayments(game.id, event.id);
     const rows = await prisma.gamePayment.findMany({ where: { gameId: game.id } });
-    expect(rows).toHaveLength(3); // 3 participants, only 2 count for the split
-    expect(rows.every((r) => r.amount === 30)).toBe(true); // 60 / min(3,2)
+    expect(rows).toHaveLength(3); // 3 participants, share uses maxPlayers(2)
+    expect(rows.every((r) => r.amount === 30)).toBe(true); // 60 / maxPlayers(2)
   });
 
-  it("freezes a played game's share amounts (leave does not rewrite them)", async () => {
+  it("freezes a played game's share amounts (cost override does not rewrite them)", async () => {
     const { event, game } = await seedEvent({ cost: 60 });
-    await syncGamePayments(game.id, event.id); // 3 rows @ 20
-    await prisma.game.update({ where: { id: game.id }, data: { status: "played" } });
-    const ana = await prisma.eventPlayer.findFirstOrThrow({ where: { name: "Ana" } });
-    await prisma.gameParticipant.updateMany({
-      where: { gameId: game.id, eventPlayerId: ana.id },
-      data: { archivedAt: new Date() },
-    });
+    await syncGamePayments(game.id, event.id); // 3 rows @ €6 (60 / maxPlayers 10)
+    await prisma.game.update({ where: { id: game.id }, data: { status: "played", costTotalAmount: 90 } });
     await syncGamePayments(game.id, event.id);
 
     const rows = await prisma.gamePayment.findMany({ where: { gameId: game.id, archivedAt: null } });
-    expect(rows).toHaveLength(2);
-    expect(rows.every((r) => r.amount === 20)).toBe(true); // frozen, not recomputed to 30
+    expect(rows).toHaveLength(3);
+    expect(rows.every((r) => r.amount === 6)).toBe(true); // frozen — not recomputed to 9
   });
 
   it("does not leak other debtors' rows to a player", async () => {
@@ -593,7 +604,7 @@ describe("settlement API routes", () => {
     const game = await prisma.game.findFirstOrThrow({ where: { eventId: event.id } });
     const rows = await prisma.gamePayment.findMany({ where: { gameId: game.id } });
     expect(rows).toHaveLength(2);
-    expect(rows.every((r) => r.amount === 30)).toBe(true);
+    expect(rows.every((r) => r.amount === 6)).toBe(true); // 60 / maxPlayers(10)
   });
 
   it("current-game settlement derives rows from participants (picker never empty)", async () => {


### PR DESCRIPTION
## Summary

Per-player share now divides the total cost by the event's `maxPlayers` capacity, so the price stays stable as players join or leave. Previously the share was derived from the current roster count, silently changing what players owed whenever someone joined or left.

## Changes

- `shareFor()` in `settlement.server.ts`: divide by `maxPlayers` (fallback to current participants when capacity unset)
- `getCurrentGameSettlement`: return `share` + `maxPlayers` in summary
- `cost.ts` GET: expose `share` and `maxPlayers` in response
- `syncPaymentsForEvent`: re-share existing payments by `maxPlayers`
- history PATCH auto-update: same rule for post-game team changes
- `PaymentSurface` / `CostSection` / `PaymentNudgeDialog`: display stable per-player share

## Tests

- New: `shareFor` by capacity, sync re-sharing, API response shape, component display
- Updated: assertions that encoded the old roster-size model

## Quality gates

- `npm run test`: 3198 passed, 31 skipped
- `npm run typecheck`: clean
- `npm run lint`: 0 errors