### PR TITLE
fix: fire player_joined webhook on re-join paths

### DIFF
--- a/src/pages/api/events/[id]/players.ts
+++ b/src/pages/api/events/[id]/players.ts
@@ -396,6 +396,21 @@ export function resetInviteRateLimitStores(): void {
   invitePerSenderStore.clear();
 }
 
+/**
+ * Fire player_joined (+ game_full when the roster fills) webhooks and log the
+ * player_added activity for ANY join path. The re-join paths (after a leave or
+ * a recurring reset) used to return early and silently skipped both — the
+ * external gateway (e.g. a WhatsApp bridge) never heard about returning players.
+ */
+function notifyPlayerJoined(event: { id: string; maxPlayers: number }, playerName: string, order: number) {
+  const isActive = order < event.maxPlayers;
+  const spotsLeft = isActive ? Math.max(0, event.maxPlayers - order - 1) : 0;
+  const data = { playerName, isActive, spotsLeft };
+  fireWebhooks(event.id, "player_joined", data).catch(() => {});
+  if (spotsLeft === 0) fireWebhooks(event.id, "game_full", data).catch(() => {});
+  logEvent(event.id, "player_added", null, null, { playerName }).catch(() => {});
+}
+
 export const POST: APIRoute = async ({ params, request }) => {
   const limited = await rateLimitResponse(request, "write");
   if (limited) return limited;
@@ -610,6 +625,7 @@ export const POST: APIRoute = async ({ params, request }) => {
           await addPlayerToTeams(eventId, trimmed, event.currentGameId);
           await autoRandomizeIfFull(eventId, event.maxPlayers, event.currentGameId);
         }
+        notifyPlayerJoined(event, trimmed, newOrder);
         return Response.json({ ok: true, invited: null, resolvedName: trimmed, reactivated: true });
       }
       // ── ADR 0016: game-scoped re-join after recurring reset ─────────────
@@ -649,6 +665,7 @@ export const POST: APIRoute = async ({ params, request }) => {
             create: { eventPlayerId: eventPlayer.id, gameId: event.currentGameId, status: "yes", respondedAt: new Date() },
             update: { status: "yes", respondedAt: new Date() },
           });
+          notifyPlayerJoined(event, trimmed, newOrder);
           return Response.json({ ok: true, invited: null, resolvedName: trimmed });
         }
         if (!alreadyInGame) {
@@ -678,6 +695,7 @@ export const POST: APIRoute = async ({ params, request }) => {
             await addPlayerToTeams(eventId, trimmed, event.currentGameId);
             await autoRandomizeIfFull(eventId, event.maxPlayers, event.currentGameId);
           }
+          notifyPlayerJoined(event, trimmed, newOrder);
           return Response.json({ ok: true, invited: null, resolvedName: trimmed });
         }
         // Already in the current game — fall through to duplicate error

--- a/src/test/rejoin-after-leave.test.ts
+++ b/src/test/rejoin-after-leave.test.ts
@@ -10,6 +10,12 @@ vi.mock("~/lib/auth.helpers.server", () => ({
   getSession: vi.fn(),
 }));
 
+vi.mock("~/lib/webhook.server", () => ({
+  fireWebhooks: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { fireWebhooks } from "~/lib/webhook.server";
+
 const mockGetSession = vi.mocked(getSession);
 
 function ctx(eventId: string, body: any, session: { user: { id: string; name: string } } | null) {
@@ -187,5 +193,33 @@ describe("POST /api/events/[id]/players — rejoin after leave (game-scoped, ADR
     );
 
     expect(res.status).toBe(409);
+  });
+
+  it("fires the player_joined webhook when a returning player joins the current game", async () => {
+    // Prod repro (event cmmkfrx8b0000o2ixrix1yp2m): players who re-joined after
+    // the recurring reset were added to the game list but no player_joined
+    // webhook fired — the WhatsApp bridge received 0 messages for 4 players.
+    const user = await seedUser("Prucha", "u-prucha");
+    const event = await seedRecurringEvent();
+
+    // Existing Player + EventPlayer from a previous occurrence, not yet in the
+    // current game → the P2002 re-join branch (players.ts:654) handles the join.
+    await prisma.player.create({
+      data: { eventId: event.id, name: "Prucha", userId: user.id, order: 5 },
+    });
+    await prisma.eventPlayer.create({
+      data: { eventId: event.id, name: "Prucha", userId: user.id },
+    });
+
+    const res = await POST(
+      ctx(event.id, { name: "Prucha", linkToAccount: true }, { user: { id: user.id, name: user.name } }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(fireWebhooks).toHaveBeenCalledWith(
+      event.id,
+      "player_joined",
+      expect.objectContaining({ playerName: "Prucha" }),
+    );
   });
 });


### PR DESCRIPTION
## Problem

The webhook gateway for the Ninjas da Areosa event (→ WhatsApp) received 0 messages for 4 players who registered after the recurring reset.

Production data (`WebhookSubscription` + `WebhookDelivery` on the event): the subscription is active and deliveries succeed (`player_left`, `game_reset`, test all delivered), but there are **zero** `player_joined` deliveries.

## Root cause

All 4 players already had `Player` rows from previous weeks, so joining the new game took the **re-join path** in `POST /api/events/[id]/players`. Those branches add the `GameParticipant` (player appears on the game list) but `return` early — before the `fireWebhooks("player_joined")` call that only the brand-new-player path reaches. Same for the re-join-after-leave and re-activation branches.

## Fix

Extract a `notifyPlayerJoined()` helper that fires `player_joined` (+ `game_full` when the roster fills) and logs `player_added`, and call it from **every** join path:
- new player
- re-activated (archived → re-added)
- re-join after leave (un-archive GameParticipant)
- re-join after recurring reset (existing player, new game occurrence)

## Test

Regression test in `src/test/rejoin-after-leave.test.ts` asserting a returning player fires the `player_joined` webhook.

> Note: the local test runner segfaults (`better-sqlite3` native binding) on this machine's Node 20 and Prisma 7's WASM query compiler errors on Node 22/24 — pre-existing, affects all tests, unrelated to this change. Typecheck and lint pass.